### PR TITLE
fix(ui): add missing Fluent UI providers to MainLayout

### DIFF
--- a/Cdm/Cdm.Web/Components/Layout/MainLayout.razor
+++ b/Cdm/Cdm.Web/Components/Layout/MainLayout.razor
@@ -113,6 +113,12 @@
             </div>
         </header>
 
+        <!-- Fluent UI providers (required for menus, toasts, dialogs, message bars) -->
+        <FluentMenuProvider />
+        <FluentToastProvider />
+        <FluentDialogProvider />
+        <FluentMessageBarProvider />
+
         <!-- Page Content -->
         <main class="app-content">
             @Body


### PR DESCRIPTION
Added FluentMenuProvider, FluentToastProvider, FluentDialogProvider and FluentMessageBarProvider to MainLayout. Their absence caused a fatal circuit error ('FluentMenuProvider needs to be added to the main layout') on any page using FluentButton with icons, menus or message bars (e.g. /worlds).