### PR TITLE
feat: session live badge, @mentions in GM view, SessionEnded notifica…

### DIFF
--- a/Cdm/Cdm.Business.Common/Services/SessionService.cs
+++ b/Cdm/Cdm.Business.Common/Services/SessionService.cs
@@ -219,7 +219,13 @@ public class SessionService(AppDbContext dbContext, ILogger<SessionService> logg
     {
         try
         {
-            var session = await this.dbContext.Sessions.FindAsync(sessionId);
+            var session = await this.dbContext.Sessions
+                .Include(s => s.Campaign)
+                .Include(s => s.Participants)
+                    .ThenInclude(p => p.WorldCharacter)
+                        .ThenInclude(wc => wc.Character)
+                .FirstOrDefaultAsync(s => s.Id == sessionId);
+
             if (session == null)
             {
                 return false;
@@ -234,6 +240,23 @@ public class SessionService(AppDbContext dbContext, ILogger<SessionService> logg
             session.Status = SessionStatus.Ended;
             session.EndedAt = DateTime.UtcNow;
             await this.dbContext.SaveChangesAsync();
+
+            // Notify participants that the session has ended
+            foreach (var participant in session.Participants)
+            {
+                if (participant.WorldCharacter?.Character == null) continue;
+                await this.notificationService.CreateNotificationAsync(new CreateNotificationDto
+                {
+                    UserId = participant.WorldCharacter.Character.UserId,
+                    Type = NotificationType.SessionEnded,
+                    Title = "Session terminée",
+                    Message = $"La session de la campagne « {session.Campaign?.Name ?? "Campagne"} » est terminée.",
+                    RelatedEntityId = session.Id,
+                    RelatedEntityType = "Session",
+                    ActionUrl = $"/sessions",
+                    SentBy = userId
+                });
+            }
 
             this.logger.LogInformation("Session {SessionId} ended by user {UserId}", sessionId, userId);
             return true;

--- a/Cdm/Cdm.Common/Enums/NotificationType.cs
+++ b/Cdm/Cdm.Common/Enums/NotificationType.cs
@@ -48,5 +48,10 @@ public enum NotificationType
     /// <summary>
     /// Character status change
     /// </summary>
-    CharacterUpdate = 7
+    CharacterUpdate = 7,
+
+    /// <summary>
+    /// Session has ended
+    /// </summary>
+    SessionEnded = 9
 }

--- a/Cdm/Cdm.Web/Components/Layout/MainLayout.razor
+++ b/Cdm/Cdm.Web/Components/Layout/MainLayout.razor
@@ -27,7 +27,13 @@
                 <span class="nav-label">@L["Nav_Characters"]</span>
             </a>
             <a href="/sessions" class="nav-item @ActiveClass("/sessions")" title="@L["Nav_Sessions"]">
-                <i class="bi bi-play-circle nav-icon"></i>
+                <span class="nav-icon-wrapper">
+                    <i class="bi bi-play-circle nav-icon"></i>
+                    @if (HasActiveSession)
+                    {
+                        <span class="session-live-dot" title="Session active en cours"></span>
+                    }
+                </span>
                 <span class="nav-label">@L["Nav_Sessions"]</span>
             </a>
 

--- a/Cdm/Cdm.Web/Components/Layout/MainLayout.razor.cs
+++ b/Cdm/Cdm.Web/Components/Layout/MainLayout.razor.cs
@@ -1,4 +1,5 @@
 using Cdm.Business.Abstraction.DTOs;
+using Cdm.Common.Enums;
 using Cdm.Web.Models;
 using Cdm.Web.Resources;
 using Cdm.Web.Services;
@@ -19,6 +20,7 @@ public partial class MainLayout : IDisposable
     [Inject] private NavigationManager Nav { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
     [Inject] private NotificationApiClient NotificationClient { get; set; } = default!;
+    [Inject] private SessionApiClient SessionClient { get; set; } = default!;
 
     private bool IsCollapsed = false;
     private bool _wasAutoCollapsed = false;
@@ -34,9 +36,14 @@ public partial class MainLayout : IDisposable
     private List<NotificationModel> Notifications = new();
     private bool IsLoadingNotifications = false;
 
+    // Active session badge
+    private bool HasActiveSession = false;
+    private int? ActiveSessionId;
+
     protected override async Task OnInitializedAsync()
     {
         NavContext.OnContextChanged += OnContextChanged;
+        Nav.LocationChanged += OnLocationChanged;
 
         var authState = await AuthProvider.GetAuthenticationStateAsync();
         var user = authState.User;
@@ -49,6 +56,29 @@ public partial class MainLayout : IDisposable
 
             UserInitials = BuildInitials(UserName);
             UnreadNotificationCount = await NotificationClient.GetUnreadCountAsync();
+            await RefreshActiveSessionBadgeAsync();
+        }
+    }
+
+    private async void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+    {
+        await RefreshActiveSessionBadgeAsync();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task RefreshActiveSessionBadgeAsync()
+    {
+        try
+        {
+            var sessions = await SessionClient.GetMySessionsAsync();
+            var active = sessions.FirstOrDefault(s => s.Status == Cdm.Common.Enums.SessionStatus.Active);
+            HasActiveSession = active != null;
+            ActiveSessionId = active?.Id;
+        }
+        catch
+        {
+            HasActiveSession = false;
+            ActiveSessionId = null;
         }
     }
 
@@ -216,5 +246,6 @@ public partial class MainLayout : IDisposable
     public void Dispose()
     {
         NavContext.OnContextChanged -= OnContextChanged;
+        Nav.LocationChanged -= OnLocationChanged;
     }
 }

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor
@@ -121,14 +121,16 @@ else if (Session != null)
                     </div>
 
                     <div class="session-chapter-body">
+                        <div id="session-chapter-preview-content">
                         @if (!string.IsNullOrWhiteSpace(SelectedChapter.Content))
                         {
-                            <div class="chapter-content-text">@SelectedChapter.Content</div>
+                            <div class="chapter-content-text">@RenderChapterContent(SelectedChapter.Content)</div>
                         }
                         else
                         {
                             <p style="color: var(--color-text-muted); font-style: italic;">Ce chapitre n'a pas encore de contenu.</p>
                         }
+                        </div>
 
                         @if (ChapterNpcs.Count > 0)
                         {
@@ -140,7 +142,7 @@ else if (Session != null)
                                 <div class="npc-list">
                                     @foreach (var npc in ChapterNpcs)
                                     {
-                                        <div class="npc-card">
+                                        <div class="npc-card" id="gm-npc-@npc.Id">
                                             <div class="npc-card-header">
                                                 <strong>@npc.DisplayName</strong>
                                                 @if (npc.Age.HasValue)

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor.cs
@@ -7,12 +7,13 @@ using Cdm.Web.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.Localization;
+using Microsoft.JSInterop;
 using System.Security.Claims;
 using System.Text.Json;
 
 namespace Cdm.Web.Components.Pages.Sessions;
 
-public partial class SessionGm
+public partial class SessionGm : IAsyncDisposable
 {
     [Parameter] public int SessionId { get; set; }
 
@@ -24,6 +25,7 @@ public partial class SessionGm
     [Inject] private AuthenticationStateProvider AuthStateProvider { get; set; } = default!;
     [Inject] private NavigationManager Nav { get; set; } = default!;
     [Inject] private IStringLocalizer<AppStrings> L { get; set; } = default!;
+    [Inject] private IJSRuntime JS { get; set; } = default!;
 
     private SessionDto? Session;
     private List<ChapterDto> Chapters = new();
@@ -35,6 +37,9 @@ public partial class SessionGm
     private bool IsEnding = false;
     private string? ErrorMessage;
     private int CurrentUserId;
+
+    private DotNetObjectReference<SessionGm>? _dotNetRef;
+    private bool _needsPreviewClickInit = false;
 
     protected override async Task OnInitializedAsync()
     {
@@ -89,6 +94,7 @@ public partial class SessionGm
     {
         SelectedChapter = chapter;
         ChapterNpcs = await NpcClient.GetNpcsByChapterAsync(chapter.Id);
+        _needsPreviewClickInit = true;
         if (Session != null)
         {
             var updated = await SessionClient.UpdateCurrentChapterAsync(Session.Id, chapter.Id);
@@ -131,6 +137,78 @@ public partial class SessionGm
         SelectedPlayerSheet = SelectedPlayerSheet?.Id == sheet?.Id ? null : sheet;
     }
 
+    private MarkupString RenderChapterContent(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return new MarkupString(string.Empty);
+        var npcMap = ChapterNpcs.ToDictionary(n => n.Id, n => n);
+        var pcMap = WorldCharacters.ToDictionary(c => c.CharacterId, c => c);
+        var escaped = text.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+
+        // Render NPC mentions: @[Name](npc:id)
+        var rendered = System.Text.RegularExpressions.Regex.Replace(
+            escaped,
+            @"@\[([^\]]+)\]\(npc:(\d+)\)",
+            m =>
+            {
+                var name = m.Groups[1].Value;
+                var id = int.TryParse(m.Groups[2].Value, out var i) ? i : 0;
+                var tooltip = id > 0 && npcMap.TryGetValue(id, out var npc)
+                    ? (npc.Description ?? npc.PhysicalDescription ?? string.Empty)
+                    : string.Empty;
+                var tip = string.IsNullOrEmpty(tooltip) ? "" : $" data-tooltip=\"{tooltip.Replace("\"", "&quot;")}\"";
+                return $"<span class=\"npc-mention\" data-mention-type=\"npc\" data-mention-id=\"{id}\"{tip}>@{name}</span>";
+            });
+
+        // Render PJ mentions: @[Name](pc:id)
+        rendered = System.Text.RegularExpressions.Regex.Replace(
+            rendered,
+            @"@\[([^\]]+)\]\(pc:(\d+)\)",
+            m =>
+            {
+                var name = m.Groups[1].Value;
+                var id = int.TryParse(m.Groups[2].Value, out var i) ? i : 0;
+                var tooltip = id > 0 && pcMap.TryGetValue(id, out var pc)
+                    ? $"Personnage joueur{(pc.Level.HasValue ? $" — Niveau {pc.Level}" : string.Empty)}"
+                    : "Personnage joueur";
+                var tip = $" data-tooltip=\"{tooltip}\"";
+                return $"<span class=\"npc-mention pc-mention\" data-mention-type=\"pc\" data-mention-id=\"{id}\"{tip}>@{name}</span>";
+            });
+
+        rendered = rendered.Replace("\r\n", "\n").Replace("\n", "<br />");
+        return new MarkupString(rendered);
+    }
+
+    [JSInvokable]
+    public void OpenMentionDetail(string type, int id)
+    {
+        if (type == "npc")
+        {
+            // Scroll to NPC in the list
+            var npc = ChapterNpcs.FirstOrDefault(n => n.Id == id);
+            if (npc != null)
+                _ = JS.InvokeVoidAsync("document.getElementById", $"gm-npc-{id}");
+        }
+        else if (type == "pc")
+        {
+            Nav.NavigateTo($"/characters/{id}");
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender || _needsPreviewClickInit)
+        {
+            _needsPreviewClickInit = false;
+            _dotNetRef ??= DotNetObjectReference.Create(this);
+            try
+            {
+                var module = await JS.InvokeAsync<IJSObjectReference>("import", "./js/mention.js");
+                await module.InvokeVoidAsync("initPreviewClicks", "session-chapter-preview-content", _dotNetRef);
+            }
+            catch { /* ignore — prerendering or JS unavailable */ }
+        }
+    }
+
     private Dictionary<string, string> ParseGameSpecificData(string? json)
     {
         if (string.IsNullOrWhiteSpace(json)) return new();
@@ -155,4 +233,10 @@ public partial class SessionGm
         SessionParticipantStatus.Invited => "Invité",
         _ => "Déconnecté"
     };
+
+    public async ValueTask DisposeAsync()
+    {
+        _dotNetRef?.Dispose();
+        await ValueTask.CompletedTask;
+    }
 }

--- a/Cdm/Cdm.Web/Models/NotificationModel.cs
+++ b/Cdm/Cdm.Web/Models/NotificationModel.cs
@@ -49,6 +49,7 @@ public class NotificationModel
     {
         NotificationType.CampaignInvite => "Invitation à une campagne",
         NotificationType.SessionStarting => "Session imminente",
+        NotificationType.SessionEnded => "Session terminée",
         NotificationType.AchievementUnlocked => "Succès débloqué",
         NotificationType.TradeProposed => "Échange proposé",
         NotificationType.MessageMention => "Mention",
@@ -64,6 +65,7 @@ public class NotificationModel
     {
         NotificationType.CampaignInvite => "bi-envelope",
         NotificationType.SessionStarting => "bi-clock",
+        NotificationType.SessionEnded => "bi-stop-circle",
         NotificationType.AchievementUnlocked => "bi-trophy",
         NotificationType.TradeProposed => "bi-arrow-left-right",
         NotificationType.MessageMention => "bi-at",

--- a/Cdm/Cdm.Web/wwwroot/css/layouts/layout-shell.css
+++ b/Cdm/Cdm.Web/wwwroot/css/layouts/layout-shell.css
@@ -139,6 +139,37 @@
   text-align: center;
 }
 
+/* Wrapper for icon + live badge */
+.nav-icon-wrapper {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  width: 20px;
+  justify-content: center;
+}
+
+.nav-icon-wrapper .nav-icon {
+  width: auto;
+}
+
+/* Pulsing dot for active sessions */
+.session-live-dot {
+  position: absolute;
+  top: -3px;
+  right: -4px;
+  width: 8px;
+  height: 8px;
+  background: var(--color-success, #22c55e);
+  border-radius: 50%;
+  border: 1.5px solid var(--color-surface, #1e1e2e);
+  animation: session-pulse 2s ease-in-out infinite;
+}
+
+@keyframes session-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.4); }
+  50% { opacity: 0.85; transform: scale(0.9); box-shadow: 0 0 0 4px rgba(34, 197, 94, 0); }
+}
+
 .nav-item .nav-label {
   transition: opacity var(--duration-fast), width var(--duration-fast);
   overflow: hidden;


### PR DESCRIPTION
…tions

- MainLayout: inject SessionApiClient, add HasActiveSession badge on Sessions nav item (pulsing green dot, refreshed on LocationChanged + LocationChanged cleanup)
- layout-shell.css: .nav-icon-wrapper, .session-live-dot with pulse animation
- SessionGm: add RenderChapterContent() with npc/pc mention rendering, IJSRuntime initPreviewClicks, IAsyncDisposable, id='session-chapter-preview-content'
- NotificationType: add SessionEnded = 9
- NotificationModel: icon + display name for SessionEnded
- SessionService.EndSessionAsync: notify all participants on session end