### PR TITLE
fix: resolve CI failures - NuGet vulnerabilities + EF Core version co…

### DIFF
--- a/Cdm/Cdm.Business.Common.Tests/Cdm.Business.Common.Tests.csproj
+++ b/Cdm/Cdm.Business.Common.Tests/Cdm.Business.Common.Tests.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="3.0.0" />

--- a/Cdm/Cdm.ServiceDefaults/Cdm.ServiceDefaults.csproj
+++ b/Cdm/Cdm.ServiceDefaults/Cdm.ServiceDefaults.csproj
@@ -12,11 +12,11 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.2.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.2.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/Cdm/Directory.Build.props
+++ b/Cdm/Directory.Build.props
@@ -1,0 +1,22 @@
+<Project>
+  <!--
+    Global transitive dependency version overrides.
+    These pin vulnerable/conflicting transitive packages to their patched versions.
+    See: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning
+  -->
+  <ItemGroup>
+    <!-- OpenTelemetry.Api 1.12/1.14 → patched in 1.16.0 (GHSA-g94r-2vxg-569j) -->
+    <PackageReference Include="OpenTelemetry.Api" Version="1.16.0" />
+    <!-- MessagePack 2.5.192 → patched in 2.5.302 (GHSA-hv8m-jj95-wg3x et al.) -->
+    <PackageReference Include="MessagePack" Version="2.5.302" />
+    <!-- Microsoft.OpenApi 2.0.0 → patched in 2.8.0 (GHSA-v5pm-xwqc-g5wc) -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.8.0" />
+    <!--
+      Aspire.Microsoft.EntityFrameworkCore.SqlServer 13.1.3 brings EFCore.Relational 10.0.1
+      which conflicts with the explicit 10.0.5 used by Cdm.Data.Common.
+      Pin to 10.0.5 to resolve MSB3277.
+    -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
…nflict

- Add Cdm/Directory.Build.props to pin transitive deps globally:
  * OpenTelemetry.Api 1.16.0 (GHSA-g94r-2vxg-569j)
  * MessagePack 2.5.302 (GHSA-hv8m-jj95-wg3x)
  * Microsoft.OpenApi 2.8.0 (GHSA-v5pm-xwqc-g5wc)
  * EFCore.Relational + SqlServer 10.0.5 (fixes MSB3277)
- Update Cdm.ServiceDefaults OpenTelemetry 1.12 -> 1.16.0
- Update Cdm.Business.Common.Tests EFCore.InMemory 9.0.10 -> 10.0.5
- Build: 0 warnings, 0 errors with /warnaserror