### PR TITLE
fix: resolve remaining CI build errors (CS8601, CS8604, ASPDEPR002)

### DIFF
--- a/Cdm/Cdm.ApiService/Cdm.ApiService.csproj
+++ b/Cdm/Cdm.ApiService/Cdm.ApiService.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- WithOpenApi() is deprecated in ASP.NET Core 10 (ASPDEPR002) but still functional.
+         Migration to the new implicit OpenAPI generation is tracked separately. -->
+    <NoWarn>ASPDEPR002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cdm/Cdm.Business.Common/Services/CampaignService.cs
+++ b/Cdm/Cdm.Business.Common/Services/CampaignService.cs
@@ -98,7 +98,7 @@ public class CampaignService(
                 if (coverImageUrl != null)
                 {
                     var actualImageUrl = await this.imageStorageService.UploadCampaignCoverAsync(
-                        dto.CoverImageBase64,
+                        dto.CoverImageBase64!,
                         campaign.Id);
 
                     if (actualImageUrl != null)

--- a/Cdm/Cdm.Web/Components/Pages/Characters/CharacterEdit.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/CharacterEdit.razor.cs
@@ -37,7 +37,7 @@ public partial class CharacterEdit
             Model = new UpdateCharacterDto
             {
                 Name = Character.Name,
-                FirstName = Character.FirstName,
+                FirstName = Character.FirstName ?? string.Empty,
                 Description = Character.Description,
                 Age = Character.Age,
                 AvatarUrl = Character.AvatarUrl


### PR DESCRIPTION
- CharacterEdit.razor.cs: FirstName nullable -> non-nullable with ?? string.Empty (CS8601)
- CampaignService.cs: CoverImageBase64 null-forgiving in upload rename path (CS8604)
- Cdm.ApiService.csproj: suppress ASPDEPR002 for WithOpenApi() deprecation