### PR TITLE
fix(tests): répare la suite de tests unitaires et la branche dans la CI

### DIFF
--- a/Cdm/Cdm.Business.Common.Tests/Cdm.Business.Common.Tests.csproj
+++ b/Cdm/Cdm.Business.Common.Tests/Cdm.Business.Common.Tests.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+    <!-- xUnit1051 (pass TestContext.Current.CancellationToken) is a style suggestion irrelevant
+         to these fast in-memory tests; suppress so the solution's /warnaserror build stays green. -->
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
 
     <!-- To enable Microsoft.Testing.Platform, uncomment the following line. -->
     <!-- <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner> -->

--- a/Cdm/Cdm.Business.Common.Tests/Services/AchievementServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/AchievementServiceTests.cs
@@ -7,6 +7,7 @@
 namespace Cdm.Business.Common.Tests.Services;
 
 using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.Services;
 using Cdm.Business.Common.Services;
 using Cdm.Common.Enums;
 using Cdm.Data.Common;
@@ -22,10 +23,12 @@ using Xunit;
 public class AchievementServiceTests
 {
     private readonly Mock<ILogger<AchievementService>> loggerMock;
+    private readonly Mock<INotificationService> notificationServiceMock;
 
     public AchievementServiceTests()
     {
         this.loggerMock = new Mock<ILogger<AchievementService>>();
+        this.notificationServiceMock = new Mock<INotificationService>();
     }
 
     [Fact]
@@ -45,7 +48,7 @@ public class AchievementServiceTests
         context.Worlds.Add(world);
         await context.SaveChangesAsync();
 
-        var service = new AchievementService(context, this.loggerMock.Object);
+        var service = new AchievementService(context, this.notificationServiceMock.Object, this.loggerMock.Object);
 
         var createDto = new CreateAchievementDto
         {
@@ -99,7 +102,7 @@ public class AchievementServiceTests
         context.Achievements.Add(achievement);
         await context.SaveChangesAsync();
 
-        var service = new AchievementService(context, this.loggerMock.Object);
+        var service = new AchievementService(context, this.notificationServiceMock.Object, this.loggerMock.Object);
 
         // Act
         var result = await service.AwardAchievementAsync(1, 2, 1, "Well done!");
@@ -108,7 +111,7 @@ public class AchievementServiceTests
         Assert.NotNull(result);
         Assert.Equal(1, result!.AchievementId);
         Assert.Equal(2, result.UserId);
-        Assert.Equal("Well done!", result.Message);
+        Assert.Equal("Well done!", result.AwardMessage);
     }
 
     [Fact]
@@ -159,7 +162,7 @@ public class AchievementServiceTests
         );
         await context.SaveChangesAsync();
 
-        var service = new AchievementService(context, this.loggerMock.Object);
+        var service = new AchievementService(context, this.notificationServiceMock.Object, this.loggerMock.Object);
 
         // Act
         var result = await service.GetUserAchievementsAsync(1);
@@ -210,7 +213,7 @@ public class AchievementServiceTests
         context.UserAchievements.Add(userAchievement);
         await context.SaveChangesAsync();
 
-        var service = new AchievementService(context, this.loggerMock.Object);
+        var service = new AchievementService(context, this.notificationServiceMock.Object, this.loggerMock.Object);
 
         // Act
         var result = await service.RevokeAchievementAsync(1, 1);
@@ -245,7 +248,7 @@ public class AchievementServiceTests
         );
         await context.SaveChangesAsync();
 
-        var service = new AchievementService(context, this.loggerMock.Object);
+        var service = new AchievementService(context, this.notificationServiceMock.Object, this.loggerMock.Object);
 
         // Act
         var result = await service.GetAchievementsByWorldAsync(1, 1);

--- a/Cdm/Cdm.Business.Common.Tests/Services/CampaignServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/CampaignServiceTests.cs
@@ -7,6 +7,7 @@
 namespace Cdm.Business.Common.Tests.Services;
 
 using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.Services;
 using Cdm.Business.Common.Services;
 using Cdm.Common.Enums;
 using Cdm.Common.Services;
@@ -23,6 +24,7 @@ using Xunit;
 public class CampaignServiceTests
 {
     private readonly Mock<IImageStorageService> imageStorageServiceMock;
+    private readonly Mock<INotificationService> notificationServiceMock;
     private readonly Mock<ILogger<CampaignService>> loggerMock;
 
     /// <summary>
@@ -31,7 +33,18 @@ public class CampaignServiceTests
     public CampaignServiceTests()
     {
         this.imageStorageServiceMock = new Mock<IImageStorageService>();
+        this.notificationServiceMock = new Mock<INotificationService>();
         this.loggerMock = new Mock<ILogger<CampaignService>>();
+    }
+
+    private CampaignService CreateService(AppDbContext context) =>
+        new(context, this.imageStorageServiceMock.Object, this.notificationServiceMock.Object, this.loggerMock.Object);
+
+    private static World SeedWorld(AppDbContext context, int id = 1, int ownerId = 1, GameType gameType = GameType.DnD5e)
+    {
+        var world = new World { Id = id, Name = $"World {id}", GameType = gameType, UserId = ownerId, CreatedAt = DateTime.UtcNow };
+        context.Worlds.Add(world);
+        return world;
     }
 
     /// <summary>
@@ -48,7 +61,6 @@ public class CampaignServiceTests
 
         using var context = new AppDbContext(options);
 
-        // Add a test user
         var testUser = new User
         {
             Id = 1,
@@ -58,15 +70,16 @@ public class CampaignServiceTests
             CreatedAt = DateTime.UtcNow,
         };
         context.Users.Add(testUser);
+        SeedWorld(context);
         await context.SaveChangesAsync();
 
-        var service = new CampaignService(context, this.imageStorageServiceMock.Object, this.loggerMock.Object);
+        var service = this.CreateService(context);
 
         var createDto = new CreateCampaignDto
         {
             Name = "Test Campaign",
             Description = "A test campaign description",
-            GameType = GameType.DnD5e,
+            WorldId = 1,
             Visibility = Visibility.Private,
             MaxPlayers = 5,
         };
@@ -78,7 +91,6 @@ public class CampaignServiceTests
         Assert.NotNull(result);
         Assert.Equal("Test Campaign", result!.Name);
         Assert.Equal("A test campaign description", result.Description);
-        Assert.Equal(GameType.DnD5e, result.GameType);
         Assert.Equal(Visibility.Private, result.Visibility);
         Assert.Equal(5, result.MaxPlayers);
         Assert.Equal(1, result.CreatedBy);
@@ -112,6 +124,7 @@ public class CampaignServiceTests
             CreatedAt = DateTime.UtcNow,
         };
         context.Users.Add(testUser);
+        SeedWorld(context);
         await context.SaveChangesAsync();
 
         // Setup mock to return a valid image URL
@@ -119,12 +132,12 @@ public class CampaignServiceTests
             .Setup(x => x.UploadCampaignCoverAsync(It.IsAny<string>(), It.IsAny<int>()))
             .ReturnsAsync("/uploads/campaigns/test-image.jpg");
 
-        var service = new CampaignService(context, this.imageStorageServiceMock.Object, this.loggerMock.Object);
+        var service = this.CreateService(context);
 
         var createDto = new CreateCampaignDto
         {
             Name = "Campaign With Image",
-            GameType = GameType.Generic,
+            WorldId = 1,
             CoverImageBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==", // 1x1 transparent PNG
         };
 
@@ -159,12 +172,13 @@ public class CampaignServiceTests
         var user1 = new User { Id = 1, Email = "user1@test.com", Nickname = "User1", PasswordHash = "hash", CreatedAt = DateTime.UtcNow };
         var user2 = new User { Id = 2, Email = "user2@test.com", Nickname = "User2", PasswordHash = "hash", CreatedAt = DateTime.UtcNow };
         context.Users.AddRange(user1, user2);
+        SeedWorld(context);
 
         // Add campaigns for different users
         var campaign1 = new Campaign
         {
             Name = "User1 Campaign 1",
-            GameType = GameType.Generic,
+            WorldId = 1,
             Visibility = Visibility.Private,
             MaxPlayers = 6,
             CreatedBy = 1,
@@ -176,7 +190,7 @@ public class CampaignServiceTests
         var campaign2 = new Campaign
         {
             Name = "User1 Campaign 2",
-            GameType = GameType.DnD5e,
+            WorldId = 1,
             Visibility = Visibility.Public,
             MaxPlayers = 4,
             CreatedBy = 1,
@@ -188,7 +202,7 @@ public class CampaignServiceTests
         var campaign3 = new Campaign
         {
             Name = "User2 Campaign",
-            GameType = GameType.Pathfinder,
+            WorldId = 1,
             Visibility = Visibility.Private,
             MaxPlayers = 8,
             CreatedBy = 2,
@@ -200,7 +214,7 @@ public class CampaignServiceTests
         context.Campaigns.AddRange(campaign1, campaign2, campaign3);
         await context.SaveChangesAsync();
 
-        var service = new CampaignService(context, this.imageStorageServiceMock.Object, this.loggerMock.Object);
+        var service = this.CreateService(context);
 
         // Act
         var result = await service.GetMyCampaignsAsync(1);
@@ -209,6 +223,7 @@ public class CampaignServiceTests
         var campaigns = result.ToList();
         Assert.Equal(2, campaigns.Count);
         Assert.All(campaigns, c => Assert.Equal(1, c.CreatedBy));
+        Assert.All(campaigns, c => Assert.Equal(GameType.DnD5e, c.GameType));
         Assert.Contains(campaigns, c => c.Name == "User1 Campaign 1");
         Assert.Contains(campaigns, c => c.Name == "User1 Campaign 2");
     }
@@ -230,12 +245,13 @@ public class CampaignServiceTests
         var user1 = new User { Id = 1, Email = "user1@test.com", Nickname = "User1", PasswordHash = "hash", CreatedAt = DateTime.UtcNow };
         var user2 = new User { Id = 2, Email = "user2@test.com", Nickname = "User2", PasswordHash = "hash", CreatedAt = DateTime.UtcNow };
         context.Users.AddRange(user1, user2);
+        SeedWorld(context);
 
         var campaign = new Campaign
         {
             Id = 1,
             Name = "Private Campaign",
-            GameType = GameType.Generic,
+            WorldId = 1,
             Visibility = Visibility.Private,
             MaxPlayers = 6,
             CreatedBy = 1,
@@ -247,7 +263,7 @@ public class CampaignServiceTests
         context.Campaigns.Add(campaign);
         await context.SaveChangesAsync();
 
-        var service = new CampaignService(context, this.imageStorageServiceMock.Object, this.loggerMock.Object);
+        var service = this.CreateService(context);
 
         // Act - authorized user (campaign creator)
         var authorizedResult = await service.GetCampaignByIdAsync(1, 1);

--- a/Cdm/Cdm.Business.Common.Tests/Services/EventServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/EventServiceTests.cs
@@ -223,6 +223,7 @@ public class EventServiceTests
         // Assert
         Assert.True(result);
         var deletedEvent = await context.Events.FindAsync(1);
-        Assert.Null(deletedEvent); // Hard delete in EventService
+        Assert.NotNull(deletedEvent); // Soft delete in EventService
+        Assert.False(deletedEvent!.IsActive);
     }
 }

--- a/Cdm/Cdm.Business.Common.Tests/Services/JwtServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/JwtServiceTests.cs
@@ -32,10 +32,13 @@ public class JwtServiceTests
         this.mockConfiguration = new Mock<IConfiguration>();
         this.mockLogger = new Mock<ILogger<JwtService>>();
 
-        // Configure mock to return a valid JWT secret key
-        var mockJwtSection = new Mock<IConfigurationSection>();
-        mockJwtSection.Setup(x => x.Value).Returns("ThisIsAVerySecureSecretKeyForJwtTokenGeneration123456");
-        this.mockConfiguration.Setup(x => x.GetSection("Jwt:SecretKey")).Returns(mockJwtSection.Object);
+        // JwtService reads the key via the IConfiguration indexer (configuration["Jwt:SecretKey"]).
+        this.mockConfiguration.Setup(x => x["Jwt:SecretKey"]).Returns("ThisIsAVerySecureSecretKeyForJwtTokenGeneration123456");
+
+        // By default JwtSecurityTokenHandler maps .NET ClaimTypes URIs to short JWT names on write
+        // (NameIdentifier -> "nameid", etc.), so a raw ReadJwtToken would not see ClaimTypes.NameIdentifier.
+        // Clearing the outbound map keeps the semantic claim types in the token for these assertions.
+        JwtSecurityTokenHandler.DefaultOutboundClaimTypeMap.Clear();
 
         this.jwtService = new JwtService(this.mockConfiguration.Object, this.mockLogger.Object);
     }
@@ -139,9 +142,11 @@ public class JwtServiceTests
         var token = this.jwtService.GenerateToken(userId, email, roles);
 
         // Act
-        var (extractedUserId, extractedEmail, extractedRoles) = this.jwtService.GetUserInfoFromToken(token);
+        var info = this.jwtService.GetUserInfoFromToken(token);
 
         // Assert
+        Assert.NotNull(info);
+        var (extractedUserId, extractedEmail, extractedRoles) = info!.Value;
         Assert.Equal(userId, extractedUserId);
         Assert.Equal(email, extractedEmail);
         Assert.NotNull(extractedRoles);
@@ -165,9 +170,11 @@ public class JwtServiceTests
         var token = this.jwtService.GenerateToken(userId, email, roles);
 
         // Act
-        var (extractedUserId, extractedEmail, extractedRoles) = this.jwtService.GetUserInfoFromToken(token);
+        var info = this.jwtService.GetUserInfoFromToken(token);
 
         // Assert
+        Assert.NotNull(info);
+        var (extractedUserId, extractedEmail, extractedRoles) = info!.Value;
         Assert.Equal(userId, extractedUserId);
         Assert.Equal(email, extractedEmail);
         Assert.NotNull(extractedRoles);

--- a/Cdm/Cdm.Business.Common.Tests/Services/RoleServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/RoleServiceTests.cs
@@ -342,20 +342,18 @@ public class RoleServiceTests
         var result = await service.AssignRoleAsync(user.Id, adminRole.Id);
 
         // Assert
-        Assert.NotNull(result);
-        Assert.Equal(user.Id, result.UserId);
-        Assert.Equal(adminRole.Id, result.RoleId);
+        Assert.True(result);
 
         var hasRole = await context.UserRoles.AnyAsync(ur => ur.UserId == user.Id && ur.RoleId == adminRole.Id);
         Assert.True(hasRole);
     }
 
     /// <summary>
-    /// Tests that AssignRoleAsync returns null when user already has the role.
+    /// Tests that AssignRoleAsync returns false when user already has the role.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Fact]
-    public async Task AssignRoleAsync_WhenUserAlreadyHasRole_ReturnsNull()
+    public async Task AssignRoleAsync_WhenUserAlreadyHasRole_ReturnsFalse()
     {
         // Arrange
         var options = new DbContextOptionsBuilder<AppDbContext>()
@@ -396,6 +394,6 @@ public class RoleServiceTests
         var result = await service.AssignRoleAsync(user.Id, adminRole.Id);
 
         // Assert
-        Assert.Null(result);
+        Assert.False(result);
     }
 }

--- a/Cdm/Cdm.Business.Common.Tests/Services/WorldServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/WorldServiceTests.cs
@@ -7,9 +7,9 @@
 namespace Cdm.Business.Common.Tests.Services;
 
 using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.Services;
 using Cdm.Business.Common.Services;
 using Cdm.Common.Enums;
-using Cdm.Common.Services;
 using Cdm.Data.Common;
 using Cdm.Data.Common.Models;
 using Microsoft.EntityFrameworkCore;
@@ -22,17 +22,20 @@ using Xunit;
 /// </summary>
 public class WorldServiceTests
 {
-    private readonly Mock<IImageStorageService> imageStorageServiceMock;
     private readonly Mock<ILogger<WorldService>> loggerMock;
+    private readonly Mock<INotificationService> notificationServiceMock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WorldServiceTests"/> class.
     /// </summary>
     public WorldServiceTests()
     {
-        this.imageStorageServiceMock = new Mock<IImageStorageService>();
         this.loggerMock = new Mock<ILogger<WorldService>>();
+        this.notificationServiceMock = new Mock<INotificationService>();
     }
+
+    private WorldService CreateService(AppDbContext context) =>
+        new(context, this.loggerMock.Object, this.notificationServiceMock.Object);
 
     /// <summary>
     /// Tests that CreateWorldAsync successfully creates a world with valid data.
@@ -59,15 +62,13 @@ public class WorldServiceTests
         context.Users.Add(testUser);
         await context.SaveChangesAsync();
 
-        var service = new WorldService(context, this.imageStorageServiceMock.Object, this.loggerMock.Object);
+        var service = this.CreateService(context);
 
         var createDto = new CreateWorldDto
         {
             Name = "Fantasy Realm",
             Description = "A magical world",
             GameType = GameType.DnD5e,
-            Visibility = Visibility.Public,
-            MaxCampaigns = 3,
         };
 
         // Act
@@ -106,7 +107,7 @@ public class WorldServiceTests
         );
         await context.SaveChangesAsync();
 
-        var service = new WorldService(context, this.imageStorageServiceMock.Object, this.loggerMock.Object);
+        var service = this.CreateService(context);
 
         // Act
         var result = await service.GetMyWorldsAsync(1);
@@ -131,7 +132,7 @@ public class WorldServiceTests
             .Options;
 
         using var context = new AppDbContext(options);
-        var service = new WorldService(context, this.imageStorageServiceMock.Object, this.loggerMock.Object);
+        var service = this.CreateService(context);
 
         // Act
         var result = await service.GetWorldByIdAsync(999, 1);
@@ -163,22 +164,19 @@ public class WorldServiceTests
             Name = "Old Name",
             Description = "Old Description",
             GameType = GameType.Generic,
-            Visibility = Visibility.Private,
             UserId = 1,
             CreatedAt = DateTime.UtcNow
         };
         context.Worlds.Add(world);
         await context.SaveChangesAsync();
 
-        var service = new WorldService(context, this.imageStorageServiceMock.Object, this.loggerMock.Object);
+        var service = this.CreateService(context);
 
         var updateDto = new CreateWorldDto
         {
             Name = "New Name",
             Description = "New Description",
             GameType = GameType.DnD5e,
-            Visibility = Visibility.Public,
-            MaxCampaigns = 5
         };
 
         // Act
@@ -192,7 +190,7 @@ public class WorldServiceTests
     }
 
     /// <summary>
-    /// Tests that DeleteWorldAsync soft deletes the world.
+    /// Tests that DeleteWorldAsync soft deletes the world (IsActive = false).
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Fact]
@@ -213,14 +211,13 @@ public class WorldServiceTests
             Id = 1,
             Name = "Test World",
             GameType = GameType.Generic,
-            Visibility = Visibility.Private,
             UserId = 1,
             CreatedAt = DateTime.UtcNow
         };
         context.Worlds.Add(world);
         await context.SaveChangesAsync();
 
-        var service = new WorldService(context, this.imageStorageServiceMock.Object, this.loggerMock.Object);
+        var service = this.CreateService(context);
 
         // Act
         var result = await service.DeleteWorldAsync(1, 1);
@@ -229,7 +226,7 @@ public class WorldServiceTests
         Assert.True(result);
         var deletedWorld = await context.Worlds.FindAsync(1);
         Assert.NotNull(deletedWorld);
-        Assert.True(deletedWorld!.IsDeleted);
+        Assert.False(deletedWorld!.IsActive);
     }
 
     /// <summary>
@@ -255,14 +252,13 @@ public class WorldServiceTests
             Id = 1,
             Name = "User1's World",
             GameType = GameType.Generic,
-            Visibility = Visibility.Private,
             UserId = 1,
             CreatedAt = DateTime.UtcNow
         };
         context.Worlds.Add(world);
         await context.SaveChangesAsync();
 
-        var service = new WorldService(context, this.imageStorageServiceMock.Object, this.loggerMock.Object);
+        var service = this.CreateService(context);
 
         var updateDto = new CreateWorldDto { Name = "Hacked Name", GameType = GameType.Custom };
 

--- a/Cdm/Cdm.Common.Tests/Cdm.Common.Tests.csproj
+++ b/Cdm/Cdm.Common.Tests/Cdm.Common.Tests.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+    <!-- xUnit1051 (pass TestContext.Current.CancellationToken) is a style suggestion irrelevant
+         to these fast tests; suppress so the solution's /warnaserror build stays green. -->
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cdm/Cdm.slnx
+++ b/Cdm/Cdm.slnx
@@ -26,6 +26,10 @@
   <Folder Name="/Front/">
     <Project Path="Cdm.Web/Cdm.Web.csproj" />
   </Folder>
+  <Folder Name="/Tests/">
+    <Project Path="Cdm.Business.Common.Tests/Cdm.Business.Common.Tests.csproj" />
+    <Project Path="Cdm.Common.Tests/Cdm.Common.Tests.csproj" />
+  </Folder>
   <Project Path="Cdm.Business.Abstraction/Cdm.Business.Abstraction.csproj" />
   <Project Path="Cdm.Business.DnD5e/Cdm.Business.DnD5e.csproj" />
 </Solution>


### PR DESCRIPTION
Le projet Cdm.Business.Common.Tests ne compilait plus (dérive de signatures et de DTO/modèles) et aucun projet de tests n'était référencé dans Cdm.slnx : la CI n'exécutait donc aucun test unitaire.

- Aligne les tests sur les signatures actuelles :
  - WorldService(db, logger, INotificationService) ; GameType porté par World, DeleteWorldAsync = soft-delete via IsActive.
  - CampaignService(db, imageStorage, INotificationService, logger) ; World requis, GameType issu du World ; Campaign sans GameType.
  - AchievementService(db, INotificationService, logger) ; UserAchievementDto.AwardMessage.
  - JwtService : mock de l'indexeur IConfiguration + neutralisation du remappage des ClaimTypes ; GetUserInfoFromToken retourne un tuple nullable.
  - RoleService.AssignRoleAsync et EventService.DeleteEventAsync retournent bool / soft-delete.
- Supprime xUnit1051 (NoWarn) pour garder le build /warnaserror vert.
- Ajoute les deux projets de tests à Cdm.slnx → la CI exécute enfin 68 tests.

Vérifié : build Release /warnaserror OK, `dotnet test Cdm.slnx` = 68/68 verts.