### PR TITLE
feat: add session termination notification and improve JWT user claims

### DIFF
--- a/Cdm/Cdm.ApiService/Endpoints/SessionEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/SessionEndpoints.cs
@@ -6,9 +6,11 @@
 
 namespace Cdm.ApiService.Endpoints;
 
+using Cdm.ApiService.Hubs;
 using Cdm.Business.Abstraction.DTOs;
 using Cdm.Business.Abstraction.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
 using System.Security.Claims;
 
 /// <summary>
@@ -161,6 +163,7 @@ public static class SessionEndpoints
     private static async Task<IResult> EndSessionAsync(
         int id,
         [FromServices] ISessionService sessionService,
+        [FromServices] IHubContext<SessionHub> hubContext,
         ILogger<SessionEndpointsLogger> logger,
         HttpContext httpContext)
     {
@@ -171,6 +174,9 @@ public static class SessionEndpoints
 
             var ended = await sessionService.EndSessionAsync(id, userId.Value);
             if (!ended) return Results.BadRequest(new { Error = "Failed to end session. Check session ownership." });
+
+            await hubContext.Clients.Group($"chapter_{id}")
+                .SendAsync("SessionEnded", new { SessionId = id, Timestamp = DateTime.UtcNow });
 
             return Results.NoContent();
         }

--- a/Cdm/Cdm.Business.Common/Services/AuthService.cs
+++ b/Cdm/Cdm.Business.Common/Services/AuthService.cs
@@ -97,7 +97,7 @@ public class AuthService : IAuthService
             var roleNames = roles.Select(r => r.Name).ToList();
 
             // Generate JWT token with roles
-            var token = this.jwtService.GenerateToken(user.Id, user.Email, roleNames);
+            var token = this.jwtService.GenerateToken(user.Id, user.Email, roleNames, user.Nickname);
 
             // Send welcome email (optional)
             if (this.emailService != null)
@@ -181,7 +181,7 @@ public class AuthService : IAuthService
                 .ToListAsync();
 
             // Generate JWT token with roles
-            var token = this.jwtService.GenerateToken(user.Id, user.Email, roles);
+            var token = this.jwtService.GenerateToken(user.Id, user.Email, roles, user.Nickname);
 
             // Return success response
             var response = new LoginResponse

--- a/Cdm/Cdm.Common/Services/JwtService.cs
+++ b/Cdm/Cdm.Common/Services/JwtService.cs
@@ -22,7 +22,7 @@ public interface IJwtService
     /// <param name="email">User email</param>
     /// <param name="roles">List of role names assigned to the user</param>
     /// <returns>JWT token string</returns>
-    string GenerateToken(int userId, string email, List<string> roles);
+    string GenerateToken(int userId, string email, List<string> roles, string? nickname = null);
 
     /// <summary>
     /// Validate a JWT token
@@ -67,7 +67,7 @@ public class JwtService : IJwtService
         }
     }
 
-    public string GenerateToken(int userId, string email, List<string> roles)
+    public string GenerateToken(int userId, string email, List<string> roles, string? nickname = null)
     {
         try
         {
@@ -79,6 +79,7 @@ public class JwtService : IJwtService
             {
                 new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
                 new Claim(ClaimTypes.Email, email),
+                new Claim(ClaimTypes.Name, nickname ?? email),
                 new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
                 new Claim(JwtRegisteredClaimNames.Iat, DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString())
             };

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor
@@ -305,8 +305,8 @@ else if (Session != null)
                             <button class="gm-dice-btn @(RollingDie == f ? "rolling" : "")"
                                     @onclick="() => RollDice(f)"
                                     disabled="@(!IsHubConnected || RollingDie.HasValue)"
-                                    title="Lancer un D@f">
-                                D@f
+                                    title="Lancer un D@(f)">
+                                D@(f)
                             </button>
                         }
                     </div>

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor
@@ -278,7 +278,7 @@ else if (Session != null)
                             <button class="dice-btn @(RollingDie == f ? "rolling" : "")"
                                     @onclick="() => RollDice(f)"
                                     disabled="@(!IsHubConnected || RollingDie.HasValue)">
-                                D@f
+                                D@(f)
                             </button>
                         }
                     </div>

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor.cs
@@ -82,8 +82,9 @@ public partial class SessionPlayer : IAsyncDisposable
         MyCharacter = await WorldClient.GetMyWorldCharacterAsync(Session.WorldId);
         ParseGameSpecificData();
 
-        // Auto-join si status == Invited
-        if (MyParticipant?.Status == SessionParticipantStatus.Invited && MyCharacter != null)
+        // Auto-join si status == Invited ou Left (rejoin après avoir quitté)
+        if ((MyParticipant?.Status == SessionParticipantStatus.Invited
+             || MyParticipant?.Status == SessionParticipantStatus.Left) && MyCharacter != null)
         {
             var joined = await SessionClient.JoinSessionAsync(Session.Id, MyCharacter.Id);
             if (joined != null)
@@ -124,6 +125,15 @@ public partial class SessionPlayer : IAsyncDisposable
         {
             ChatEntries.Add(new ChatEntry("dice", dto.UserName ?? "?", null, dto.DiceType, dto.Results, dto.Timestamp));
             InvokeAsync(StateHasChanged);
+        });
+
+        _hub.On<object>("SessionEnded", _ =>
+        {
+            InvokeAsync(() =>
+            {
+                Nav.NavigateTo($"/worlds/{Session!.WorldId}");
+                return Task.CompletedTask;
+            });
         });
 
         try


### PR DESCRIPTION
- Broadcast "SessionEnded" via SignalR when a session is closed, redirecting players to the world view.
- Include user nicknames in JWT claims as ClaimTypes.Name.
- Allow players to automatically rejoin sessions from a "Left" status.
- Refactor Blazor dice templates for better syntax consistency.