### PR TITLE
fix: add missing DB migration for Sessions, SessionParticipants, and …

### DIFF
--- a/Cdm/Cdm.Migrations/Migrations/20260419210000_AddIsLockedAndSessions.cs
+++ b/Cdm/Cdm.Migrations/Migrations/20260419210000_AddIsLockedAndSessions.cs
@@ -1,0 +1,140 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Cdm.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsLockedAndSessions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Add IsLocked column to Characters table
+            migrationBuilder.AddColumn<bool>(
+                name: "IsLocked",
+                table: "Characters",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Characters_IsLocked",
+                table: "Characters",
+                column: "IsLocked");
+
+            // Create Sessions table
+            migrationBuilder.CreateTable(
+                name: "Sessions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    CampaignId = table.Column<int>(type: "int", nullable: false),
+                    StartedById = table.Column<int>(type: "int", nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    EndedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false, defaultValue: 1),
+                    CurrentChapterId = table.Column<int>(type: "int", nullable: true),
+                    WelcomeMessage = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Sessions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Sessions_Campaigns_CampaignId",
+                        column: x => x.CampaignId,
+                        principalTable: "Campaigns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Sessions_Users_StartedById",
+                        column: x => x.StartedById,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Sessions_Chapters_CurrentChapterId",
+                        column: x => x.CurrentChapterId,
+                        principalTable: "Chapters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_CampaignId",
+                table: "Sessions",
+                column: "CampaignId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_StartedById",
+                table: "Sessions",
+                column: "StartedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_Status",
+                table: "Sessions",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sessions_CurrentChapterId",
+                table: "Sessions",
+                column: "CurrentChapterId");
+
+            // Create SessionParticipants table
+            migrationBuilder.CreateTable(
+                name: "SessionParticipants",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SessionId = table.Column<int>(type: "int", nullable: false),
+                    WorldCharacterId = table.Column<int>(type: "int", nullable: false),
+                    JoinedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false, defaultValue: 0)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SessionParticipants", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SessionParticipants_Sessions_SessionId",
+                        column: x => x.SessionId,
+                        principalTable: "Sessions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SessionParticipants_WorldCharacters_WorldCharacterId",
+                        column: x => x.WorldCharacterId,
+                        principalTable: "WorldCharacters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SessionParticipants_SessionId",
+                table: "SessionParticipants",
+                column: "SessionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SessionParticipants_WorldCharacterId",
+                table: "SessionParticipants",
+                column: "WorldCharacterId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "SessionParticipants");
+            migrationBuilder.DropTable(name: "Sessions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Characters_IsLocked",
+                table: "Characters");
+
+            migrationBuilder.DropColumn(
+                name: "IsLocked",
+                table: "Characters");
+        }
+    }
+}

--- a/Cdm/Cdm.Migrations/Migrations/MigrationsContextModelSnapshot.cs
+++ b/Cdm/Cdm.Migrations/Migrations/MigrationsContextModelSnapshot.cs
@@ -743,6 +743,87 @@ namespace Cdm.Migrations.Migrations
                     b.ToTable("WorldCharacters");
                 });
 
+            modelBuilder.Entity("Cdm.Data.Common.Models.Session", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<int>("CampaignId")
+                        .HasColumnType("int");
+
+                    b.Property<int?>("CurrentChapterId")
+                        .HasColumnType("int");
+
+                    b.Property<DateTime?>("EndedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<DateTime>("StartedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<int>("StartedById")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Status")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasDefaultValue(1);
+
+                    b.Property<string>("WelcomeMessage")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CampaignId")
+                        .HasDatabaseName("IX_Sessions_CampaignId");
+
+                    b.HasIndex("CurrentChapterId")
+                        .HasDatabaseName("IX_Sessions_CurrentChapterId");
+
+                    b.HasIndex("StartedById")
+                        .HasDatabaseName("IX_Sessions_StartedById");
+
+                    b.HasIndex("Status")
+                        .HasDatabaseName("IX_Sessions_Status");
+
+                    b.ToTable("Sessions");
+                });
+
+            modelBuilder.Entity("Cdm.Data.Common.Models.SessionParticipant", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTime>("JoinedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<int>("SessionId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Status")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasDefaultValue(0);
+
+                    b.Property<int>("WorldCharacterId")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("SessionId")
+                        .HasDatabaseName("IX_SessionParticipants_SessionId");
+
+                    b.HasIndex("WorldCharacterId")
+                        .HasDatabaseName("IX_SessionParticipants_WorldCharacterId");
+
+                    b.ToTable("SessionParticipants");
+                });
+
             modelBuilder.Entity("Cdm.Data.Common.Models.Achievement", b =>
                 {
                     b.HasOne("Cdm.Data.Common.Models.Campaign", "Campaign")
@@ -934,6 +1015,51 @@ namespace Cdm.Migrations.Migrations
                     b.Navigation("World");
                 });
 
+            modelBuilder.Entity("Cdm.Data.Common.Models.Session", b =>
+                {
+                    b.HasOne("Cdm.Data.Common.Models.Campaign", "Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Cdm.Data.Common.Models.Chapter", "CurrentChapter")
+                        .WithMany()
+                        .HasForeignKey("CurrentChapterId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.HasOne("Cdm.Data.Common.Models.User", "StartedBy")
+                        .WithMany()
+                        .HasForeignKey("StartedById")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("Campaign");
+
+                    b.Navigation("CurrentChapter");
+
+                    b.Navigation("StartedBy");
+                });
+
+            modelBuilder.Entity("Cdm.Data.Common.Models.SessionParticipant", b =>
+                {
+                    b.HasOne("Cdm.Data.Common.Models.Session", "Session")
+                        .WithMany("Participants")
+                        .HasForeignKey("SessionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("Cdm.Data.Common.Models.WorldCharacter", "WorldCharacter")
+                        .WithMany()
+                        .HasForeignKey("WorldCharacterId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Session");
+
+                    b.Navigation("WorldCharacter");
+                });
+
             modelBuilder.Entity("Cdm.Data.Common.Models.Achievement", b =>
                 {
                     b.Navigation("UserAchievements");
@@ -968,6 +1094,11 @@ namespace Cdm.Migrations.Migrations
             modelBuilder.Entity("Cdm.Data.Common.Models.User", b =>
                 {
                     b.Navigation("UserRoles");
+                });
+
+            modelBuilder.Entity("Cdm.Data.Common.Models.Session", b =>
+                {
+                    b.Navigation("Participants");
                 });
 
             modelBuilder.Entity("Cdm.Data.Common.Models.World", b =>

--- a/Cdm/Cdm.Migrations/MigrationsContext.cs
+++ b/Cdm/Cdm.Migrations/MigrationsContext.cs
@@ -73,6 +73,16 @@ public class MigrationsContext : DbContext
     /// </summary>
     public DbSet<NonPlayerCharacter> NonPlayerCharacters { get; set; } = null!;
 
+    /// <summary>
+    /// Sessions table
+    /// </summary>
+    public DbSet<Session> Sessions { get; set; } = null!;
+
+    /// <summary>
+    /// Session participants table
+    /// </summary>
+    public DbSet<SessionParticipant> SessionParticipants { get; set; } = null!;
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -359,6 +369,50 @@ public class MigrationsContext : DbContext
 
             entity.Property(npc => npc.CreatedAt).HasDefaultValueSql("GETUTCDATE()");
             entity.Property(npc => npc.IsActive).HasDefaultValue(true);
+        });
+
+        // Configure Session entity
+        modelBuilder.Entity<Session>(entity =>
+        {
+            entity.HasIndex(s => s.CampaignId).HasDatabaseName("IX_Sessions_CampaignId");
+            entity.HasIndex(s => s.StartedById).HasDatabaseName("IX_Sessions_StartedById");
+            entity.HasIndex(s => s.Status).HasDatabaseName("IX_Sessions_Status");
+
+            entity.HasOne(s => s.Campaign)
+                .WithMany()
+                .HasForeignKey(s => s.CampaignId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(s => s.StartedBy)
+                .WithMany()
+                .HasForeignKey(s => s.StartedById)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne(s => s.CurrentChapter)
+                .WithMany()
+                .HasForeignKey(s => s.CurrentChapterId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            entity.Property(s => s.Status).HasDefaultValue(SessionStatus.Active);
+        });
+
+        // Configure SessionParticipant entity
+        modelBuilder.Entity<SessionParticipant>(entity =>
+        {
+            entity.HasIndex(p => p.SessionId).HasDatabaseName("IX_SessionParticipants_SessionId");
+            entity.HasIndex(p => p.WorldCharacterId).HasDatabaseName("IX_SessionParticipants_WorldCharacterId");
+
+            entity.HasOne(p => p.Session)
+                .WithMany(s => s.Participants)
+                .HasForeignKey(p => p.SessionId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(p => p.WorldCharacter)
+                .WithMany()
+                .HasForeignKey(p => p.WorldCharacterId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.Property(p => p.Status).HasDefaultValue(SessionParticipantStatus.Invited);
         });
 
         // Seed global roles: Player, GameMaster, Admin


### PR DESCRIPTION
…Characters.IsLocked

- Create migration 20260419210000_AddIsLockedAndSessions
  - Add IsLocked (bit, NOT NULL, default 0) column to Characters table
  - Add IX_Characters_IsLocked index
  - Create Sessions table with FK to Campaigns, Users, Chapters
  - Create SessionParticipants table with FK to Sessions, WorldCharacters
- Update MigrationsContext to include Session/SessionParticipant DbSets with full OnModelCreating config
- Update MigrationsContextModelSnapshot to reflect new schema

Fixes 'Invalid column name IsLocked' and 'Invalid object name Sessions' runtime errors.