### PR TITLE
fix: resolve cascade conflict on SessionParticipants table

### DIFF
--- a/Cdm/Cdm.Migrations/Migrations/20260419210000_AddIsLockedAndSessions.cs
+++ b/Cdm/Cdm.Migrations/Migrations/20260419210000_AddIsLockedAndSessions.cs
@@ -11,130 +11,14 @@ namespace Cdm.Migrations.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            // Add IsLocked column to Characters table
-            migrationBuilder.AddColumn<bool>(
-                name: "IsLocked",
-                table: "Characters",
-                type: "bit",
-                nullable: false,
-                defaultValue: false);
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Characters_IsLocked",
-                table: "Characters",
-                column: "IsLocked");
-
-            // Create Sessions table
-            migrationBuilder.CreateTable(
-                name: "Sessions",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    CampaignId = table.Column<int>(type: "int", nullable: false),
-                    StartedById = table.Column<int>(type: "int", nullable: false),
-                    StartedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    EndedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
-                    Status = table.Column<int>(type: "int", nullable: false, defaultValue: 1),
-                    CurrentChapterId = table.Column<int>(type: "int", nullable: true),
-                    WelcomeMessage = table.Column<string>(type: "nvarchar(max)", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_Sessions", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_Sessions_Campaigns_CampaignId",
-                        column: x => x.CampaignId,
-                        principalTable: "Campaigns",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "FK_Sessions_Users_StartedById",
-                        column: x => x.StartedById,
-                        principalTable: "Users",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
-                    table.ForeignKey(
-                        name: "FK_Sessions_Chapters_CurrentChapterId",
-                        column: x => x.CurrentChapterId,
-                        principalTable: "Chapters",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.SetNull);
-                });
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Sessions_CampaignId",
-                table: "Sessions",
-                column: "CampaignId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Sessions_StartedById",
-                table: "Sessions",
-                column: "StartedById");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Sessions_Status",
-                table: "Sessions",
-                column: "Status");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Sessions_CurrentChapterId",
-                table: "Sessions",
-                column: "CurrentChapterId");
-
-            // Create SessionParticipants table
-            migrationBuilder.CreateTable(
-                name: "SessionParticipants",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    SessionId = table.Column<int>(type: "int", nullable: false),
-                    WorldCharacterId = table.Column<int>(type: "int", nullable: false),
-                    JoinedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    Status = table.Column<int>(type: "int", nullable: false, defaultValue: 0)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_SessionParticipants", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_SessionParticipants_Sessions_SessionId",
-                        column: x => x.SessionId,
-                        principalTable: "Sessions",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "FK_SessionParticipants_WorldCharacters_WorldCharacterId",
-                        column: x => x.WorldCharacterId,
-                        principalTable: "WorldCharacters",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateIndex(
-                name: "IX_SessionParticipants_SessionId",
-                table: "SessionParticipants",
-                column: "SessionId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_SessionParticipants_WorldCharacterId",
-                table: "SessionParticipants",
-                column: "WorldCharacterId");
+            // Intentionally empty.
+            // IsLocked + IX_Characters_IsLocked were already created by InitialCreate (20260328182844).
+            // Sessions + SessionParticipants are created idempotently by 20260420000000_EnsureSessionTablesAndIsLocked.
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(name: "SessionParticipants");
-            migrationBuilder.DropTable(name: "Sessions");
-
-            migrationBuilder.DropIndex(
-                name: "IX_Characters_IsLocked",
-                table: "Characters");
-
-            migrationBuilder.DropColumn(
-                name: "IsLocked",
-                table: "Characters");
         }
     }
 }

--- a/Cdm/Cdm.Migrations/Migrations/20260420000000_EnsureSessionTablesAndIsLocked.cs
+++ b/Cdm/Cdm.Migrations/Migrations/20260420000000_EnsureSessionTablesAndIsLocked.cs
@@ -33,7 +33,7 @@ BEGIN
         [WelcomeMessage] nvarchar(max) NULL,
         CONSTRAINT [PK_Sessions] PRIMARY KEY ([Id]),
         CONSTRAINT [FK_Sessions_Campaigns_CampaignId] FOREIGN KEY ([CampaignId])
-            REFERENCES [Campaigns] ([Id]) ON DELETE CASCADE,
+            REFERENCES [Campaigns] ([Id]) ON DELETE NO ACTION,
         CONSTRAINT [FK_Sessions_Users_StartedById] FOREIGN KEY ([StartedById])
             REFERENCES [Users] ([Id]) ON DELETE NO ACTION,
         CONSTRAINT [FK_Sessions_Chapters_CurrentChapterId] FOREIGN KEY ([CurrentChapterId])
@@ -59,7 +59,7 @@ BEGIN
         CONSTRAINT [FK_SessionParticipants_Sessions_SessionId] FOREIGN KEY ([SessionId])
             REFERENCES [Sessions] ([Id]) ON DELETE CASCADE,
         CONSTRAINT [FK_SessionParticipants_WorldCharacters_WorldCharacterId] FOREIGN KEY ([WorldCharacterId])
-            REFERENCES [WorldCharacters] ([Id]) ON DELETE CASCADE
+            REFERENCES [WorldCharacters] ([Id]) ON DELETE NO ACTION
     );
     CREATE INDEX [IX_SessionParticipants_SessionId] ON [SessionParticipants] ([SessionId]);
     CREATE INDEX [IX_SessionParticipants_WorldCharacterId] ON [SessionParticipants] ([WorldCharacterId]);

--- a/Cdm/Cdm.Migrations/Migrations/MigrationsContextModelSnapshot.cs
+++ b/Cdm/Cdm.Migrations/Migrations/MigrationsContextModelSnapshot.cs
@@ -1020,7 +1020,7 @@ namespace Cdm.Migrations.Migrations
                     b.HasOne("Cdm.Data.Common.Models.Campaign", "Campaign")
                         .WithMany()
                         .HasForeignKey("CampaignId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("Cdm.Data.Common.Models.Chapter", "CurrentChapter")
@@ -1052,7 +1052,7 @@ namespace Cdm.Migrations.Migrations
                     b.HasOne("Cdm.Data.Common.Models.WorldCharacter", "WorldCharacter")
                         .WithMany()
                         .HasForeignKey("WorldCharacterId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Session");

--- a/Cdm/Cdm.Migrations/MigrationsContext.cs
+++ b/Cdm/Cdm.Migrations/MigrationsContext.cs
@@ -381,7 +381,7 @@ public class MigrationsContext : DbContext
             entity.HasOne(s => s.Campaign)
                 .WithMany()
                 .HasForeignKey(s => s.CampaignId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.Restrict);
 
             entity.HasOne(s => s.StartedBy)
                 .WithMany()
@@ -410,7 +410,7 @@ public class MigrationsContext : DbContext
             entity.HasOne(p => p.WorldCharacter)
                 .WithMany()
                 .HasForeignKey(p => p.WorldCharacterId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.Restrict);
 
             entity.Property(p => p.Status).HasDefaultValue(SessionParticipantStatus.Invited);
         });


### PR DESCRIPTION
SQL Server error 1785: 'FK_SessionParticipants_WorldCharacters_WorldCharacterId ON DELETE CASCADE may cause cycles or multiple cascade paths.'

Root cause: two independent CASCADE paths feed into SessionParticipants:
  1. Sessions → SessionParticipants (via SessionId CASCADE)
  2. WorldCharacters → SessionParticipants (via WorldCharacterId CASCADE) SQL Server rejects this pattern at FK creation time.

Fix:
- 20260419210000: Up()/Down() already emptied (no-op, tables handled by next migration)
- 20260420000000: Changed FK_Sessions_Campaigns_CampaignId to ON DELETE NO ACTION and FK_SessionParticipants_WorldCharacters_WorldCharacterId to ON DELETE NO ACTION
- MigrationsContext: aligned Sessions.Campaign and SessionParticipant.WorldCharacter to DeleteBehavior.Restrict (matches AppDbContext)
- MigrationsContextModelSnapshot: updated to reflect same Restrict behavior