### PR TITLE
feat(session): recharge l'historique chat/dés à l'ouverture d'une ses…

### DIFF
--- a/Cdm/Cdm.ApiService/Endpoints/SessionEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/SessionEndpoints.cs
@@ -68,6 +68,11 @@ public static class SessionEndpoints
         group.MapPut("/{id:int}/leave", LeaveSessionAsync)
             .WithName("LeaveSession")
             .WithOpenApi();
+
+        // GET /api/sessions/{id}/history - Get persisted chat & dice history
+        group.MapGet("/{id:int}/history", GetSessionHistoryAsync)
+            .WithName("GetSessionHistory")
+            .WithOpenApi();
     }
 
     private static async Task<IResult> StartSessionAsync(
@@ -254,6 +259,29 @@ public static class SessionEndpoints
         catch (Exception ex)
         {
             logger.LogError(ex, "Error leaving session {SessionId}", id);
+            return Results.Problem(statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    private static async Task<IResult> GetSessionHistoryAsync(
+        int id,
+        [FromServices] ISessionService sessionService,
+        ILogger<SessionEndpointsLogger> logger,
+        HttpContext httpContext)
+    {
+        try
+        {
+            var userId = GetUserId(httpContext);
+            if (userId == null) return Results.Unauthorized();
+
+            var history = await sessionService.GetSessionHistoryAsync(id, userId.Value);
+            if (history == null) return Results.NotFound();
+
+            return Results.Ok(history);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error retrieving history for session {SessionId}", id);
             return Results.Problem(statusCode: StatusCodes.Status500InternalServerError);
         }
     }

--- a/Cdm/Cdm.Business.Abstraction/DTOs/SessionHistoryDto.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/SessionHistoryDto.cs
@@ -1,0 +1,74 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionHistoryDto.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.DTOs;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// DTO carrying the persisted chat and dice history of a session,
+/// so a client reopening a session can rebuild its timeline.
+/// </summary>
+public class SessionHistoryDto
+{
+    /// <summary>Gets or sets the chat messages, ordered chronologically.</summary>
+    public List<SessionMessageDto> Messages { get; set; } = [];
+
+    /// <summary>Gets or sets the dice rolls, ordered chronologically.</summary>
+    public List<SessionDiceRollDto> DiceRolls { get; set; } = [];
+}
+
+/// <summary>
+/// DTO representing a persisted chat message.
+/// </summary>
+public class SessionMessageDto
+{
+    /// <summary>Gets or sets the sender user ID.</summary>
+    public int UserId { get; set; }
+
+    /// <summary>Gets or sets the sender display name at the time of sending.</summary>
+    public string UserName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the message content.</summary>
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets when the message was sent (UTC).</summary>
+    public DateTime SentAt { get; set; }
+}
+
+/// <summary>
+/// DTO representing a persisted dice roll.
+/// </summary>
+public class SessionDiceRollDto
+{
+    /// <summary>Gets or sets the roller user ID.</summary>
+    public int UserId { get; set; }
+
+    /// <summary>Gets or sets the roller display name at the time of rolling.</summary>
+    public string UserName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the dice type (e.g. "D20").</summary>
+    public string DiceType { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the number of dice rolled.</summary>
+    public int Count { get; set; }
+
+    /// <summary>Gets or sets the individual die results.</summary>
+    public int[] Results { get; set; } = [];
+
+    /// <summary>Gets or sets the modifier applied to the roll.</summary>
+    public int Modifier { get; set; }
+
+    /// <summary>Gets or sets the total (sum of results + modifier).</summary>
+    public int Total { get; set; }
+
+    /// <summary>Gets or sets the optional reason for the roll.</summary>
+    public string? Reason { get; set; }
+
+    /// <summary>Gets or sets when the roll occurred (UTC).</summary>
+    public DateTime RolledAt { get; set; }
+}

--- a/Cdm/Cdm.Business.Abstraction/Services/ISessionService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/ISessionService.cs
@@ -79,4 +79,13 @@ public interface ISessionService
     /// <param name="userId">The player user identifier.</param>
     /// <returns>True if successful, false otherwise.</returns>
     Task<bool> LeaveSessionAsync(int sessionId, int userId);
+
+    /// <summary>
+    /// Gets the persisted chat and dice history of a session so a reopened
+    /// session can rebuild its timeline. Only the GM or a participant can access it.
+    /// </summary>
+    /// <param name="sessionId">The session identifier.</param>
+    /// <param name="userId">The requesting user identifier.</param>
+    /// <returns>The session history, or null if not found/unauthorized.</returns>
+    Task<SessionHistoryDto?> GetSessionHistoryAsync(int sessionId, int userId);
 }

--- a/Cdm/Cdm.Business.Common.Tests/Services/SessionServiceHistoryTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/SessionServiceHistoryTests.cs
@@ -1,0 +1,119 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionServiceHistoryTests.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Tests.Services;
+
+using Cdm.Business.Abstraction.Services;
+using Cdm.Business.Common.Services;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="SessionService.GetSessionHistoryAsync"/>.
+/// </summary>
+public class SessionServiceHistoryTests
+{
+    private readonly Mock<ILogger<SessionService>> loggerMock = new();
+    private readonly Mock<INotificationService> notificationServiceMock = new();
+
+    private static DbContextOptions<AppDbContext> NewOptions(string name) =>
+        new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: name)
+            .Options;
+
+    private SessionService CreateService(AppDbContext context) =>
+        new(context, this.loggerMock.Object, this.notificationServiceMock.Object);
+
+    /// <summary>
+    /// The GM of a session gets its chat and dice history, merged and ordered chronologically,
+    /// with the comma-separated die results parsed back into integers.
+    /// </summary>
+    [Fact]
+    public async Task GetSessionHistoryAsync_AsGameMaster_ReturnsOrderedHistory()
+    {
+        // Arrange
+        using var context = new AppDbContext(NewOptions(nameof(GetSessionHistoryAsync_AsGameMaster_ReturnsOrderedHistory)));
+
+        const int gmUserId = 1;
+        var baseTime = new DateTime(2026, 07, 19, 10, 0, 0, DateTimeKind.Utc);
+
+        context.Sessions.Add(new Session { Id = 10, CampaignId = 5, StartedById = gmUserId, StartedAt = baseTime });
+        context.SessionMessages.Add(new SessionMessage
+        {
+            SessionId = 10, UserId = gmUserId, UserName = "MJ", Message = "Bienvenue", SentAt = baseTime.AddMinutes(1)
+        });
+        context.SessionDiceRolls.Add(new SessionDiceRoll
+        {
+            SessionId = 10, UserId = gmUserId, UserName = "MJ", DiceType = "D20", Count = 1,
+            Results = "18", Modifier = 2, Total = 20, RolledAt = baseTime.AddMinutes(2)
+        });
+        context.SessionMessages.Add(new SessionMessage
+        {
+            SessionId = 10, UserId = gmUserId, UserName = "MJ", Message = "À toi de jouer", SentAt = baseTime.AddMinutes(3)
+        });
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        // Act
+        var history = await service.GetSessionHistoryAsync(10, gmUserId);
+
+        // Assert
+        Assert.NotNull(history);
+        Assert.Equal(2, history!.Messages.Count);
+        Assert.Single(history.DiceRolls);
+        Assert.Equal("Bienvenue", history.Messages[0].Message);
+        Assert.Equal("À toi de jouer", history.Messages[1].Message);
+        Assert.Equal(new[] { 18 }, history.DiceRolls[0].Results);
+        Assert.Equal(20, history.DiceRolls[0].Total);
+    }
+
+    /// <summary>
+    /// A user who is neither the GM nor a participant is denied the history (null).
+    /// </summary>
+    [Fact]
+    public async Task GetSessionHistoryAsync_UnauthorizedUser_ReturnsNull()
+    {
+        // Arrange
+        using var context = new AppDbContext(NewOptions(nameof(GetSessionHistoryAsync_UnauthorizedUser_ReturnsNull)));
+
+        context.Sessions.Add(new Session { Id = 20, CampaignId = 5, StartedById = 1, StartedAt = DateTime.UtcNow });
+        context.SessionMessages.Add(new SessionMessage
+        {
+            SessionId = 20, UserId = 1, UserName = "MJ", Message = "Secret", SentAt = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        // Act — user 99 is neither GM nor participant
+        var history = await service.GetSessionHistoryAsync(20, 99);
+
+        // Assert
+        Assert.Null(history);
+    }
+
+    /// <summary>
+    /// A history request for a session that does not exist returns null rather than throwing.
+    /// </summary>
+    [Fact]
+    public async Task GetSessionHistoryAsync_MissingSession_ReturnsNull()
+    {
+        // Arrange
+        using var context = new AppDbContext(NewOptions(nameof(GetSessionHistoryAsync_MissingSession_ReturnsNull)));
+        var service = this.CreateService(context);
+
+        // Act
+        var history = await service.GetSessionHistoryAsync(999, 1);
+
+        // Assert
+        Assert.Null(history);
+    }
+}

--- a/Cdm/Cdm.Business.Common/Services/SessionService.cs
+++ b/Cdm/Cdm.Business.Common/Services/SessionService.cs
@@ -352,6 +352,100 @@ public class SessionService(AppDbContext dbContext, ILogger<SessionService> logg
         }
     }
 
+    /// <inheritdoc/>
+    public async Task<SessionHistoryDto?> GetSessionHistoryAsync(int sessionId, int userId)
+    {
+        try
+        {
+            // Authorize: GM of the session or a participant who owns a character in it.
+            var session = await this.dbContext.Sessions
+                .AsNoTracking()
+                .FirstOrDefaultAsync(s => s.Id == sessionId);
+
+            if (session == null)
+            {
+                return null;
+            }
+
+            var isGm = session.StartedById == userId;
+            var isParticipant = await this.dbContext.SessionParticipants
+                .AsNoTracking()
+                .AnyAsync(p => p.SessionId == sessionId && p.WorldCharacter.Character.UserId == userId);
+
+            if (!isGm && !isParticipant)
+            {
+                return null;
+            }
+
+            // Cap the payload: keep the most recent entries, then present them chronologically.
+            const int MaxEntries = 500;
+
+            var messages = await this.dbContext.SessionMessages
+                .AsNoTracking()
+                .Where(m => m.SessionId == sessionId)
+                .OrderByDescending(m => m.SentAt)
+                .Take(MaxEntries)
+                .ToListAsync();
+
+            var diceRolls = await this.dbContext.SessionDiceRolls
+                .AsNoTracking()
+                .Where(d => d.SessionId == sessionId)
+                .OrderByDescending(d => d.RolledAt)
+                .Take(MaxEntries)
+                .ToListAsync();
+
+            return new SessionHistoryDto
+            {
+                Messages = messages
+                    .OrderBy(m => m.SentAt)
+                    .Select(m => new SessionMessageDto
+                    {
+                        UserId = m.UserId,
+                        UserName = m.UserName,
+                        Message = m.Message,
+                        SentAt = m.SentAt
+                    })
+                    .ToList(),
+                DiceRolls = diceRolls
+                    .OrderBy(d => d.RolledAt)
+                    .Select(d => new SessionDiceRollDto
+                    {
+                        UserId = d.UserId,
+                        UserName = d.UserName,
+                        DiceType = d.DiceType,
+                        Count = d.Count,
+                        Results = ParseResults(d.Results),
+                        Modifier = d.Modifier,
+                        Total = d.Total,
+                        Reason = d.Reason,
+                        RolledAt = d.RolledAt
+                    })
+                    .ToList()
+            };
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error retrieving history for session {SessionId}", sessionId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses the comma-separated die results into an integer array, tolerating malformed entries.
+    /// </summary>
+    private static int[] ParseResults(string? results)
+    {
+        if (string.IsNullOrWhiteSpace(results))
+        {
+            return [];
+        }
+
+        return results
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(part => int.TryParse(part, out var value) ? value : 0)
+            .ToArray();
+    }
+
     private async Task<SessionDto?> BuildSessionDtoAsync(int sessionId)
     {
         var session = await this.dbContext.Sessions

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor.cs
@@ -99,7 +99,25 @@ public partial class SessionGm : IAsyncDisposable
         NavContext.ClearContext();
         IsLoading = false;
 
+        // Rebuild the timeline from persisted history BEFORE connecting to the hub,
+        // so live events only ever append to an already-complete history (no duplicates).
+        await LoadHistoryAsync();
+
         await ConnectToHubAsync();
+    }
+
+    private async Task LoadHistoryAsync()
+    {
+        var history = await SessionClient.GetSessionHistoryAsync(SessionId);
+        if (history == null) return;
+
+        var entries = new List<ChatEntry>(history.Messages.Count + history.DiceRolls.Count);
+        foreach (var m in history.Messages)
+            entries.Add(new ChatEntry("text", m.UserName, m.Message, null, null, m.SentAt));
+        foreach (var d in history.DiceRolls)
+            entries.Add(new ChatEntry("dice", d.UserName, null, d.DiceType, d.Results, d.RolledAt));
+
+        ChatEntries = entries.OrderBy(e => e.Timestamp).ToList();
     }
 
     private async Task ConnectToHubAsync()

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor.cs
@@ -103,7 +103,25 @@ public partial class SessionPlayer : IAsyncDisposable
 
         ActiveCombat = await CombatClient.GetActiveCombatForSessionAsync(SessionId);
 
+        // Rebuild the timeline from persisted history BEFORE connecting to the hub,
+        // so live events only ever append to an already-complete history (no duplicates).
+        await LoadHistoryAsync();
+
         await ConnectToHubAsync();
+    }
+
+    private async Task LoadHistoryAsync()
+    {
+        var history = await SessionClient.GetSessionHistoryAsync(SessionId);
+        if (history == null) return;
+
+        var entries = new List<ChatEntry>(history.Messages.Count + history.DiceRolls.Count);
+        foreach (var m in history.Messages)
+            entries.Add(new ChatEntry("text", m.UserName, m.Message, null, null, m.SentAt));
+        foreach (var d in history.DiceRolls)
+            entries.Add(new ChatEntry("dice", d.UserName, null, d.DiceType, d.Results, d.RolledAt));
+
+        ChatEntries = entries.OrderBy(e => e.Timestamp).ToList();
     }
 
     private async Task ConnectToHubAsync()

--- a/Cdm/Cdm.Web/Services/ApiClients/SessionApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ApiClients/SessionApiClient.cs
@@ -162,6 +162,23 @@ public class SessionApiClient
         }
     }
 
+    /// <summary>Get the persisted chat &amp; dice history of a session.</summary>
+    public async Task<SessionHistoryDto?> GetSessionHistoryAsync(int sessionId)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await _httpClient.GetAsync($"api/sessions/{sessionId}/history");
+            if (!response.IsSuccessStatusCode) return null;
+            return await response.Content.ReadFromJsonAsync<SessionHistoryDto>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching history for session {SessionId}", sessionId);
+            return null;
+        }
+    }
+
     /// <summary>Returns the API base URL for constructing hub URLs.</summary>
     public string GetApiBaseUrl() => _httpClient.BaseAddress?.ToString().TrimEnd('/') ?? string.Empty;
 }


### PR DESCRIPTION
…sion

Les messages et jets de dés étaient persistés mais jamais relus : le chat repartait vide à chaque connexion. Ajoute la relecture de l'historique.

- SessionHistoryDto (messages + dés) et GetSessionHistoryAsync côté service, avec autorisation (MJ ou participant) et plafond de 500 entrées par type.
- Endpoint GET /api/sessions/{id}/history + méthode SessionApiClient.
- Pages joueur et MJ : reconstruction de la timeline AVANT connexion au hub, triée chronologiquement (les événements live ne font qu'ajouter → pas de doublon).
- Tests unitaires du service (MJ autorisé + tri, accès refusé, session absente).

Note : le projet Cdm.Business.Common.Tests ne compile pas (dérive de signatures préexistante, hors solution/CI) — à réparer dans une branche dédiée (dette #1).