### PR TITLE
feat(trades): échanges d'objets en session (proposition, réponse, ann…

### DIFF
--- a/Cdm/Cdm.ApiService/Endpoints/SessionEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/SessionEndpoints.cs
@@ -73,6 +73,11 @@ public static class SessionEndpoints
         group.MapGet("/{id:int}/history", GetSessionHistoryAsync)
             .WithName("GetSessionHistory")
             .WithOpenApi();
+
+        // GET /api/sessions/{id}/trades/pending - Get pending object trades
+        group.MapGet("/{id:int}/trades/pending", GetPendingTradesAsync)
+            .WithName("GetPendingTrades")
+            .WithOpenApi();
     }
 
     private static async Task<IResult> StartSessionAsync(
@@ -282,6 +287,29 @@ public static class SessionEndpoints
         catch (Exception ex)
         {
             logger.LogError(ex, "Error retrieving history for session {SessionId}", id);
+            return Results.Problem(statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    private static async Task<IResult> GetPendingTradesAsync(
+        int id,
+        [FromServices] ITradeService tradeService,
+        ILogger<SessionEndpointsLogger> logger,
+        HttpContext httpContext)
+    {
+        try
+        {
+            var userId = GetUserId(httpContext);
+            if (userId == null) return Results.Unauthorized();
+
+            var trades = await tradeService.GetPendingTradesAsync(id, userId.Value);
+            if (trades == null) return Results.NotFound();
+
+            return Results.Ok(trades);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error retrieving pending trades for session {SessionId}", id);
             return Results.Problem(statusCode: StatusCodes.Status500InternalServerError);
         }
     }

--- a/Cdm/Cdm.ApiService/Hubs/SessionHub.cs
+++ b/Cdm/Cdm.ApiService/Hubs/SessionHub.cs
@@ -6,6 +6,7 @@
 
 namespace Cdm.ApiService.Hubs;
 
+using Cdm.Business.Abstraction.Services;
 using Cdm.Data.Common;
 using Cdm.Data.Common.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -22,16 +23,19 @@ public class SessionHub : Hub
 {
     private readonly ILogger<SessionHub> logger;
     private readonly AppDbContext db;
+    private readonly ITradeService tradeService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SessionHub"/> class.
     /// </summary>
     /// <param name="logger">Logger instance.</param>
     /// <param name="db">Database context.</param>
-    public SessionHub(ILogger<SessionHub> logger, AppDbContext db)
+    /// <param name="tradeService">Trade service for object-exchange proposals.</param>
+    public SessionHub(ILogger<SessionHub> logger, AppDbContext db, ITradeService tradeService)
     {
         this.logger = logger;
         this.db = db;
+        this.tradeService = tradeService;
     }
 
     /// <summary>
@@ -194,36 +198,71 @@ public class SessionHub : Hub
     }
 
     /// <summary>
-    /// Proposes a theoretical trade between characters (theory-based RPG mechanic).
+    /// Proposes a theory-based object trade to another session member (GM→player or player→player).
+    /// The proposal is persisted and the recipient is notified; the pending list survives reconnection.
     /// </summary>
     /// <param name="sessionId">The session identifier.</param>
     /// <param name="targetUserId">The user ID being offered the trade.</param>
     /// <param name="offerDescription">Description of what's being offered.</param>
     /// <param name="requestDescription">Description of what's being requested.</param>
     /// <returns>A task representing the async operation.</returns>
-    public async Task ProposeTradeTheory(int sessionId, int targetUserId, string offerDescription, string requestDescription)
+    public async Task ProposeTrade(int sessionId, int targetUserId, string offerDescription, string requestDescription)
     {
         var userId = this.GetUserId();
-        var userName = this.GetUserName();
         var groupName = $"session_{sessionId}";
 
-        this.logger.LogInformation(
-            "User {UserId} proposed trade to {TargetUserId} in session {SessionId}",
-            userId,
-            targetUserId,
-            sessionId);
+        var trade = await this.tradeService.ProposeTradeAsync(sessionId, userId, targetUserId, offerDescription, requestDescription);
+        if (trade == null)
+        {
+            throw new HubException("Impossible de proposer cet échange.");
+        }
 
-        await this.Clients.Group(groupName).SendAsync(
-            "TradeProposed",
-            new
-            {
-                FromUserId = userId,
-                FromUserName = userName,
-                ToUserId = targetUserId,
-                Offer = offerDescription,
-                Request = requestDescription,
-                Timestamp = DateTime.UtcNow
-            });
+        this.logger.LogInformation(
+            "User {UserId} proposed trade {TradeId} to {TargetUserId} in session {SessionId}",
+            userId, trade.Id, targetUserId, sessionId);
+
+        await this.Clients.Group(groupName).SendAsync("TradeProposed", trade);
+    }
+
+    /// <summary>
+    /// Responds to a pending trade (accept or decline). Only the recipient may respond.
+    /// </summary>
+    /// <param name="sessionId">The session identifier (for group broadcast).</param>
+    /// <param name="tradeId">The trade identifier.</param>
+    /// <param name="accept"><c>true</c> to accept, <c>false</c> to decline.</param>
+    /// <returns>A task representing the async operation.</returns>
+    public async Task RespondToTrade(int sessionId, int tradeId, bool accept)
+    {
+        var userId = this.GetUserId();
+        var groupName = $"session_{sessionId}";
+
+        var trade = await this.tradeService.RespondToTradeAsync(tradeId, userId, accept);
+        if (trade == null)
+        {
+            throw new HubException("Impossible de répondre à cet échange.");
+        }
+
+        await this.Clients.Group(groupName).SendAsync("TradeResolved", trade);
+    }
+
+    /// <summary>
+    /// Cancels a pending trade. Only the proposer may cancel it.
+    /// </summary>
+    /// <param name="sessionId">The session identifier (for group broadcast).</param>
+    /// <param name="tradeId">The trade identifier.</param>
+    /// <returns>A task representing the async operation.</returns>
+    public async Task CancelTrade(int sessionId, int tradeId)
+    {
+        var userId = this.GetUserId();
+        var groupName = $"session_{sessionId}";
+
+        var trade = await this.tradeService.CancelTradeAsync(tradeId, userId);
+        if (trade == null)
+        {
+            throw new HubException("Impossible d'annuler cet échange.");
+        }
+
+        await this.Clients.Group(groupName).SendAsync("TradeResolved", trade);
     }
 
     /// <summary>

--- a/Cdm/Cdm.ApiService/Program.cs
+++ b/Cdm/Cdm.ApiService/Program.cs
@@ -166,6 +166,7 @@ builder.Services.AddScoped<IEventService, EventService>();
 builder.Services.AddScoped<IAchievementService, AchievementService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<ISessionService, SessionService>();
+builder.Services.AddScoped<ITradeService, TradeService>();
 builder.Services.AddScoped<INpcService, NpcService>();
 builder.Services.AddScoped<ICombatService, CombatService>();
 

--- a/Cdm/Cdm.Business.Abstraction/DTOs/SessionTradeDto.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/SessionTradeDto.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionTradeDto.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.DTOs;
+
+using System;
+using Cdm.Common.Enums;
+
+/// <summary>
+/// DTO representing a theory-based object trade in a session.
+/// </summary>
+public class SessionTradeDto
+{
+    /// <summary>Gets or sets the trade ID.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the session ID.</summary>
+    public int SessionId { get; set; }
+
+    /// <summary>Gets or sets the proposer user ID.</summary>
+    public int FromUserId { get; set; }
+
+    /// <summary>Gets or sets the proposer display name.</summary>
+    public string FromUserName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the recipient user ID.</summary>
+    public int ToUserId { get; set; }
+
+    /// <summary>Gets or sets the recipient display name.</summary>
+    public string ToUserName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets what is offered.</summary>
+    public string OfferDescription { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets what is requested in return.</summary>
+    public string RequestDescription { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the current status.</summary>
+    public TradeStatus Status { get; set; }
+
+    /// <summary>Gets or sets when the trade was proposed (UTC).</summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>Gets or sets when the trade was answered or cancelled (UTC), if any.</summary>
+    public DateTime? RespondedAt { get; set; }
+}

--- a/Cdm/Cdm.Business.Abstraction/Services/ITradeService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/ITradeService.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="ITradeService.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.Services;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cdm.Business.Abstraction.DTOs;
+
+/// <summary>
+/// Service for managing theory-based object trades within a session.
+/// </summary>
+public interface ITradeService
+{
+    /// <summary>
+    /// Proposes a trade from one session member to another. The proposer and the
+    /// recipient must both belong to the session (as GM or participant).
+    /// </summary>
+    /// <param name="sessionId">The session identifier.</param>
+    /// <param name="fromUserId">The proposer user identifier.</param>
+    /// <param name="toUserId">The recipient user identifier.</param>
+    /// <param name="offerDescription">Description of what is offered.</param>
+    /// <param name="requestDescription">Description of what is requested in return.</param>
+    /// <returns>The created trade DTO, or null if invalid/unauthorized.</returns>
+    Task<SessionTradeDto?> ProposeTradeAsync(int sessionId, int fromUserId, int toUserId, string offerDescription, string requestDescription);
+
+    /// <summary>
+    /// Responds to a pending trade. Only the recipient may accept or decline it.
+    /// </summary>
+    /// <param name="tradeId">The trade identifier.</param>
+    /// <param name="userId">The responding user identifier (must be the recipient).</param>
+    /// <param name="accept"><c>true</c> to accept, <c>false</c> to decline.</param>
+    /// <returns>The updated trade DTO, or null if invalid/unauthorized/already answered.</returns>
+    Task<SessionTradeDto?> RespondToTradeAsync(int tradeId, int userId, bool accept);
+
+    /// <summary>
+    /// Cancels a pending trade. Only the proposer may cancel it.
+    /// </summary>
+    /// <param name="tradeId">The trade identifier.</param>
+    /// <param name="userId">The cancelling user identifier (must be the proposer).</param>
+    /// <returns>The updated trade DTO, or null if invalid/unauthorized/already answered.</returns>
+    Task<SessionTradeDto?> CancelTradeAsync(int tradeId, int userId);
+
+    /// <summary>
+    /// Gets the pending trades of a session. Only the GM or a participant can access them.
+    /// </summary>
+    /// <param name="sessionId">The session identifier.</param>
+    /// <param name="userId">The requesting user identifier.</param>
+    /// <returns>The pending trades, or null if not found/unauthorized.</returns>
+    Task<IReadOnlyList<SessionTradeDto>?> GetPendingTradesAsync(int sessionId, int userId);
+}

--- a/Cdm/Cdm.Business.Common.Tests/Services/TradeServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/TradeServiceTests.cs
@@ -1,0 +1,177 @@
+// -----------------------------------------------------------------------
+// <copyright file="TradeServiceTests.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Tests.Services;
+
+using Cdm.Business.Abstraction.Services;
+using Cdm.Business.Common.Services;
+using Cdm.Common.Enums;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="TradeService"/>.
+/// </summary>
+public class TradeServiceTests
+{
+    private readonly Mock<INotificationService> notificationServiceMock = new();
+    private readonly Mock<ILogger<TradeService>> loggerMock = new();
+
+    private const int GmUserId = 1;
+    private const int PlayerUserId = 2;
+
+    private static DbContextOptions<AppDbContext> NewOptions(string name) =>
+        new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: name)
+            .Options;
+
+    private TradeService CreateService(AppDbContext context) =>
+        new(context, this.notificationServiceMock.Object, this.loggerMock.Object);
+
+    /// <summary>
+    /// Seeds a session (GM = user 1) with one joined participant (player = user 2).
+    /// </summary>
+    private static async Task SeedSessionWithParticipantAsync(AppDbContext context, int sessionId = 10)
+    {
+        context.Users.AddRange(
+            new User { Id = GmUserId, Email = "gm@test.com", Nickname = "MJ", PasswordHash = "h", CreatedAt = DateTime.UtcNow },
+            new User { Id = PlayerUserId, Email = "player@test.com", Nickname = "Joueur", PasswordHash = "h", CreatedAt = DateTime.UtcNow });
+
+        context.Sessions.Add(new Session { Id = sessionId, CampaignId = 5, StartedById = GmUserId, StartedAt = DateTime.UtcNow });
+
+        var character = new Character { Id = 100, UserId = PlayerUserId, Name = "Aragorn", IsActive = true };
+        context.Characters.Add(character);
+        var worldCharacter = new WorldCharacter { Id = 200, CharacterId = 100, WorldId = 1, IsActive = true };
+        context.WorldCharacters.Add(worldCharacter);
+        context.SessionParticipants.Add(new SessionParticipant
+        {
+            Id = 300, SessionId = sessionId, WorldCharacterId = 200, JoinedAt = DateTime.UtcNow, Status = SessionParticipantStatus.Joined
+        });
+
+        await context.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// The GM can propose a trade to a participant; the trade is persisted as Pending.
+    /// </summary>
+    [Fact]
+    public async Task ProposeTradeAsync_GmToParticipant_CreatesPendingTrade()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(ProposeTradeAsync_GmToParticipant_CreatesPendingTrade)));
+        await SeedSessionWithParticipantAsync(context);
+        var service = this.CreateService(context);
+
+        var trade = await service.ProposeTradeAsync(10, GmUserId, PlayerUserId, "Une épée", "50 pièces d'or");
+
+        Assert.NotNull(trade);
+        Assert.Equal(TradeStatus.Pending, trade!.Status);
+        Assert.Equal(GmUserId, trade.FromUserId);
+        Assert.Equal(PlayerUserId, trade.ToUserId);
+        Assert.Equal("Une épée", trade.OfferDescription);
+
+        var persisted = await context.SessionTrades.FirstOrDefaultAsync(t => t.Id == trade.Id);
+        Assert.NotNull(persisted);
+        Assert.Equal(TradeStatus.Pending, persisted!.Status);
+
+        // The recipient is notified.
+        this.notificationServiceMock.Verify(
+            n => n.CreateNotificationAsync(It.Is<Cdm.Business.Abstraction.DTOs.CreateNotificationDto>(d => d.UserId == PlayerUserId)),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Proposing a trade to a user who is not a member of the session is rejected.
+    /// </summary>
+    [Fact]
+    public async Task ProposeTradeAsync_TargetNotMember_ReturnsNull()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(ProposeTradeAsync_TargetNotMember_ReturnsNull)));
+        await SeedSessionWithParticipantAsync(context);
+        var service = this.CreateService(context);
+
+        var trade = await service.ProposeTradeAsync(10, GmUserId, 999, "X", "Y");
+
+        Assert.Null(trade);
+    }
+
+    /// <summary>
+    /// Proposing a trade to oneself is rejected.
+    /// </summary>
+    [Fact]
+    public async Task ProposeTradeAsync_ToSelf_ReturnsNull()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(ProposeTradeAsync_ToSelf_ReturnsNull)));
+        await SeedSessionWithParticipantAsync(context);
+        var service = this.CreateService(context);
+
+        var trade = await service.ProposeTradeAsync(10, GmUserId, GmUserId, "X", "Y");
+
+        Assert.Null(trade);
+    }
+
+    /// <summary>
+    /// The recipient can accept a pending trade, moving it to Accepted.
+    /// </summary>
+    [Fact]
+    public async Task RespondToTradeAsync_ByRecipient_Accepts()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(RespondToTradeAsync_ByRecipient_Accepts)));
+        await SeedSessionWithParticipantAsync(context);
+        var service = this.CreateService(context);
+
+        var proposed = await service.ProposeTradeAsync(10, GmUserId, PlayerUserId, "Une potion", "Une carte");
+        Assert.NotNull(proposed);
+
+        var result = await service.RespondToTradeAsync(proposed!.Id, PlayerUserId, accept: true);
+
+        Assert.NotNull(result);
+        Assert.Equal(TradeStatus.Accepted, result!.Status);
+        Assert.NotNull(result.RespondedAt);
+    }
+
+    /// <summary>
+    /// A user who is not the recipient cannot respond to a trade.
+    /// </summary>
+    [Fact]
+    public async Task RespondToTradeAsync_ByNonRecipient_ReturnsNull()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(RespondToTradeAsync_ByNonRecipient_ReturnsNull)));
+        await SeedSessionWithParticipantAsync(context);
+        var service = this.CreateService(context);
+
+        var proposed = await service.ProposeTradeAsync(10, GmUserId, PlayerUserId, "Une potion", "Une carte");
+        Assert.NotNull(proposed);
+
+        // The GM (proposer) is not the recipient and cannot answer.
+        var result = await service.RespondToTradeAsync(proposed!.Id, GmUserId, accept: true);
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Only members can read the pending trades; an outsider gets null.
+    /// </summary>
+    [Fact]
+    public async Task GetPendingTradesAsync_Outsider_ReturnsNull()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(GetPendingTradesAsync_Outsider_ReturnsNull)));
+        await SeedSessionWithParticipantAsync(context);
+        var service = this.CreateService(context);
+
+        await service.ProposeTradeAsync(10, GmUserId, PlayerUserId, "A", "B");
+
+        var asOutsider = await service.GetPendingTradesAsync(10, 999);
+        Assert.Null(asOutsider);
+
+        var asGm = await service.GetPendingTradesAsync(10, GmUserId);
+        Assert.NotNull(asGm);
+        Assert.Single(asGm!);
+    }
+}

--- a/Cdm/Cdm.Business.Common/Services/TradeService.cs
+++ b/Cdm/Cdm.Business.Common/Services/TradeService.cs
@@ -1,0 +1,255 @@
+// -----------------------------------------------------------------------
+// <copyright file="TradeService.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Services;
+
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.Services;
+using Cdm.Common.Enums;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Service for managing theory-based object trades within a session.
+/// </summary>
+public class TradeService(
+    AppDbContext dbContext,
+    INotificationService notificationService,
+    ILogger<TradeService> logger) : ITradeService
+{
+    private readonly AppDbContext dbContext = dbContext;
+    private readonly INotificationService notificationService = notificationService;
+    private readonly ILogger<TradeService> logger = logger;
+
+    /// <inheritdoc/>
+    public async Task<SessionTradeDto?> ProposeTradeAsync(int sessionId, int fromUserId, int toUserId, string offerDescription, string requestDescription)
+    {
+        try
+        {
+            if (fromUserId == toUserId)
+            {
+                return null;
+            }
+
+            var session = await this.dbContext.Sessions.AsNoTracking().FirstOrDefaultAsync(s => s.Id == sessionId);
+            if (session == null)
+            {
+                return null;
+            }
+
+            // Both the proposer and the recipient must belong to the session.
+            if (!await this.IsMemberAsync(session, fromUserId) || !await this.IsMemberAsync(session, toUserId))
+            {
+                this.logger.LogWarning(
+                    "Trade proposal rejected: user {FromUserId} or {ToUserId} is not a member of session {SessionId}",
+                    fromUserId, toUserId, sessionId);
+                return null;
+            }
+
+            var fromName = await this.GetUserNameAsync(fromUserId);
+            var toName = await this.GetUserNameAsync(toUserId);
+
+            var trade = new SessionTrade
+            {
+                SessionId = sessionId,
+                FromUserId = fromUserId,
+                FromUserName = fromName,
+                ToUserId = toUserId,
+                ToUserName = toName,
+                OfferDescription = offerDescription?.Trim() ?? string.Empty,
+                RequestDescription = requestDescription?.Trim() ?? string.Empty,
+                Status = TradeStatus.Pending,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            this.dbContext.SessionTrades.Add(trade);
+            await this.dbContext.SaveChangesAsync();
+
+            await this.notificationService.CreateNotificationAsync(new CreateNotificationDto
+            {
+                UserId = toUserId,
+                Type = NotificationType.TradeProposed,
+                Title = "Proposition d'échange",
+                Message = $"{fromName} vous propose un échange.",
+                RelatedEntityId = trade.Id,
+                RelatedEntityType = "SessionTrade",
+                ActionUrl = $"/sessions/{sessionId}/player",
+                SentBy = fromUserId
+            });
+
+            this.logger.LogInformation(
+                "Trade {TradeId} proposed by {FromUserId} to {ToUserId} in session {SessionId}",
+                trade.Id, fromUserId, toUserId, sessionId);
+
+            return MapToDto(trade);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error proposing trade in session {SessionId}", sessionId);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<SessionTradeDto?> RespondToTradeAsync(int tradeId, int userId, bool accept)
+    {
+        try
+        {
+            var trade = await this.dbContext.SessionTrades.FirstOrDefaultAsync(t => t.Id == tradeId);
+            if (trade == null || trade.Status != TradeStatus.Pending)
+            {
+                return null;
+            }
+
+            // Only the recipient may answer.
+            if (trade.ToUserId != userId)
+            {
+                this.logger.LogWarning("User {UserId} is not the recipient of trade {TradeId}", userId, tradeId);
+                return null;
+            }
+
+            trade.Status = accept ? TradeStatus.Accepted : TradeStatus.Declined;
+            trade.RespondedAt = DateTime.UtcNow;
+            await this.dbContext.SaveChangesAsync();
+
+            await this.notificationService.CreateNotificationAsync(new CreateNotificationDto
+            {
+                UserId = trade.FromUserId,
+                Type = NotificationType.TradeProposed,
+                Title = accept ? "Échange accepté" : "Échange refusé",
+                Message = accept
+                    ? $"{trade.ToUserName} a accepté votre échange."
+                    : $"{trade.ToUserName} a refusé votre échange.",
+                RelatedEntityId = trade.Id,
+                RelatedEntityType = "SessionTrade",
+                ActionUrl = $"/sessions/{trade.SessionId}/player",
+                SentBy = userId
+            });
+
+            this.logger.LogInformation(
+                "Trade {TradeId} {Status} by {UserId}", tradeId, trade.Status, userId);
+
+            return MapToDto(trade);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error responding to trade {TradeId}", tradeId);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<SessionTradeDto?> CancelTradeAsync(int tradeId, int userId)
+    {
+        try
+        {
+            var trade = await this.dbContext.SessionTrades.FirstOrDefaultAsync(t => t.Id == tradeId);
+            if (trade == null || trade.Status != TradeStatus.Pending)
+            {
+                return null;
+            }
+
+            // Only the proposer may cancel.
+            if (trade.FromUserId != userId)
+            {
+                this.logger.LogWarning("User {UserId} is not the proposer of trade {TradeId}", userId, tradeId);
+                return null;
+            }
+
+            trade.Status = TradeStatus.Cancelled;
+            trade.RespondedAt = DateTime.UtcNow;
+            await this.dbContext.SaveChangesAsync();
+
+            this.logger.LogInformation("Trade {TradeId} cancelled by {UserId}", tradeId, userId);
+
+            return MapToDto(trade);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error cancelling trade {TradeId}", tradeId);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<SessionTradeDto>?> GetPendingTradesAsync(int sessionId, int userId)
+    {
+        try
+        {
+            var session = await this.dbContext.Sessions.AsNoTracking().FirstOrDefaultAsync(s => s.Id == sessionId);
+            if (session == null)
+            {
+                return null;
+            }
+
+            if (!await this.IsMemberAsync(session, userId))
+            {
+                return null;
+            }
+
+            var trades = await this.dbContext.SessionTrades
+                .AsNoTracking()
+                .Where(t => t.SessionId == sessionId && t.Status == TradeStatus.Pending)
+                .OrderBy(t => t.CreatedAt)
+                .ToListAsync();
+
+            return trades.Select(MapToDto).ToList();
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error retrieving pending trades for session {SessionId}", sessionId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether a user belongs to a session, either as the GM or as a participant.
+    /// </summary>
+    private async Task<bool> IsMemberAsync(Session session, int userId)
+    {
+        if (userId <= 0)
+        {
+            return false;
+        }
+
+        if (session.StartedById == userId)
+        {
+            return true;
+        }
+
+        return await this.dbContext.SessionParticipants
+            .AsNoTracking()
+            .AnyAsync(p => p.SessionId == session.Id && p.WorldCharacter.Character.UserId == userId);
+    }
+
+    /// <summary>
+    /// Resolves a user's display name (nickname, falling back to email).
+    /// </summary>
+    private async Task<string> GetUserNameAsync(int userId)
+    {
+        var user = await this.dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == userId);
+        return user?.Nickname ?? user?.Email ?? "Inconnu";
+    }
+
+    private static SessionTradeDto MapToDto(SessionTrade trade) => new()
+    {
+        Id = trade.Id,
+        SessionId = trade.SessionId,
+        FromUserId = trade.FromUserId,
+        FromUserName = trade.FromUserName,
+        ToUserId = trade.ToUserId,
+        ToUserName = trade.ToUserName,
+        OfferDescription = trade.OfferDescription,
+        RequestDescription = trade.RequestDescription,
+        Status = trade.Status,
+        CreatedAt = trade.CreatedAt,
+        RespondedAt = trade.RespondedAt
+    };
+}

--- a/Cdm/Cdm.Common/Enums/TradeStatus.cs
+++ b/Cdm/Cdm.Common/Enums/TradeStatus.cs
@@ -1,0 +1,19 @@
+namespace Cdm.Common.Enums;
+
+/// <summary>
+/// Status of a theory-based object trade between two session members.
+/// </summary>
+public enum TradeStatus
+{
+    /// <summary>The trade has been proposed and awaits a response.</summary>
+    Pending = 0,
+
+    /// <summary>The recipient accepted the trade.</summary>
+    Accepted = 1,
+
+    /// <summary>The recipient declined the trade.</summary>
+    Declined = 2,
+
+    /// <summary>The proposer cancelled the trade before it was answered.</summary>
+    Cancelled = 3
+}

--- a/Cdm/Cdm.Data.Common/AppDbContext.cs
+++ b/Cdm/Cdm.Data.Common/AppDbContext.cs
@@ -113,6 +113,11 @@ public class AppDbContext : DbContext
     /// </summary>
     public DbSet<SessionDiceRoll> SessionDiceRolls { get; set; } = null!;
 
+    /// <summary>
+    /// Gets or sets the theory-based object trades proposed during sessions.
+    /// </summary>
+    public DbSet<SessionTrade> SessionTrades { get; set; } = null!;
+
     // ---- D&D 5e reference data ----
 
     /// <summary>D&amp;D 5e playable races.</summary>

--- a/Cdm/Cdm.Data.Common/Models/SessionTrade.cs
+++ b/Cdm/Cdm.Data.Common/Models/SessionTrade.cs
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="SessionTrade.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Data.Common.Models;
+
+using Cdm.Common.Enums;
+
+/// <summary>
+/// Represents a theory-based object trade proposed during a session
+/// (GM → player or player → player). The exchange is described in text;
+/// the record tracks its lifecycle so pending proposals survive reconnection.
+/// </summary>
+public class SessionTrade
+{
+    /// <summary>Gets or sets the trade ID.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the session this trade belongs to.</summary>
+    public int SessionId { get; set; }
+
+    /// <summary>Gets or sets the user ID of the proposer.</summary>
+    public int FromUserId { get; set; }
+
+    /// <summary>Gets or sets the display name of the proposer at proposal time.</summary>
+    public string FromUserName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the user ID of the recipient.</summary>
+    public int ToUserId { get; set; }
+
+    /// <summary>Gets or sets the display name of the recipient at proposal time.</summary>
+    public string ToUserName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the description of what is offered.</summary>
+    public string OfferDescription { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the description of what is requested in return.</summary>
+    public string RequestDescription { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the current status of the trade.</summary>
+    public TradeStatus Status { get; set; } = TradeStatus.Pending;
+
+    /// <summary>Gets or sets when the trade was proposed (UTC).</summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Gets or sets when the trade was answered or cancelled (UTC), if applicable.</summary>
+    public DateTime? RespondedAt { get; set; }
+
+    /// <summary>Gets or sets the session navigation property.</summary>
+    public virtual Session Session { get; set; } = null!;
+}

--- a/Cdm/Cdm.Migrations/Migrations/20260719140000_AddSessionTrades.cs
+++ b/Cdm/Cdm.Migrations/Migrations/20260719140000_AddSessionTrades.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Cdm.Migrations;
+
+#nullable disable
+
+namespace Cdm.Migrations.Migrations
+{
+    /// <summary>
+    /// Ajoute la table [SessionTrades] : les échanges d'objets « théoriques »
+    /// proposés en session (MJ→Joueur et Joueur→Joueur), avec leur cycle de vie
+    /// (Pending / Accepted / Declined / Cancelled) pour que les propositions en
+    /// attente survivent à une reconnexion.
+    /// </summary>
+    [DbContext(typeof(MigrationsContext))]
+    [Migration("20260719140000_AddSessionTrades")]
+    public partial class AddSessionTrades : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF OBJECT_ID(N'[SessionTrades]', N'U') IS NULL
+                BEGIN
+                    CREATE TABLE [SessionTrades] (
+                        [Id] int NOT NULL IDENTITY,
+                        [SessionId] int NOT NULL,
+                        [FromUserId] int NOT NULL,
+                        [FromUserName] nvarchar(256) NOT NULL DEFAULT N'',
+                        [ToUserId] int NOT NULL,
+                        [ToUserName] nvarchar(256) NOT NULL DEFAULT N'',
+                        [OfferDescription] nvarchar(1000) NOT NULL DEFAULT N'',
+                        [RequestDescription] nvarchar(1000) NOT NULL DEFAULT N'',
+                        [Status] int NOT NULL DEFAULT 0,
+                        [CreatedAt] datetime2 NOT NULL DEFAULT (GETUTCDATE()),
+                        [RespondedAt] datetime2 NULL,
+                        CONSTRAINT [PK_SessionTrades] PRIMARY KEY ([Id]),
+                        CONSTRAINT [FK_SessionTrades_Sessions_SessionId] FOREIGN KEY ([SessionId])
+                            REFERENCES [Sessions] ([Id]) ON DELETE CASCADE
+                    );
+
+                    CREATE INDEX [IX_SessionTrades_SessionId] ON [SessionTrades] ([SessionId]);
+                    CREATE INDEX [IX_SessionTrades_ToUserId] ON [SessionTrades] ([ToUserId]);
+                    CREATE INDEX [IX_SessionTrades_Status] ON [SessionTrades] ([Status]);
+                END
+            ");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF OBJECT_ID(N'[SessionTrades]', N'U') IS NOT NULL
+                    DROP TABLE [SessionTrades];
+            ");
+        }
+    }
+}

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor
@@ -326,6 +326,68 @@ else if (Session != null)
                         </button>
                     </div>
                 </div>
+
+                <!-- Échanges d'objets -->
+                <div class="gm-chat-section">
+                    <div class="gm-chat-header">
+                        <i class="bi bi-arrow-left-right"></i>
+                        <span>Échanges</span>
+                    </div>
+                    <div style="padding: var(--spacing-sm); display: flex; flex-direction: column; gap: var(--spacing-xs);">
+                        @if (PendingTrades.Count == 0)
+                        {
+                            <p style="color: var(--color-text-muted); font-size: var(--font-size-xs); font-style: italic; text-align: center;">
+                                Aucune proposition en attente.
+                            </p>
+                        }
+                        @foreach (var trade in PendingTrades)
+                        {
+                            <div class="chat-entry" style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--spacing-xs);">
+                                <div class="chat-entry-meta">
+                                    <span class="chat-entry-author">@trade.FromUserName → @trade.ToUserName</span>
+                                </div>
+                                <div style="font-size: var(--font-size-xs);">
+                                    <div><strong>Offre :</strong> @trade.OfferDescription</div>
+                                    <div><strong>Demande :</strong> @trade.RequestDescription</div>
+                                </div>
+                                @if (trade.ToUserId == CurrentUserId)
+                                {
+                                    <div style="display: flex; gap: var(--spacing-xs); margin-top: var(--spacing-xs);">
+                                        <button class="btn btn-primary btn-sm" @onclick="() => RespondToTrade(trade.Id, true)" disabled="@(!IsHubConnected)">
+                                            <i class="bi bi-check-lg"></i> Accepter
+                                        </button>
+                                        <button class="btn btn-outline btn-sm" @onclick="() => RespondToTrade(trade.Id, false)" disabled="@(!IsHubConnected)">
+                                            <i class="bi bi-x-lg"></i> Refuser
+                                        </button>
+                                    </div>
+                                }
+                                else if (trade.FromUserId == CurrentUserId)
+                                {
+                                    <div style="margin-top: var(--spacing-xs);">
+                                        <button class="btn btn-outline btn-sm" @onclick="() => CancelTrade(trade.Id)" disabled="@(!IsHubConnected)">
+                                            <i class="bi bi-trash"></i> Annuler
+                                        </button>
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </div>
+                    <div style="padding: var(--spacing-sm); border-top: 1px solid var(--color-border); display: flex; flex-direction: column; gap: var(--spacing-xs);">
+                        <select class="form-control" style="font-size: var(--font-size-xs);" @bind="TradeTargetUserId" disabled="@(!IsHubConnected)">
+                            <option value="0">— Destinataire —</option>
+                            @foreach (var target in TradeTargets())
+                            {
+                                <option value="@target.UserId">@target.Name</option>
+                            }
+                        </select>
+                        <input class="form-control" style="font-size: var(--font-size-xs);" placeholder="Ce que je propose…" @bind="TradeOffer" disabled="@(!IsHubConnected)" />
+                        <input class="form-control" style="font-size: var(--font-size-xs);" placeholder="Ce que je demande en retour…" @bind="TradeRequest" disabled="@(!IsHubConnected)" />
+                        <button class="btn btn-primary btn-sm" @onclick="ProposeTrade"
+                                disabled="@(!IsHubConnected || IsProposingTrade || TradeTargetUserId <= 0 || string.IsNullOrWhiteSpace(TradeOffer) || string.IsNullOrWhiteSpace(TradeRequest))">
+                            <i class="bi bi-send"></i> Proposer l'échange
+                        </button>
+                    </div>
+                </div>
             </aside>
         </div>
     </div>

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor.cs
@@ -55,6 +55,13 @@ public partial class SessionGm : IAsyncDisposable
     private string ChatInput = "";
     private int? RollingDie;
 
+    // Trades (object exchanges)
+    private List<SessionTradeDto> PendingTrades { get; set; } = new();
+    private int TradeTargetUserId;
+    private string TradeOffer = "";
+    private string TradeRequest = "";
+    private bool IsProposingTrade;
+
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
@@ -102,8 +109,14 @@ public partial class SessionGm : IAsyncDisposable
         // Rebuild the timeline from persisted history BEFORE connecting to the hub,
         // so live events only ever append to an already-complete history (no duplicates).
         await LoadHistoryAsync();
+        await LoadTradesAsync();
 
         await ConnectToHubAsync();
+    }
+
+    private async Task LoadTradesAsync()
+    {
+        PendingTrades = await SessionClient.GetPendingTradesAsync(SessionId);
     }
 
     private async Task LoadHistoryAsync()
@@ -144,6 +157,19 @@ public partial class SessionGm : IAsyncDisposable
         _hub.On<HubDiceDto>("DiceRolled", dto =>
         {
             ChatEntries.Add(new ChatEntry("dice", dto.UserName ?? "?", null, dto.DiceType, dto.Results, dto.Timestamp));
+            InvokeAsync(StateHasChanged);
+        });
+
+        _hub.On<SessionTradeDto>("TradeProposed", trade =>
+        {
+            PendingTrades.RemoveAll(t => t.Id == trade.Id);
+            PendingTrades.Add(trade);
+            InvokeAsync(StateHasChanged);
+        });
+
+        _hub.On<SessionTradeDto>("TradeResolved", trade =>
+        {
+            PendingTrades.RemoveAll(t => t.Id == trade.Id);
             InvokeAsync(StateHasChanged);
         });
 
@@ -199,6 +225,75 @@ public partial class SessionGm : IAsyncDisposable
         }
         RollingDie = null;
         StateHasChanged();
+    }
+
+    /// <summary>
+    /// Selectable trade targets: every joined participant (the GM is the current user here).
+    /// </summary>
+    private List<(int UserId, string Name)> TradeTargets()
+    {
+        var targets = new List<(int, string)>();
+        if (Session == null) return targets;
+
+        foreach (var p in Session.Participants)
+        {
+            if (p.UserId != CurrentUserId && p.UserId > 0)
+                targets.Add((p.UserId, p.UserName));
+        }
+        return targets;
+    }
+
+    private async Task ProposeTrade()
+    {
+        if (_hub == null || !IsHubConnected || IsProposingTrade) return;
+        if (TradeTargetUserId <= 0 || string.IsNullOrWhiteSpace(TradeOffer) || string.IsNullOrWhiteSpace(TradeRequest))
+        {
+            Toast.ShowWarning("Choisissez un destinataire et décrivez l'offre et la demande.", "Échange");
+            return;
+        }
+
+        IsProposingTrade = true;
+        try
+        {
+            await _hub.InvokeAsync("ProposeTrade", SessionId, TradeTargetUserId, TradeOffer.Trim(), TradeRequest.Trim());
+            TradeOffer = "";
+            TradeRequest = "";
+            TradeTargetUserId = 0;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Proposition d'échange impossible (session {SessionId})", SessionId);
+            Toast.ShowError("Proposition d'échange non envoyée.", "Échange");
+        }
+        IsProposingTrade = false;
+    }
+
+    private async Task RespondToTrade(int tradeId, bool accept)
+    {
+        if (_hub == null || !IsHubConnected) return;
+        try
+        {
+            await _hub.InvokeAsync("RespondToTrade", SessionId, tradeId, accept);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Réponse à l'échange impossible (session {SessionId})", SessionId);
+            Toast.ShowError("Réponse non envoyée.", "Échange");
+        }
+    }
+
+    private async Task CancelTrade(int tradeId)
+    {
+        if (_hub == null || !IsHubConnected) return;
+        try
+        {
+            await _hub.InvokeAsync("CancelTrade", SessionId, tradeId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Annulation de l'échange impossible (session {SessionId})", SessionId);
+            Toast.ShowError("Annulation non envoyée.", "Échange");
+        }
     }
 
     private async Task SelectChapter(ChapterDto chapter)

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor
@@ -293,6 +293,67 @@ else if (Session != null)
                         }
                     </div>
                 </div>
+
+                <!-- Échanges d'objets -->
+                <div class="session-chat-panel">
+                    <div class="session-chat-header">
+                        <i class="bi bi-arrow-left-right"></i> Échanges
+                    </div>
+                    <div style="padding: var(--spacing-sm); display: flex; flex-direction: column; gap: var(--spacing-xs);">
+                        @if (PendingTrades.Count == 0)
+                        {
+                            <p style="color: var(--color-text-muted); font-size: var(--font-size-xs); font-style: italic; text-align: center;">
+                                Aucune proposition en attente.
+                            </p>
+                        }
+                        @foreach (var trade in PendingTrades)
+                        {
+                            <div class="chat-entry" style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--spacing-xs);">
+                                <div class="chat-entry-meta">
+                                    <span class="chat-entry-author">@trade.FromUserName → @trade.ToUserName</span>
+                                </div>
+                                <div style="font-size: var(--font-size-xs);">
+                                    <div><strong>Offre :</strong> @trade.OfferDescription</div>
+                                    <div><strong>Demande :</strong> @trade.RequestDescription</div>
+                                </div>
+                                @if (trade.ToUserId == CurrentUserId)
+                                {
+                                    <div style="display: flex; gap: var(--spacing-xs); margin-top: var(--spacing-xs);">
+                                        <button class="btn btn-primary btn-sm" @onclick="() => RespondToTrade(trade.Id, true)" disabled="@(!IsHubConnected)">
+                                            <i class="bi bi-check-lg"></i> Accepter
+                                        </button>
+                                        <button class="btn btn-outline btn-sm" @onclick="() => RespondToTrade(trade.Id, false)" disabled="@(!IsHubConnected)">
+                                            <i class="bi bi-x-lg"></i> Refuser
+                                        </button>
+                                    </div>
+                                }
+                                else if (trade.FromUserId == CurrentUserId)
+                                {
+                                    <div style="margin-top: var(--spacing-xs);">
+                                        <button class="btn btn-outline btn-sm" @onclick="() => CancelTrade(trade.Id)" disabled="@(!IsHubConnected)">
+                                            <i class="bi bi-trash"></i> Annuler
+                                        </button>
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </div>
+                    <div style="padding: var(--spacing-sm); border-top: 1px solid var(--color-border); display: flex; flex-direction: column; gap: var(--spacing-xs);">
+                        <select class="form-control" style="font-size: var(--font-size-sm);" @bind="TradeTargetUserId" disabled="@(!IsHubConnected)">
+                            <option value="0">— Destinataire —</option>
+                            @foreach (var target in TradeTargets())
+                            {
+                                <option value="@target.UserId">@target.Name</option>
+                            }
+                        </select>
+                        <input class="form-control" style="font-size: var(--font-size-sm);" placeholder="Ce que je propose…" @bind="TradeOffer" disabled="@(!IsHubConnected)" />
+                        <input class="form-control" style="font-size: var(--font-size-sm);" placeholder="Ce que je demande en retour…" @bind="TradeRequest" disabled="@(!IsHubConnected)" />
+                        <button class="btn btn-primary btn-sm" @onclick="ProposeTrade"
+                                disabled="@(!IsHubConnected || IsProposingTrade || TradeTargetUserId <= 0 || string.IsNullOrWhiteSpace(TradeOffer) || string.IsNullOrWhiteSpace(TradeRequest))">
+                            <i class="bi bi-send"></i> Proposer l'échange
+                        </button>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor.cs
@@ -51,6 +51,13 @@ public partial class SessionPlayer : IAsyncDisposable
     private string ChatInput = "";
     private int? RollingDie;
 
+    // Trades (object exchanges)
+    private List<SessionTradeDto> PendingTrades { get; set; } = new();
+    private int TradeTargetUserId;
+    private string TradeOffer = "";
+    private string TradeRequest = "";
+    private bool IsProposingTrade;
+
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
@@ -106,8 +113,14 @@ public partial class SessionPlayer : IAsyncDisposable
         // Rebuild the timeline from persisted history BEFORE connecting to the hub,
         // so live events only ever append to an already-complete history (no duplicates).
         await LoadHistoryAsync();
+        await LoadTradesAsync();
 
         await ConnectToHubAsync();
+    }
+
+    private async Task LoadTradesAsync()
+    {
+        PendingTrades = await SessionClient.GetPendingTradesAsync(SessionId);
     }
 
     private async Task LoadHistoryAsync()
@@ -148,6 +161,20 @@ public partial class SessionPlayer : IAsyncDisposable
         _hub.On<HubDiceDto>("DiceRolled", dto =>
         {
             ChatEntries.Add(new ChatEntry("dice", dto.UserName ?? "?", null, dto.DiceType, dto.Results, dto.Timestamp));
+            InvokeAsync(StateHasChanged);
+        });
+
+        _hub.On<SessionTradeDto>("TradeProposed", trade =>
+        {
+            PendingTrades.RemoveAll(t => t.Id == trade.Id);
+            PendingTrades.Add(trade);
+            InvokeAsync(StateHasChanged);
+        });
+
+        _hub.On<SessionTradeDto>("TradeResolved", trade =>
+        {
+            // Once accepted, declined or cancelled, the trade leaves the pending list.
+            PendingTrades.RemoveAll(t => t.Id == trade.Id);
             InvokeAsync(StateHasChanged);
         });
 
@@ -212,6 +239,78 @@ public partial class SessionPlayer : IAsyncDisposable
         }
         RollingDie = null;
         StateHasChanged();
+    }
+
+    /// <summary>
+    /// Selectable trade targets: the GM and every joined participant, excluding oneself.
+    /// </summary>
+    private List<(int UserId, string Name)> TradeTargets()
+    {
+        var targets = new List<(int, string)>();
+        if (Session == null) return targets;
+
+        if (Session.StartedById != CurrentUserId)
+            targets.Add((Session.StartedById, $"{Session.StartedByName} (MJ)"));
+
+        foreach (var p in Session.Participants)
+        {
+            if (p.UserId != CurrentUserId && p.UserId != Session.StartedById && p.UserId > 0)
+                targets.Add((p.UserId, p.UserName));
+        }
+        return targets;
+    }
+
+    private async Task ProposeTrade()
+    {
+        if (_hub == null || !IsHubConnected || IsProposingTrade) return;
+        if (TradeTargetUserId <= 0 || string.IsNullOrWhiteSpace(TradeOffer) || string.IsNullOrWhiteSpace(TradeRequest))
+        {
+            Toast.ShowWarning("Choisissez un destinataire et décrivez l'offre et la demande.", "Échange");
+            return;
+        }
+
+        IsProposingTrade = true;
+        try
+        {
+            await _hub.InvokeAsync("ProposeTrade", SessionId, TradeTargetUserId, TradeOffer.Trim(), TradeRequest.Trim());
+            TradeOffer = "";
+            TradeRequest = "";
+            TradeTargetUserId = 0;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Proposition d'échange impossible (session {SessionId})", SessionId);
+            Toast.ShowError("Proposition d'échange non envoyée.", "Échange");
+        }
+        IsProposingTrade = false;
+    }
+
+    private async Task RespondToTrade(int tradeId, bool accept)
+    {
+        if (_hub == null || !IsHubConnected) return;
+        try
+        {
+            await _hub.InvokeAsync("RespondToTrade", SessionId, tradeId, accept);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Réponse à l'échange impossible (session {SessionId})", SessionId);
+            Toast.ShowError("Réponse non envoyée.", "Échange");
+        }
+    }
+
+    private async Task CancelTrade(int tradeId)
+    {
+        if (_hub == null || !IsHubConnected) return;
+        try
+        {
+            await _hub.InvokeAsync("CancelTrade", SessionId, tradeId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Annulation de l'échange impossible (session {SessionId})", SessionId);
+            Toast.ShowError("Annulation non envoyée.", "Échange");
+        }
     }
 
     private async Task LeaveSession()

--- a/Cdm/Cdm.Web/Services/ApiClients/SessionApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ApiClients/SessionApiClient.cs
@@ -179,6 +179,23 @@ public class SessionApiClient
         }
     }
 
+    /// <summary>Get the pending object trades of a session.</summary>
+    public async Task<List<SessionTradeDto>> GetPendingTradesAsync(int sessionId)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await _httpClient.GetAsync($"api/sessions/{sessionId}/trades/pending");
+            if (!response.IsSuccessStatusCode) return new List<SessionTradeDto>();
+            return await response.Content.ReadFromJsonAsync<List<SessionTradeDto>>() ?? new List<SessionTradeDto>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching pending trades for session {SessionId}", sessionId);
+            return new List<SessionTradeDto>();
+        }
+    }
+
     /// <summary>Returns the API base URL for constructing hub URLs.</summary>
     public string GetApiBaseUrl() => _httpClient.BaseAddress?.ToString().TrimEnd('/') ?? string.Empty;
 }


### PR DESCRIPTION
…ulation)

Construit toute la fonctionnalité d'échange « théorique » demandée par la roadmap (MJ→Joueur et Joueur→Joueur), là où seul un broadcast sans persistance existait.

Backend :
- Modèle SessionTrade + enum TradeStatus + migration SQL idempotente AddSessionTrades.
- ITradeService/TradeService : propose, accept/decline, cancel, liste des propositions en attente ; autorisation d'appartenance à la session + notifications aux intéressés.
- Hub : ProposeTrade / RespondToTrade / CancelTrade diffusent TradeProposed / TradeResolved.
- Endpoint REST GET /api/sessions/{id}/trades/pending (rechargement à la reconnexion).

Frontend (pages MJ et Joueur) :
- Panneau « Échanges » : formulaire de proposition (destinataire, offre, demande), liste des propositions en attente, boutons Accepter / Refuser / Annuler.
- Rechargement de la liste à l'ouverture + mise à jour temps réel via le hub.

Tests : 6 tests TradeService (proposition, non-membre, self, réponse, autorisation).
Vérifié : build Release /warnaserror OK, dotnet test = 77/77 verts.