### PR TITLE
feat: implement JWT refresh tokens and persist session activity

### DIFF
--- a/Cdm/Cdm.ApiService/Endpoints/AuthEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/AuthEndpoints.cs
@@ -84,5 +84,30 @@ public static class AuthEndpoints
         .WithDescription("Authenticate with email and password to receive a JWT token")
         .Produces<LoginResponse>(StatusCodes.Status200OK)
         .Produces<ErrorResponse>(StatusCodes.Status400BadRequest);
+
+        // POST /api/auth/refresh
+        group.MapPost("/refresh", async (
+            [FromBody] RefreshTokenRequest request,
+            [FromServices] IAuthService authService,
+            ILogger<RefreshTokenRequest> logger) =>
+        {
+            logger.LogInformation("Token refresh request received");
+
+            var result = await authService.RefreshTokenAsync(request.RefreshToken);
+
+            if (result.IsSuccess)
+            {
+                logger.LogInformation("Token refreshed for user: {UserId}", result.Data!.UserId);
+                return Results.Ok(result.Data);
+            }
+
+            logger.LogWarning("Token refresh failed: {Error}", result.ErrorMessage);
+            return Results.Unauthorized();
+        })
+        .WithName("RefreshToken")
+        .WithSummary("Refresh a JWT access token")
+        .WithDescription("Exchange a valid refresh token for a new access token and refresh token")
+        .Produces<LoginResponse>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized);
     }
 }

--- a/Cdm/Cdm.ApiService/Hubs/SessionHub.cs
+++ b/Cdm/Cdm.ApiService/Hubs/SessionHub.cs
@@ -6,6 +6,8 @@
 
 namespace Cdm.ApiService.Hubs;
 
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using System.Security.Claims;
@@ -18,14 +20,17 @@ using System.Security.Claims;
 public class SessionHub : Hub
 {
     private readonly ILogger<SessionHub> logger;
+    private readonly AppDbContext db;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SessionHub"/> class.
     /// </summary>
     /// <param name="logger">Logger instance.</param>
-    public SessionHub(ILogger<SessionHub> logger)
+    /// <param name="db">Database context.</param>
+    public SessionHub(ILogger<SessionHub> logger, AppDbContext db)
     {
         this.logger = logger;
+        this.db = db;
     }
 
     /// <summary>
@@ -36,7 +41,7 @@ public class SessionHub : Hub
     public async Task JoinSession(int chapterId)
     {
         var userId = this.GetUserId();
-        var userName = this.Context.User?.Identity?.Name ?? "Unknown";
+        var userName = this.GetUserName();
         var groupName = $"chapter_{chapterId}";
 
         await this.Groups.AddToGroupAsync(this.Context.ConnectionId, groupName);
@@ -61,7 +66,7 @@ public class SessionHub : Hub
     public async Task LeaveSession(int chapterId)
     {
         var userId = this.GetUserId();
-        var userName = this.Context.User?.Identity?.Name ?? "Unknown";
+        var userName = this.GetUserName();
         var groupName = $"chapter_{chapterId}";
 
         await this.Groups.RemoveFromGroupAsync(this.Context.ConnectionId, groupName);
@@ -87,13 +92,25 @@ public class SessionHub : Hub
     public async Task SendMessage(int chapterId, string message)
     {
         var userId = this.GetUserId();
-        var userName = this.Context.User?.Identity?.Name ?? "Unknown";
+        var userName = this.GetUserName();
         var groupName = $"chapter_{chapterId}";
 
         this.logger.LogInformation(
             "User {UserId} sent message in session {ChapterId}",
             userId,
             chapterId);
+
+        // Persist message to database
+        var sessionMessage = new SessionMessage
+        {
+            ChapterId = chapterId,
+            UserId = userId,
+            UserName = userName,
+            Message = message,
+            SentAt = DateTime.UtcNow
+        };
+        this.db.SessionMessages.Add(sessionMessage);
+        await this.db.SaveChangesAsync();
 
         await this.Clients.Group(groupName).SendAsync(
             "ReceiveMessage",
@@ -119,7 +136,7 @@ public class SessionHub : Hub
     public async Task RollDice(int chapterId, string diceType, int count, int[] results, int modifier, string? reason)
     {
         var userId = this.GetUserId();
-        var userName = this.Context.User?.Identity?.Name ?? "Unknown";
+        var userName = this.GetUserName();
         var groupName = $"chapter_{chapterId}";
         var total = results.Sum() + modifier;
 
@@ -130,6 +147,23 @@ public class SessionHub : Hub
             diceType,
             chapterId,
             total);
+
+        // Persist dice roll to database
+        var diceRoll = new SessionDiceRoll
+        {
+            ChapterId = chapterId,
+            UserId = userId,
+            UserName = userName,
+            DiceType = diceType,
+            Count = count,
+            Results = string.Join(",", results),
+            Modifier = modifier,
+            Total = total,
+            Reason = reason,
+            RolledAt = DateTime.UtcNow
+        };
+        this.db.SessionDiceRolls.Add(diceRoll);
+        await this.db.SaveChangesAsync();
 
         await this.Clients.Group(groupName).SendAsync(
             "DiceRolled",
@@ -158,7 +192,7 @@ public class SessionHub : Hub
     public async Task ProposeTradeTheory(int chapterId, int targetUserId, string offerDescription, string requestDescription)
     {
         var userId = this.GetUserId();
-        var userName = this.Context.User?.Identity?.Name ?? "Unknown";
+        var userName = this.GetUserName();
         var groupName = $"chapter_{chapterId}";
 
         this.logger.LogInformation(
@@ -244,5 +278,18 @@ public class SessionHub : Hub
     {
         var userIdClaim = this.Context.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         return int.TryParse(userIdClaim, out int userId) ? userId : 0;
+    }
+
+    /// <summary>
+    /// Gets the current user's display name from claims.
+    /// Falls back through multiple claim types to handle different JWT mapping configurations.
+    /// </summary>
+    /// <returns>The user name, or "Unknown" if not found.</returns>
+    private string GetUserName()
+    {
+        return this.Context.User?.FindFirst(ClaimTypes.Name)?.Value
+            ?? this.Context.User?.FindFirst("name")?.Value
+            ?? this.Context.User?.FindFirst("unique_name")?.Value
+            ?? "Unknown";
     }
 }

--- a/Cdm/Cdm.ApiService/Program.cs
+++ b/Cdm/Cdm.ApiService/Program.cs
@@ -189,6 +189,81 @@ END
         logger.LogError(ex, "An error occurred while ensuring database schema.");
         // Do not throw — allow app to start even if safety net fails
     }
+
+    // Safety net for new tables added in migration 20260421100000
+    try
+    {
+        await appDbContext.Database.ExecuteSqlRawAsync(@"
+IF OBJECT_ID(N'[dbo].[RefreshTokens]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [dbo].[RefreshTokens] (
+        [Id] int NOT NULL IDENTITY,
+        [Token] nvarchar(500) NOT NULL,
+        [UserId] int NOT NULL,
+        [ExpiresAt] datetime2 NOT NULL,
+        [CreatedAt] datetime2 NOT NULL DEFAULT (GETUTCDATE()),
+        [RevokedAt] datetime2 NULL,
+        CONSTRAINT [PK_RefreshTokens] PRIMARY KEY ([Id]),
+        CONSTRAINT [FK_RefreshTokens_Users_UserId] FOREIGN KEY ([UserId])
+            REFERENCES [dbo].[Users] ([Id]) ON DELETE CASCADE
+    );
+    CREATE UNIQUE INDEX [IX_RefreshTokens_Token] ON [dbo].[RefreshTokens] ([Token]);
+    CREATE INDEX [IX_RefreshTokens_UserId] ON [dbo].[RefreshTokens] ([UserId]);
+    CREATE INDEX [IX_RefreshTokens_ExpiresAt] ON [dbo].[RefreshTokens] ([ExpiresAt]);
+END
+
+IF OBJECT_ID(N'[dbo].[SessionMessages]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [dbo].[SessionMessages] (
+        [Id] int NOT NULL IDENTITY,
+        [ChapterId] int NOT NULL,
+        [UserId] int NOT NULL,
+        [UserName] nvarchar(200) NOT NULL,
+        [Message] nvarchar(max) NOT NULL,
+        [SentAt] datetime2 NOT NULL DEFAULT (GETUTCDATE()),
+        CONSTRAINT [PK_SessionMessages] PRIMARY KEY ([Id]),
+        CONSTRAINT [FK_SessionMessages_Chapters_ChapterId] FOREIGN KEY ([ChapterId])
+            REFERENCES [dbo].[Chapters] ([Id]) ON DELETE CASCADE,
+        CONSTRAINT [FK_SessionMessages_Users_UserId] FOREIGN KEY ([UserId])
+            REFERENCES [dbo].[Users] ([Id]) ON DELETE NO ACTION
+    );
+    CREATE INDEX [IX_SessionMessages_ChapterId] ON [dbo].[SessionMessages] ([ChapterId]);
+    CREATE INDEX [IX_SessionMessages_UserId] ON [dbo].[SessionMessages] ([UserId]);
+    CREATE INDEX [IX_SessionMessages_SentAt] ON [dbo].[SessionMessages] ([SentAt]);
+END
+
+IF OBJECT_ID(N'[dbo].[SessionDiceRolls]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [dbo].[SessionDiceRolls] (
+        [Id] int NOT NULL IDENTITY,
+        [ChapterId] int NOT NULL,
+        [UserId] int NOT NULL,
+        [UserName] nvarchar(200) NOT NULL,
+        [DiceType] nvarchar(20) NOT NULL,
+        [Count] int NOT NULL,
+        [Results] nvarchar(500) NOT NULL,
+        [Modifier] int NOT NULL DEFAULT 0,
+        [Total] int NOT NULL,
+        [Reason] nvarchar(500) NULL,
+        [RolledAt] datetime2 NOT NULL DEFAULT (GETUTCDATE()),
+        CONSTRAINT [PK_SessionDiceRolls] PRIMARY KEY ([Id]),
+        CONSTRAINT [FK_SessionDiceRolls_Chapters_ChapterId] FOREIGN KEY ([ChapterId])
+            REFERENCES [dbo].[Chapters] ([Id]) ON DELETE CASCADE,
+        CONSTRAINT [FK_SessionDiceRolls_Users_UserId] FOREIGN KEY ([UserId])
+            REFERENCES [dbo].[Users] ([Id]) ON DELETE NO ACTION
+    );
+    CREATE INDEX [IX_SessionDiceRolls_ChapterId] ON [dbo].[SessionDiceRolls] ([ChapterId]);
+    CREATE INDEX [IX_SessionDiceRolls_UserId] ON [dbo].[SessionDiceRolls] ([UserId]);
+    CREATE INDEX [IX_SessionDiceRolls_DiceType] ON [dbo].[SessionDiceRolls] ([DiceType]);
+    CREATE INDEX [IX_SessionDiceRolls_RolledAt] ON [dbo].[SessionDiceRolls] ([RolledAt]);
+END
+");
+        logger.LogInformation("RefreshTokens, SessionMessages, SessionDiceRolls tables ensured.");
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "An error occurred while ensuring new tables schema.");
+    }
 }
 
 // Configure the HTTP request pipeline.

--- a/Cdm/Cdm.ApiService/appsettings.json
+++ b/Cdm/Cdm.ApiService/appsettings.json
@@ -14,6 +14,6 @@
     "SecretKey": "CHANGE-THIS-IN-PRODUCTION-WITH-SECURE-SECRET-KEY-AT-LEAST-32-CHARS",
     "Issuer": "ChroniqueDesMondes",
     "Audience": "ChroniqueDesMondesWeb",
-    "ExpirationDays": 7
+    "ExpirationHours": 1
   }
 }

--- a/Cdm/Cdm.Business.Abstraction/DTOs/Models/RefreshTokenRequest.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/Models/RefreshTokenRequest.cs
@@ -1,0 +1,15 @@
+namespace Cdm.Business.Abstraction.DTOs.Models;
+
+using System.ComponentModel.DataAnnotations;
+
+/// <summary>
+/// Represents a request to refresh a JWT access token.
+/// </summary>
+public class RefreshTokenRequest
+{
+    /// <summary>
+    /// Gets or sets the refresh token.
+    /// </summary>
+    [Required(ErrorMessage = "Refresh token is required")]
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/Cdm/Cdm.Business.Abstraction/DTOs/ViewModels/LoginResponse.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/ViewModels/LoginResponse.cs
@@ -26,6 +26,16 @@ public class LoginResponse
     public string Token { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the refresh token for renewing the JWT.
+    /// </summary>
+    public string RefreshToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets when the refresh token expires.
+    /// </summary>
+    public DateTime RefreshTokenExpiry { get; set; }
+
+    /// <summary>
     /// Gets or sets the success message.
     /// </summary>
     public string Message { get; set; } = "Login successful";

--- a/Cdm/Cdm.Business.Abstraction/Services/IAuthService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/IAuthService.cs
@@ -21,6 +21,13 @@ public interface IAuthService
     /// <param name="request">Login request DTO</param>
     /// <returns>Service result with login response</returns>
     Task<ServiceResult<LoginResponse>> LoginAsync(LoginRequest request);
+
+    /// <summary>
+    /// Refresh a JWT access token using a valid refresh token
+    /// </summary>
+    /// <param name="refreshToken">The refresh token string</param>
+    /// <returns>Service result with a new login response containing fresh tokens</returns>
+    Task<ServiceResult<LoginResponse>> RefreshTokenAsync(string refreshToken);
 }
 
 /// <summary>

--- a/Cdm/Cdm.Business.Common/Services/AuthService.cs
+++ b/Cdm/Cdm.Business.Common/Services/AuthService.cs
@@ -8,6 +8,7 @@ using Cdm.Data.Common;
 using Cdm.Data.Common.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System.Security.Cryptography;
 
 /// <summary>
 /// Authentication service implementation
@@ -99,6 +100,9 @@ public class AuthService : IAuthService
             // Generate JWT token with roles
             var token = this.jwtService.GenerateToken(user.Id, user.Email, roleNames, user.Nickname);
 
+            // Generate and save refresh token
+            var refreshToken = await this.CreateRefreshTokenAsync(user.Id);
+
             // Send welcome email (optional)
             if (this.emailService != null)
             {
@@ -115,7 +119,6 @@ public class AuthService : IAuthService
                 }
             }
 
-            // Return success response
             var response = new RegisterResponse
             {
                 UserId = user.Id,
@@ -183,6 +186,9 @@ public class AuthService : IAuthService
             // Generate JWT token with roles
             var token = this.jwtService.GenerateToken(user.Id, user.Email, roles, user.Nickname);
 
+            // Generate and save refresh token
+            var refreshToken = await this.CreateRefreshTokenAsync(user.Id);
+
             // Return success response
             var response = new LoginResponse
             {
@@ -190,6 +196,8 @@ public class AuthService : IAuthService
                 Email = user.Email,
                 Nickname = user.Nickname,
                 Token = token,
+                RefreshToken = refreshToken.Token,
+                RefreshTokenExpiry = refreshToken.ExpiresAt,
                 Message = "Login successful"
             };
 
@@ -201,5 +209,81 @@ public class AuthService : IAuthService
             return ServiceResult<LoginResponse>.Failure("An error occurred during login");
         }
     }
-}
 
+    public async Task<ServiceResult<LoginResponse>> RefreshTokenAsync(string refreshToken)
+    {
+        try
+        {
+            var token = await this.context.RefreshTokens
+                .Include(rt => rt.User)
+                .FirstOrDefaultAsync(rt => rt.Token == refreshToken);
+
+            if (token == null || !token.IsActive)
+            {
+                this.logger.LogWarning("Refresh token is invalid or expired");
+                return ServiceResult<LoginResponse>.Failure("Invalid or expired refresh token");
+            }
+
+            var user = token.User;
+            if (!user.IsActive)
+            {
+                return ServiceResult<LoginResponse>.Failure("Account is inactive");
+            }
+
+            // Revoke old refresh token
+            token.RevokedAt = DateTime.UtcNow;
+            this.context.RefreshTokens.Update(token);
+
+            // Generate new tokens
+            var roles = await this.context.UserRoles
+                .Where(ur => ur.UserId == user.Id)
+                .Include(ur => ur.Role)
+                .Select(ur => ur.Role.Name)
+                .ToListAsync();
+
+            var newAccessToken = this.jwtService.GenerateToken(user.Id, user.Email, roles, user.Nickname);
+            var newRefreshToken = await this.CreateRefreshTokenAsync(user.Id);
+
+            await this.context.SaveChangesAsync();
+
+            this.logger.LogInformation("Tokens refreshed for user {UserId}", user.Id);
+
+            return ServiceResult<LoginResponse>.Success(new LoginResponse
+            {
+                UserId = user.Id,
+                Email = user.Email,
+                Nickname = user.Nickname,
+                Token = newAccessToken,
+                RefreshToken = newRefreshToken.Token,
+                RefreshTokenExpiry = newRefreshToken.ExpiresAt,
+                Message = "Token refreshed"
+            });
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error during token refresh");
+            return ServiceResult<LoginResponse>.Failure("An error occurred during token refresh");
+        }
+    }
+
+    private async Task<RefreshToken> CreateRefreshTokenAsync(int userId)
+    {
+        var tokenBytes = new byte[64];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(tokenBytes);
+        var tokenString = Convert.ToBase64String(tokenBytes);
+
+        var refreshToken = new RefreshToken
+        {
+            Token = tokenString,
+            UserId = userId,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+            CreatedAt = DateTime.UtcNow
+        };
+
+        this.context.RefreshTokens.Add(refreshToken);
+        await this.context.SaveChangesAsync();
+
+        return refreshToken;
+    }
+}

--- a/Cdm/Cdm.Business.Common/Services/CharacterService.cs
+++ b/Cdm/Cdm.Business.Common/Services/CharacterService.cs
@@ -42,7 +42,7 @@ public class CharacterService(
             var character = new Character
             {
                 UserId = userId,
-                Name = dto.Name,
+                Name = string.IsNullOrEmpty(dto.Name) ? (dto.FirstName ?? string.Empty) : dto.Name,
                 FirstName = dto.FirstName,
                 Description = dto.Description,
                 Age = dto.Age,
@@ -159,7 +159,7 @@ public class CharacterService(
             }
 
             // Update fields
-            character.Name = dto.Name;
+            character.Name = string.IsNullOrEmpty(dto.Name) ? (dto.FirstName ?? string.Empty) : dto.Name;
             character.FirstName = dto.FirstName;
             character.Description = dto.Description;
             character.Age = dto.Age;

--- a/Cdm/Cdm.Business.Common/Services/SessionService.cs
+++ b/Cdm/Cdm.Business.Common/Services/SessionService.cs
@@ -383,7 +383,7 @@ public class SessionService(AppDbContext dbContext, ILogger<SessionService> logg
                 Id = p.Id,
                 SessionId = p.SessionId,
                 WorldCharacterId = p.WorldCharacterId,
-                CharacterName = p.WorldCharacter?.Character?.Name ?? string.Empty,
+                CharacterName = p.WorldCharacter?.Character?.FirstName ?? p.WorldCharacter?.Character?.Name ?? string.Empty,
                 UserId = p.WorldCharacter?.Character?.UserId ?? 0,
                 UserName = p.WorldCharacter?.Character?.Owner?.Nickname ?? string.Empty,
                 JoinedAt = p.JoinedAt,

--- a/Cdm/Cdm.Business.Common/Services/WorldService.cs
+++ b/Cdm/Cdm.Business.Common/Services/WorldService.cs
@@ -381,7 +381,7 @@ public class WorldService(
         {
             Id = wc.Id,
             CharacterId = wc.CharacterId,
-            CharacterName = wc.Character?.Name ?? string.Empty,
+            CharacterName = wc.Character?.FirstName ?? wc.Character?.Name ?? string.Empty,
             WorldId = wc.WorldId,
             WorldName = wc.World?.Name ?? string.Empty,
             GameType = wc.World?.GameType ?? GameType.Custom,

--- a/Cdm/Cdm.Common/Services/JwtService.cs
+++ b/Cdm/Cdm.Common/Services/JwtService.cs
@@ -47,7 +47,7 @@ public class JwtService : IJwtService
     private readonly string secretKey;
     private readonly string issuer;
     private readonly string audience;
-    private readonly int expirationDays;
+    private readonly int expirationHours;
     private readonly ILogger<JwtService> logger;
 
     public JwtService(IConfiguration configuration, ILogger<JwtService> logger)
@@ -59,7 +59,7 @@ public class JwtService : IJwtService
             ?? throw new InvalidOperationException("JWT secret key configuration ('Jwt:SecretKey') is missing. Please set a secure value in your configuration.");
         this.issuer = configuration["Jwt:Issuer"] ?? "ChroniqueDesMondes";
         this.audience = configuration["Jwt:Audience"] ?? "ChroniqueDesMondesWeb";
-        this.expirationDays = int.TryParse(configuration["Jwt:ExpirationDays"], out var days) ? days : 7;
+        this.expirationHours = int.TryParse(configuration["Jwt:ExpirationHours"], out var hours) ? hours : 1;
 
         if (this.secretKey.Length < 32)
         {
@@ -80,6 +80,7 @@ public class JwtService : IJwtService
                 new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
                 new Claim(ClaimTypes.Email, email),
                 new Claim(ClaimTypes.Name, nickname ?? email),
+                new Claim(JwtRegisteredClaimNames.Name, nickname ?? email),
                 new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
                 new Claim(JwtRegisteredClaimNames.Iat, DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString())
             };
@@ -93,7 +94,7 @@ public class JwtService : IJwtService
             var tokenDescriptor = new SecurityTokenDescriptor
             {
                 Subject = new ClaimsIdentity(claimsList),
-                Expires = DateTime.UtcNow.AddDays(this.expirationDays),
+                Expires = DateTime.UtcNow.AddHours(this.expirationHours),
                 Issuer = this.issuer,
                 Audience = this.audience,
                 SigningCredentials = new SigningCredentials(

--- a/Cdm/Cdm.Data.Common/AppDbContext.cs
+++ b/Cdm/Cdm.Data.Common/AppDbContext.cs
@@ -88,6 +88,21 @@ public class AppDbContext : DbContext
     /// </summary>
     public DbSet<NonPlayerCharacter> NonPlayerCharacters { get; set; } = null!;
 
+    /// <summary>
+    /// Gets or sets the refresh tokens.
+    /// </summary>
+    public DbSet<RefreshToken> RefreshTokens { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the session chat messages.
+    /// </summary>
+    public DbSet<SessionMessage> SessionMessages { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the session dice rolls.
+    /// </summary>
+    public DbSet<SessionDiceRoll> SessionDiceRolls { get; set; } = null!;
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/Cdm/Cdm.Data.Common/Models/RefreshToken.cs
+++ b/Cdm/Cdm.Data.Common/Models/RefreshToken.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------
+// <copyright file="RefreshToken.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Data.Common.Models;
+
+/// <summary>
+/// Represents a refresh token issued to a user for renewing JWT access tokens.
+/// </summary>
+public class RefreshToken
+{
+    /// <summary>Gets or sets the refresh token ID.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the opaque token string.</summary>
+    public string Token { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the user this token belongs to.</summary>
+    public int UserId { get; set; }
+
+    /// <summary>Gets or sets when this token expires.</summary>
+    public DateTime ExpiresAt { get; set; }
+
+    /// <summary>Gets or sets when this token was created.</summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Gets or sets when this token was revoked (null if still valid).</summary>
+    public DateTime? RevokedAt { get; set; }
+
+    /// <summary>Gets a value indicating whether this token is revoked.</summary>
+    public bool IsRevoked => this.RevokedAt.HasValue;
+
+    /// <summary>Gets a value indicating whether this token is expired or revoked.</summary>
+    public bool IsActive => !this.IsRevoked && this.ExpiresAt > DateTime.UtcNow;
+
+    /// <summary>Gets or sets the user navigation property.</summary>
+    public virtual User User { get; set; } = null!;
+}

--- a/Cdm/Cdm.Data.Common/Models/SessionDiceRoll.cs
+++ b/Cdm/Cdm.Data.Common/Models/SessionDiceRoll.cs
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionDiceRoll.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Data.Common.Models;
+
+/// <summary>
+/// Represents a dice roll performed during a session.
+/// Stored separately from chat messages to allow statistical queries on rolls.
+/// </summary>
+public class SessionDiceRoll
+{
+    /// <summary>Gets or sets the dice roll ID.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the chapter ID where the roll occurred.</summary>
+    public int ChapterId { get; set; }
+
+    /// <summary>Gets or sets the user ID of the player who rolled.</summary>
+    public int UserId { get; set; }
+
+    /// <summary>Gets or sets the display name of the roller at the time of rolling.</summary>
+    public string UserName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the dice type (e.g. "d20", "d6").</summary>
+    public string DiceType { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the number of dice rolled.</summary>
+    public int Count { get; set; }
+
+    /// <summary>Gets or sets the individual die results, stored as a comma-separated string.</summary>
+    public string Results { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the modifier applied to the roll.</summary>
+    public int Modifier { get; set; }
+
+    /// <summary>Gets or sets the total result (sum of results + modifier).</summary>
+    public int Total { get; set; }
+
+    /// <summary>Gets or sets the optional reason for the roll (e.g. "Attack roll", "Perception check").</summary>
+    public string? Reason { get; set; }
+
+    /// <summary>Gets or sets when this roll occurred.</summary>
+    public DateTime RolledAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Gets or sets the user navigation property.</summary>
+    public virtual User User { get; set; } = null!;
+
+    /// <summary>Gets or sets the chapter navigation property.</summary>
+    public virtual Chapter Chapter { get; set; } = null!;
+}

--- a/Cdm/Cdm.Data.Common/Models/SessionMessage.cs
+++ b/Cdm/Cdm.Data.Common/Models/SessionMessage.cs
@@ -1,0 +1,37 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionMessage.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Data.Common.Models;
+
+/// <summary>
+/// Represents a chat message sent during a session.
+/// </summary>
+public class SessionMessage
+{
+    /// <summary>Gets or sets the message ID.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the chapter ID this message belongs to.</summary>
+    public int ChapterId { get; set; }
+
+    /// <summary>Gets or sets the user ID of the sender.</summary>
+    public int UserId { get; set; }
+
+    /// <summary>Gets or sets the display name of the sender at the time of sending.</summary>
+    public string UserName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the message content.</summary>
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets when this message was sent.</summary>
+    public DateTime SentAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Gets or sets the user navigation property.</summary>
+    public virtual User User { get; set; } = null!;
+
+    /// <summary>Gets or sets the chapter navigation property.</summary>
+    public virtual Chapter Chapter { get; set; } = null!;
+}

--- a/Cdm/Cdm.Migrations/Migrations/20260421100000_AddRefreshTokensAndSessionTables.cs
+++ b/Cdm/Cdm.Migrations/Migrations/20260421100000_AddRefreshTokensAndSessionTables.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Cdm.Migrations;
+
+#nullable disable
+
+namespace Cdm.Migrations.Migrations
+{
+    [DbContext(typeof(MigrationsContext))]
+    [Migration("20260421100000_AddRefreshTokensAndSessionTables")]
+    public partial class AddRefreshTokensAndSessionTables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF OBJECT_ID(N'[RefreshTokens]', N'U') IS NULL
+                BEGIN
+                    CREATE TABLE [RefreshTokens] (
+                        [Id] int NOT NULL IDENTITY,
+                        [Token] nvarchar(500) NOT NULL,
+                        [UserId] int NOT NULL,
+                        [ExpiresAt] datetime2 NOT NULL,
+                        [CreatedAt] datetime2 NOT NULL DEFAULT (GETUTCDATE()),
+                        [RevokedAt] datetime2 NULL,
+                        CONSTRAINT [PK_RefreshTokens] PRIMARY KEY ([Id]),
+                        CONSTRAINT [FK_RefreshTokens_Users_UserId] FOREIGN KEY ([UserId])
+                            REFERENCES [Users] ([Id]) ON DELETE CASCADE
+                    );
+
+                    CREATE UNIQUE INDEX [IX_RefreshTokens_Token] ON [RefreshTokens] ([Token]);
+                    CREATE INDEX [IX_RefreshTokens_UserId] ON [RefreshTokens] ([UserId]);
+                    CREATE INDEX [IX_RefreshTokens_ExpiresAt] ON [RefreshTokens] ([ExpiresAt]);
+                END
+
+                IF OBJECT_ID(N'[SessionMessages]', N'U') IS NULL
+                BEGIN
+                    CREATE TABLE [SessionMessages] (
+                        [Id] int NOT NULL IDENTITY,
+                        [ChapterId] int NOT NULL,
+                        [UserId] int NOT NULL,
+                        [UserName] nvarchar(200) NOT NULL,
+                        [Message] nvarchar(max) NOT NULL,
+                        [SentAt] datetime2 NOT NULL DEFAULT (GETUTCDATE()),
+                        CONSTRAINT [PK_SessionMessages] PRIMARY KEY ([Id]),
+                        CONSTRAINT [FK_SessionMessages_Chapters_ChapterId] FOREIGN KEY ([ChapterId])
+                            REFERENCES [Chapters] ([Id]) ON DELETE CASCADE,
+                        CONSTRAINT [FK_SessionMessages_Users_UserId] FOREIGN KEY ([UserId])
+                            REFERENCES [Users] ([Id]) ON DELETE NO ACTION
+                    );
+
+                    CREATE INDEX [IX_SessionMessages_ChapterId] ON [SessionMessages] ([ChapterId]);
+                    CREATE INDEX [IX_SessionMessages_UserId] ON [SessionMessages] ([UserId]);
+                    CREATE INDEX [IX_SessionMessages_SentAt] ON [SessionMessages] ([SentAt]);
+                END
+
+                IF OBJECT_ID(N'[SessionDiceRolls]', N'U') IS NULL
+                BEGIN
+                    CREATE TABLE [SessionDiceRolls] (
+                        [Id] int NOT NULL IDENTITY,
+                        [ChapterId] int NOT NULL,
+                        [UserId] int NOT NULL,
+                        [UserName] nvarchar(200) NOT NULL,
+                        [DiceType] nvarchar(20) NOT NULL,
+                        [Count] int NOT NULL,
+                        [Results] nvarchar(500) NOT NULL,
+                        [Modifier] int NOT NULL DEFAULT 0,
+                        [Total] int NOT NULL,
+                        [Reason] nvarchar(500) NULL,
+                        [RolledAt] datetime2 NOT NULL DEFAULT (GETUTCDATE()),
+                        CONSTRAINT [PK_SessionDiceRolls] PRIMARY KEY ([Id]),
+                        CONSTRAINT [FK_SessionDiceRolls_Chapters_ChapterId] FOREIGN KEY ([ChapterId])
+                            REFERENCES [Chapters] ([Id]) ON DELETE CASCADE,
+                        CONSTRAINT [FK_SessionDiceRolls_Users_UserId] FOREIGN KEY ([UserId])
+                            REFERENCES [Users] ([Id]) ON DELETE NO ACTION
+                    );
+
+                    CREATE INDEX [IX_SessionDiceRolls_ChapterId] ON [SessionDiceRolls] ([ChapterId]);
+                    CREATE INDEX [IX_SessionDiceRolls_UserId] ON [SessionDiceRolls] ([UserId]);
+                    CREATE INDEX [IX_SessionDiceRolls_DiceType] ON [SessionDiceRolls] ([DiceType]);
+                    CREATE INDEX [IX_SessionDiceRolls_RolledAt] ON [SessionDiceRolls] ([RolledAt]);
+                END
+            ");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF OBJECT_ID(N'[SessionDiceRolls]', N'U') IS NOT NULL DROP TABLE [SessionDiceRolls];
+                IF OBJECT_ID(N'[SessionMessages]', N'U') IS NOT NULL DROP TABLE [SessionMessages];
+                IF OBJECT_ID(N'[RefreshTokens]', N'U') IS NOT NULL DROP TABLE [RefreshTokens];
+            ");
+        }
+    }
+}

--- a/Cdm/Cdm.Web/Components/Pages/Auth/Login.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Auth/Login.razor.cs
@@ -43,7 +43,8 @@ public partial class Login
             {
                 var provider = (CustomAuthStateProvider)AuthProvider;
                 await provider.MarkUserAsAuthenticatedAsync(
-                    response.UserId, response.Email, response.Nickname, response.Token);
+                    response.UserId, response.Email, response.Nickname, response.Token,
+                    response.RefreshToken, response.RefreshTokenExpiry);
 
                 var target = !string.IsNullOrEmpty(ReturnUrl)
                     ? Uri.UnescapeDataString(ReturnUrl)

--- a/Cdm/Cdm.Web/Components/Pages/Characters/CharacterCreate.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/CharacterCreate.razor
@@ -25,13 +25,13 @@
 
             <div class="form-two-col">
                 <div class="form-group">
-                    <label class="form-label">@L["Characters_Name"] *</label>
-                    <InputText @bind-Value="Model.Name" class="form-control" placeholder="Nom de famille..." />
-                    <ValidationMessage For="() => Model.Name" class="form-error" />
+                    <label class="form-label">@L["Characters_FirstName"] *</label>
+                    <InputText @bind-Value="Model.FirstName" class="form-control" placeholder="Prénom..." />
+                    <ValidationMessage For="() => Model.FirstName" class="form-error" />
                 </div>
                 <div class="form-group">
-                    <label class="form-label">@L["Characters_FirstName"]</label>
-                    <InputText @bind-Value="Model.FirstName" class="form-control" placeholder="Prénom..." />
+                    <label class="form-label">@L["Characters_Name"]</label>
+                    <InputText @bind-Value="Model.Name" class="form-control" placeholder="Nom de famille (optionnel)..." />
                 </div>
             </div>
 

--- a/Cdm/Cdm.Web/Components/Pages/Characters/CharacterEdit.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/CharacterEdit.razor
@@ -45,13 +45,13 @@ else
 
                 <div class="form-two-col">
                     <div class="form-group">
-                        <label class="form-label">@L["Characters_Name"] *</label>
-                        <InputText @bind-Value="Model.Name" class="form-control" />
-                        <ValidationMessage For="() => Model.Name" class="form-error" />
+                        <label class="form-label">@L["Characters_FirstName"] *</label>
+                        <InputText @bind-Value="Model.FirstName" class="form-control" />
+                        <ValidationMessage For="() => Model.FirstName" class="form-error" />
                     </div>
                     <div class="form-group">
-                        <label class="form-label">@L["Characters_FirstName"]</label>
-                        <InputText @bind-Value="Model.FirstName" class="form-control" />
+                        <label class="form-label">@L["Characters_Name"]</label>
+                        <InputText @bind-Value="Model.Name" class="form-control" />
                     </div>
                 </div>
 

--- a/Cdm/Cdm.Web/Components/Pages/Characters/Characters.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/Characters.razor
@@ -60,10 +60,10 @@ else
                 </div>
 
                 <h3 class="card-title">
-                    @character.Name
-                    @if (!string.IsNullOrEmpty(character.FirstName))
+                    @character.FirstName
+                    @if (!string.IsNullOrEmpty(character.Name))
                     {
-                        <span style="font-weight: 400;"> @character.FirstName</span>
+                        <span style="font-weight: 400;"> @character.Name</span>
                     }
                 </h3>
 

--- a/Cdm/Cdm.Web/Components/Pages/Characters/Characters.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/Characters.razor.cs
@@ -41,7 +41,9 @@ public partial class Characters
 
     private static string GetInitials(CharacterDto character)
     {
-        var parts = character.Name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var name = !string.IsNullOrEmpty(character.FirstName) ? character.FirstName : character.Name;
+        var parts = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return "?";
         if (parts.Length == 1) return parts[0][0].ToString().ToUpper();
         return $"{parts[0][0]}{parts[^1][0]}".ToUpper();
     }

--- a/Cdm/Cdm.Web/Services/ApiClients/AuthApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ApiClients/AuthApiClient.cs
@@ -9,6 +9,7 @@ public interface IAuthApiClient
 {
     Task<RegisterResponse?> RegisterAsync(RegisterRequest request);
     Task<LoginResponse?> LoginAsync(LoginRequest request);
+    Task<LoginResponse?> RefreshAsync(string refreshToken);
 }
 
 public class AuthApiClient : BaseApiClient, IAuthApiClient
@@ -50,6 +51,22 @@ public class AuthApiClient : BaseApiClient, IAuthApiClient
             this.logger.LogInformation("User logged in successfully: {Email}", response.Email);
         }
         
+        return response;
+    }
+
+    public async Task<LoginResponse?> RefreshAsync(string refreshToken)
+    {
+        this.logger.LogInformation("Attempting to refresh access token");
+
+        var response = await PostAsync<object, LoginResponse>(
+            "/api/auth/refresh",
+            new { RefreshToken = refreshToken });
+
+        if (response != null)
+        {
+            this.logger.LogInformation("Token refreshed successfully for user: {UserId}", response.UserId);
+        }
+
         return response;
     }
 }

--- a/Cdm/Cdm.Web/Services/State/CustomAuthStateProvider.cs
+++ b/Cdm/Cdm.Web/Services/State/CustomAuthStateProvider.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Components.Authorization;
 using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using Cdm.Web.Services.ApiClients;
 using Cdm.Web.Services.Storage;
 
 namespace Cdm.Web.Services.State;
@@ -8,18 +11,28 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
 {
     private readonly ILocalStorageService localStorage;
     private readonly ILogger<CustomAuthStateProvider> logger;
+    private readonly IAuthApiClient authClient;
     
     private const string AuthTokenKey = "auth_token";
     private const string AuthUserIdKey = "auth_user_id";
     private const string AuthUserEmailKey = "auth_user_email";
     private const string AuthUserNicknameKey = "auth_user_nickname";
+    private const string AuthRefreshTokenKey = "auth_refresh_token";
+    private const string AuthRefreshTokenExpiryKey = "auth_refresh_token_expiry";
     
     public CustomAuthStateProvider(
         ILocalStorageService localStorage,
-        ILogger<CustomAuthStateProvider> logger)
+        ILogger<CustomAuthStateProvider> logger,
+        IAuthApiClient authClient)
     {
         this.localStorage = localStorage;
         this.logger = logger;
+        this.authClient = authClient;
+    }
+
+    public void SetAuthClient(IAuthApiClient client)
+    {
+        // kept for backward compat — constructor injection is preferred
     }
     
     public override async Task<AuthenticationState> GetAuthenticationStateAsync()
@@ -30,6 +43,19 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
         {
             this.logger.LogDebug("No authentication token found, user is anonymous");
             return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
+        }
+        
+        // Check if JWT is expired and attempt refresh
+        if (IsJwtExpired(token))
+        {
+            this.logger.LogInformation("JWT is expired, attempting refresh");
+            var refreshed = await TryRefreshTokenAsync();
+            if (!refreshed)
+            {
+                await this.ClearStorageAsync();
+                return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
+            }
+            token = await this.localStorage.GetItemAsync(AuthTokenKey) ?? string.Empty;
         }
         
         try
@@ -66,12 +92,21 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
         }
     }
     
-    public async Task MarkUserAsAuthenticatedAsync(int userId, string email, string nickname, string token)
+    public async Task MarkUserAsAuthenticatedAsync(
+        int userId, string email, string nickname, string token,
+        string? refreshToken = null, DateTime? refreshTokenExpiry = null)
     {
         await this.localStorage.SetItemAsync(AuthTokenKey, token);
         await this.localStorage.SetItemAsync(AuthUserIdKey, userId.ToString());
         await this.localStorage.SetItemAsync(AuthUserEmailKey, email);
         await this.localStorage.SetItemAsync(AuthUserNicknameKey, nickname);
+
+        if (!string.IsNullOrEmpty(refreshToken))
+        {
+            await this.localStorage.SetItemAsync(AuthRefreshTokenKey, refreshToken);
+            await this.localStorage.SetItemAsync(AuthRefreshTokenExpiryKey, 
+                (refreshTokenExpiry ?? DateTime.UtcNow.AddDays(7)).ToString("O"));
+        }
         
         var claims = new List<Claim>
         {
@@ -91,15 +126,81 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
     
     public async Task MarkUserAsLoggedOutAsync()
     {
-        await this.localStorage.RemoveItemAsync(AuthTokenKey);
-        await this.localStorage.RemoveItemAsync(AuthUserIdKey);
-        await this.localStorage.RemoveItemAsync(AuthUserEmailKey);
-        await this.localStorage.RemoveItemAsync(AuthUserNicknameKey);
+        await this.ClearStorageAsync();
         
         var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
         NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(anonymous)));
         
         this.logger.LogInformation("User logged out");
+    }
+
+    private async Task<bool> TryRefreshTokenAsync()
+    {
+        try
+        {
+            var refreshToken = await this.localStorage.GetItemAsync(AuthRefreshTokenKey);
+            if (string.IsNullOrEmpty(refreshToken)) return false;
+
+            var response = await this.authClient.RefreshAsync(refreshToken);
+            if (response == null || string.IsNullOrEmpty(response.Token)) return false;
+
+            await this.MarkUserAsAuthenticatedAsync(
+                response.UserId, response.Email, response.Nickname, response.Token,
+                response.RefreshToken, response.RefreshTokenExpiry);
+
+            this.logger.LogInformation("Token refreshed successfully for user {UserId}", response.UserId);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogWarning(ex, "Token refresh failed");
+            return false;
+        }
+    }
+
+    private async Task ClearStorageAsync()
+    {
+        await this.localStorage.RemoveItemAsync(AuthTokenKey);
+        await this.localStorage.RemoveItemAsync(AuthUserIdKey);
+        await this.localStorage.RemoveItemAsync(AuthUserEmailKey);
+        await this.localStorage.RemoveItemAsync(AuthUserNicknameKey);
+        await this.localStorage.RemoveItemAsync(AuthRefreshTokenKey);
+        await this.localStorage.RemoveItemAsync(AuthRefreshTokenExpiryKey);
+    }
+
+    private static bool IsJwtExpired(string token)
+    {
+        try
+        {
+            var parts = token.Split('.');
+            if (parts.Length != 3) return true;
+
+            var payload = parts[1];
+            // Pad base64url to valid base64
+            payload = payload.Replace('-', '+').Replace('_', '/');
+            switch (payload.Length % 4)
+            {
+                case 2: payload += "=="; break;
+                case 3: payload += "="; break;
+            }
+
+            var jsonBytes = Convert.FromBase64String(payload);
+            var json = Encoding.UTF8.GetString(jsonBytes);
+            var doc = JsonDocument.Parse(json);
+
+            if (doc.RootElement.TryGetProperty("exp", out var expElement))
+            {
+                var exp = expElement.GetInt64();
+                var expiry = DateTimeOffset.FromUnixTimeSeconds(exp).UtcDateTime;
+                return expiry <= DateTime.UtcNow.AddSeconds(30); // 30s buffer
+            }
+
+            return true;
+        }
+        catch
+        {
+            return true;
+        }
     }
 }
 

--- a/Cdm/Cdm.Web/Shared/DTOs/Models/CharacterModels.cs
+++ b/Cdm/Cdm.Web/Shared/DTOs/Models/CharacterModels.cs
@@ -61,17 +61,17 @@ public class CharacterDto
 public class CreateCharacterDto
 {
     /// <summary>
-    /// Gets or sets the character's name (required)
+    /// Gets or sets the character's first name (required)
     /// </summary>
-    [Required(ErrorMessage = "Le nom est requis")]
-    [MaxLength(100, ErrorMessage = "Le nom ne peut pas dépasser 100 caractères")]
-    public string Name { get; set; } = string.Empty;
+    [Required(ErrorMessage = "Le prénom est requis")]
+    [MaxLength(100, ErrorMessage = "Le prénom ne peut pas dépasser 100 caractères")]
+    public string FirstName { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the character's first name
+    /// Gets or sets the character's last name
     /// </summary>
-    [MaxLength(100, ErrorMessage = "Le prénom ne peut pas dépasser 100 caractères")]
-    public string? FirstName { get; set; }
+    [MaxLength(100, ErrorMessage = "Le nom ne peut pas dépasser 100 caractères")]
+    public string? Name { get; set; }
 
     /// <summary>
     /// Gets or sets the character's description
@@ -99,17 +99,17 @@ public class CreateCharacterDto
 public class UpdateCharacterDto
 {
     /// <summary>
-    /// Gets or sets the character's name
+    /// Gets or sets the character's first name (required)
     /// </summary>
-    [Required(ErrorMessage = "Le nom est requis")]
-    [MaxLength(100, ErrorMessage = "Le nom ne peut pas dépasser 100 caractères")]
-    public string Name { get; set; } = string.Empty;
+    [Required(ErrorMessage = "Le prénom est requis")]
+    [MaxLength(100, ErrorMessage = "Le prénom ne peut pas dépasser 100 caractères")]
+    public string FirstName { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the character's first name
+    /// Gets or sets the character's last name
     /// </summary>
-    [MaxLength(100, ErrorMessage = "Le prénom ne peut pas dépasser 100 caractères")]
-    public string? FirstName { get; set; }
+    [MaxLength(100, ErrorMessage = "Le nom ne peut pas dépasser 100 caractères")]
+    public string? Name { get; set; }
 
     /// <summary>
     /// Gets or sets the character's description

--- a/Cdm/Cdm.Web/Shared/DTOs/ViewModels/LoginResponse.cs
+++ b/Cdm/Cdm.Web/Shared/DTOs/ViewModels/LoginResponse.cs
@@ -26,6 +26,16 @@ public class LoginResponse
     public string Token { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the refresh token for renewing the JWT.
+    /// </summary>
+    public string RefreshToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets when the refresh token expires.
+    /// </summary>
+    public DateTime RefreshTokenExpiry { get; set; }
+
+    /// <summary>
     /// Gets or sets the success message.
     /// </summary>
     public string Message { get; set; } = string.Empty;

--- a/Cdm/Cdm.Web/wwwroot/css/components/components.css
+++ b/Cdm/Cdm.Web/wwwroot/css/components/components.css
@@ -1899,6 +1899,7 @@ textarea.form-control {
 .participant-name {
   font-size: var(--font-size-sm);
   font-weight: 600;
+  color: var(--color-text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
- Add refresh token support to the authentication flow, reducing JWT lifespan to 1 hour.
- Implement automatic token renewal in the Blazor frontend via CustomAuthStateProvider.
- Persist session chat messages and dice rolls to the database to preserve history.
- Refactor character name logic to prioritize First Name over Name.
- Update database schema with new tables for RefreshTokens, SessionMessages, and SessionDiceRolls.