### PR TITLE
feat(achievements): attribution automatique des succès + affichage pr…

### DIFF
--- a/Cdm/Cdm.ApiService/Hubs/SessionHub.cs
+++ b/Cdm/Cdm.ApiService/Hubs/SessionHub.cs
@@ -24,6 +24,7 @@ public class SessionHub : Hub
     private readonly ILogger<SessionHub> logger;
     private readonly AppDbContext db;
     private readonly ITradeService tradeService;
+    private readonly IAchievementEvaluationService achievementEvaluation;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SessionHub"/> class.
@@ -31,11 +32,13 @@ public class SessionHub : Hub
     /// <param name="logger">Logger instance.</param>
     /// <param name="db">Database context.</param>
     /// <param name="tradeService">Trade service for object-exchange proposals.</param>
-    public SessionHub(ILogger<SessionHub> logger, AppDbContext db, ITradeService tradeService)
+    /// <param name="achievementEvaluation">Evaluator that awards automatic achievements.</param>
+    public SessionHub(ILogger<SessionHub> logger, AppDbContext db, ITradeService tradeService, IAchievementEvaluationService achievementEvaluation)
     {
         this.logger = logger;
         this.db = db;
         this.tradeService = tradeService;
+        this.achievementEvaluation = achievementEvaluation;
     }
 
     /// <summary>
@@ -180,6 +183,9 @@ public class SessionHub : Hub
         };
         this.db.SessionDiceRolls.Add(diceRoll);
         await this.db.SaveChangesAsync();
+
+        // Award any automatic achievement whose condition this roll satisfies (crit, fumble, dice count).
+        await this.achievementEvaluation.OnDiceRolledAsync(userId, sessionId, diceType, results);
 
         await this.Clients.Group(groupName).SendAsync(
             "DiceRolled",

--- a/Cdm/Cdm.ApiService/Program.cs
+++ b/Cdm/Cdm.ApiService/Program.cs
@@ -164,6 +164,7 @@ builder.Services.AddScoped<IWorldService, WorldService>();
 builder.Services.AddScoped<IChapterService, ChapterService>();
 builder.Services.AddScoped<IEventService, EventService>();
 builder.Services.AddScoped<IAchievementService, AchievementService>();
+builder.Services.AddScoped<IAchievementEvaluationService, AchievementEvaluationService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<ISessionService, SessionService>();
 builder.Services.AddScoped<ITradeService, TradeService>();

--- a/Cdm/Cdm.Business.Abstraction/Services/IAchievementEvaluationService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/IAchievementEvaluationService.cs
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="IAchievementEvaluationService.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.Services;
+
+using System.Threading.Tasks;
+
+/// <summary>
+/// Evaluates automatic achievement conditions when gameplay events occur and
+/// awards any matching, not-yet-unlocked achievements in scope. All methods are
+/// best-effort: a failure to evaluate must never break the triggering action.
+/// </summary>
+public interface IAchievementEvaluationService
+{
+    /// <summary>
+    /// Evaluates dice-related conditions after a player shares a roll in a session
+    /// (critical / fumble on a d20, and cumulative dice count).
+    /// </summary>
+    /// <param name="userId">The rolling user.</param>
+    /// <param name="sessionId">The session the roll happened in.</param>
+    /// <param name="diceType">The dice type (e.g. "D20").</param>
+    /// <param name="results">The individual die results.</param>
+    Task OnDiceRolledAsync(int userId, int sessionId, string diceType, int[] results);
+
+    /// <summary>
+    /// Evaluates session-attendance conditions when a player joins a session.
+    /// </summary>
+    /// <param name="userId">The joining user.</param>
+    /// <param name="sessionId">The session joined.</param>
+    Task OnSessionAttendedAsync(int userId, int sessionId);
+
+    /// <summary>
+    /// Evaluates trade conditions when an object trade is accepted.
+    /// </summary>
+    /// <param name="userId">A user party to the accepted trade.</param>
+    /// <param name="sessionId">The session the trade belongs to.</param>
+    Task OnTradeAcceptedAsync(int userId, int sessionId);
+
+    /// <summary>
+    /// Evaluates combat conditions when a combat ends (won / survived), for every
+    /// player that took part in it.
+    /// </summary>
+    /// <param name="combatId">The combat that just ended.</param>
+    Task OnCombatEndedAsync(int combatId);
+}

--- a/Cdm/Cdm.Business.Common.Tests/Services/AchievementEvaluationServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/AchievementEvaluationServiceTests.cs
@@ -1,0 +1,179 @@
+// -----------------------------------------------------------------------
+// <copyright file="AchievementEvaluationServiceTests.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Tests.Services;
+
+using Cdm.Business.Abstraction.Services;
+using Cdm.Business.Common.Services;
+using Cdm.Common.Enums;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="AchievementEvaluationService"/>.
+/// </summary>
+public class AchievementEvaluationServiceTests
+{
+    private readonly Mock<INotificationService> notificationServiceMock = new();
+    private readonly Mock<ILogger<AchievementEvaluationService>> loggerMock = new();
+
+    private const int PlayerUserId = 2;
+    private const int WorldId = 1;
+    private const int CampaignId = 5;
+    private const int SessionId = 10;
+
+    private static DbContextOptions<AppDbContext> NewOptions(string name) =>
+        new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase(name).Options;
+
+    private AchievementEvaluationService CreateService(AppDbContext context) =>
+        new(context, this.notificationServiceMock.Object, this.loggerMock.Object);
+
+    /// <summary>
+    /// Seeds a world/campaign/session and one automatic World-level achievement with the given condition.
+    /// </summary>
+    private static async Task<int> SeedAsync(AppDbContext context, string condition)
+    {
+        context.Users.Add(new User { Id = PlayerUserId, Email = "p@test.com", Nickname = "Joueur", PasswordHash = "h", CreatedAt = DateTime.UtcNow });
+        context.Worlds.Add(new World { Id = WorldId, Name = "Monde", GameType = GameType.Generic, UserId = 1, CreatedAt = DateTime.UtcNow });
+        context.Campaigns.Add(new Campaign { Id = CampaignId, Name = "Campagne", WorldId = WorldId, CreatedBy = 1, CreatedAt = DateTime.UtcNow });
+        context.Sessions.Add(new Session { Id = SessionId, CampaignId = CampaignId, StartedById = 1, StartedAt = DateTime.UtcNow });
+
+        var achievement = new Achievement
+        {
+            Id = 50,
+            Name = "Succès auto",
+            Description = "Test",
+            Level = AchievementLevel.World,
+            WorldId = WorldId,
+            Rarity = AchievementRarity.Common,
+            IsActive = true,
+            IsAutomatic = true,
+            AutomaticCondition = condition,
+            CreatedBy = 1,
+            CreatedAt = DateTime.UtcNow
+        };
+        context.Achievements.Add(achievement);
+        await context.SaveChangesAsync();
+        return achievement.Id;
+    }
+
+    /// <summary>
+    /// A natural 20 on a d20 unlocks a DiceCritical automatic achievement.
+    /// </summary>
+    [Fact]
+    public async Task OnDiceRolledAsync_NaturalTwenty_UnlocksCritical()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(OnDiceRolledAsync_NaturalTwenty_UnlocksCritical)));
+        var achievementId = await SeedAsync(context, "DiceCritical");
+        var service = this.CreateService(context);
+
+        await service.OnDiceRolledAsync(PlayerUserId, SessionId, "D20", new[] { 20 });
+
+        var unlocked = await context.UserAchievements.AnyAsync(ua => ua.UserId == PlayerUserId && ua.AchievementId == achievementId);
+        Assert.True(unlocked);
+    }
+
+    /// <summary>
+    /// A roll without a natural 20 does not unlock a DiceCritical achievement.
+    /// </summary>
+    [Fact]
+    public async Task OnDiceRolledAsync_NoTwenty_DoesNotUnlock()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(OnDiceRolledAsync_NoTwenty_DoesNotUnlock)));
+        await SeedAsync(context, "DiceCritical");
+        var service = this.CreateService(context);
+
+        await service.OnDiceRolledAsync(PlayerUserId, SessionId, "D20", new[] { 14 });
+
+        Assert.False(await context.UserAchievements.AnyAsync());
+    }
+
+    /// <summary>
+    /// The critical achievement is only awarded once, even on repeated crits.
+    /// </summary>
+    [Fact]
+    public async Task OnDiceRolledAsync_TwiceCritical_UnlocksOnce()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(OnDiceRolledAsync_TwiceCritical_UnlocksOnce)));
+        var achievementId = await SeedAsync(context, "DiceCritical");
+        var service = this.CreateService(context);
+
+        await service.OnDiceRolledAsync(PlayerUserId, SessionId, "D20", new[] { 20 });
+        await service.OnDiceRolledAsync(PlayerUserId, SessionId, "D20", new[] { 20 });
+
+        var count = await context.UserAchievements.CountAsync(ua => ua.UserId == PlayerUserId && ua.AchievementId == achievementId);
+        Assert.Equal(1, count);
+    }
+
+    /// <summary>
+    /// Attending the first session unlocks a "SessionsAttended:1" achievement.
+    /// </summary>
+    [Fact]
+    public async Task OnSessionAttendedAsync_ThresholdMet_Unlocks()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(OnSessionAttendedAsync_ThresholdMet_Unlocks)));
+        var achievementId = await SeedAsync(context, "SessionsAttended:1");
+
+        // The player must be an actual participant for the attendance count.
+        context.Characters.Add(new Character { Id = 100, UserId = PlayerUserId, Name = "Perso", IsActive = true });
+        context.WorldCharacters.Add(new WorldCharacter { Id = 200, CharacterId = 100, WorldId = WorldId, IsActive = true });
+        context.SessionParticipants.Add(new SessionParticipant { Id = 300, SessionId = SessionId, WorldCharacterId = 200, JoinedAt = DateTime.UtcNow, Status = SessionParticipantStatus.Joined });
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        await service.OnSessionAttendedAsync(PlayerUserId, SessionId);
+
+        Assert.True(await context.UserAchievements.AnyAsync(ua => ua.UserId == PlayerUserId && ua.AchievementId == achievementId));
+    }
+
+    /// <summary>
+    /// A "SessionsAttended:3" achievement stays locked when only one session was attended.
+    /// </summary>
+    [Fact]
+    public async Task OnSessionAttendedAsync_ThresholdNotMet_StaysLocked()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(OnSessionAttendedAsync_ThresholdNotMet_StaysLocked)));
+        await SeedAsync(context, "SessionsAttended:3");
+
+        context.Characters.Add(new Character { Id = 100, UserId = PlayerUserId, Name = "Perso", IsActive = true });
+        context.WorldCharacters.Add(new WorldCharacter { Id = 200, CharacterId = 100, WorldId = WorldId, IsActive = true });
+        context.SessionParticipants.Add(new SessionParticipant { Id = 300, SessionId = SessionId, WorldCharacterId = 200, JoinedAt = DateTime.UtcNow, Status = SessionParticipantStatus.Joined });
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        await service.OnSessionAttendedAsync(PlayerUserId, SessionId);
+
+        Assert.False(await context.UserAchievements.AnyAsync());
+    }
+
+    /// <summary>
+    /// Completing an accepted trade unlocks a "TradesCompleted:1" achievement.
+    /// </summary>
+    [Fact]
+    public async Task OnTradeAcceptedAsync_ThresholdMet_Unlocks()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(OnTradeAcceptedAsync_ThresholdMet_Unlocks)));
+        var achievementId = await SeedAsync(context, "TradesCompleted:1");
+        context.SessionTrades.Add(new SessionTrade
+        {
+            Id = 400, SessionId = SessionId, FromUserId = 1, ToUserId = PlayerUserId,
+            Status = TradeStatus.Accepted, CreatedAt = DateTime.UtcNow, RespondedAt = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        await service.OnTradeAcceptedAsync(PlayerUserId, SessionId);
+
+        Assert.True(await context.UserAchievements.AnyAsync(ua => ua.UserId == PlayerUserId && ua.AchievementId == achievementId));
+    }
+}

--- a/Cdm/Cdm.Business.Common.Tests/Services/SessionServiceHistoryTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/SessionServiceHistoryTests.cs
@@ -22,6 +22,7 @@ public class SessionServiceHistoryTests
 {
     private readonly Mock<ILogger<SessionService>> loggerMock = new();
     private readonly Mock<INotificationService> notificationServiceMock = new();
+    private readonly Mock<IAchievementEvaluationService> achievementEvaluationMock = new();
 
     private static DbContextOptions<AppDbContext> NewOptions(string name) =>
         new DbContextOptionsBuilder<AppDbContext>()
@@ -29,7 +30,7 @@ public class SessionServiceHistoryTests
             .Options;
 
     private SessionService CreateService(AppDbContext context) =>
-        new(context, this.loggerMock.Object, this.notificationServiceMock.Object);
+        new(context, this.loggerMock.Object, this.notificationServiceMock.Object, this.achievementEvaluationMock.Object);
 
     /// <summary>
     /// The GM of a session gets its chat and dice history, merged and ordered chronologically,

--- a/Cdm/Cdm.Business.Common.Tests/Services/TradeServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/TradeServiceTests.cs
@@ -22,6 +22,7 @@ using Xunit;
 public class TradeServiceTests
 {
     private readonly Mock<INotificationService> notificationServiceMock = new();
+    private readonly Mock<IAchievementEvaluationService> achievementEvaluationMock = new();
     private readonly Mock<ILogger<TradeService>> loggerMock = new();
 
     private const int GmUserId = 1;
@@ -33,7 +34,7 @@ public class TradeServiceTests
             .Options;
 
     private TradeService CreateService(AppDbContext context) =>
-        new(context, this.notificationServiceMock.Object, this.loggerMock.Object);
+        new(context, this.notificationServiceMock.Object, this.achievementEvaluationMock.Object, this.loggerMock.Object);
 
     /// <summary>
     /// Seeds a session (GM = user 1) with one joined participant (player = user 2).

--- a/Cdm/Cdm.Business.Common/Services/AchievementCondition.cs
+++ b/Cdm/Cdm.Business.Common/Services/AchievementCondition.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="AchievementCondition.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Services;
+
+using Cdm.Common.Enums;
+
+/// <summary>
+/// Parsed representation of an achievement's automatic condition, stored on
+/// <c>Achievement.AutomaticCondition</c> as <c>"Type"</c> or <c>"Type:Threshold"</c>.
+/// </summary>
+public readonly record struct AchievementCondition(AchievementConditionType Type, int Threshold)
+{
+    /// <summary>
+    /// Parses a stored condition code (e.g. <c>"SessionsAttended:5"</c> or <c>"DiceCritical"</c>).
+    /// A missing or invalid threshold defaults to 1.
+    /// </summary>
+    /// <param name="raw">The stored condition string.</param>
+    /// <param name="condition">The parsed condition when successful.</param>
+    /// <returns><c>true</c> if the code was recognised.</returns>
+    public static bool TryParse(string? raw, out AchievementCondition condition)
+    {
+        condition = default;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        var parts = raw.Split(':', 2);
+        if (!Enum.TryParse<AchievementConditionType>(parts[0].Trim(), ignoreCase: true, out var type))
+        {
+            return false;
+        }
+
+        var threshold = 1;
+        if (parts.Length == 2 && int.TryParse(parts[1].Trim(), out var parsed) && parsed > 0)
+        {
+            threshold = parsed;
+        }
+
+        condition = new AchievementCondition(type, threshold);
+        return true;
+    }
+}

--- a/Cdm/Cdm.Business.Common/Services/AchievementEvaluationService.cs
+++ b/Cdm/Cdm.Business.Common/Services/AchievementEvaluationService.cs
@@ -1,0 +1,264 @@
+// -----------------------------------------------------------------------
+// <copyright file="AchievementEvaluationService.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Services;
+
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.Services;
+using Cdm.Common.Enums;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Evaluates and awards automatic achievements. Every entry point is best-effort:
+/// exceptions are logged and swallowed so gameplay actions are never broken by
+/// achievement evaluation.
+/// </summary>
+public class AchievementEvaluationService(
+    AppDbContext dbContext,
+    INotificationService notificationService,
+    ILogger<AchievementEvaluationService> logger) : IAchievementEvaluationService
+{
+    private const int CombatEndedStatus = 3;
+
+    private readonly AppDbContext dbContext = dbContext;
+    private readonly INotificationService notificationService = notificationService;
+    private readonly ILogger<AchievementEvaluationService> logger = logger;
+
+    /// <inheritdoc/>
+    public async Task OnDiceRolledAsync(int userId, int sessionId, string diceType, int[] results)
+    {
+        try
+        {
+            var scope = await this.ResolveSessionScopeAsync(sessionId);
+            if (scope is null)
+            {
+                return;
+            }
+
+            var isD20 = string.Equals(diceType?.TrimStart('d', 'D'), "20", StringComparison.OrdinalIgnoreCase);
+            if (isD20 && results.Contains(20))
+            {
+                await this.AwardMatchingAsync(userId, scope.Value, AchievementConditionType.DiceCritical, currentStat: 1);
+            }
+
+            if (isD20 && results.Contains(1))
+            {
+                await this.AwardMatchingAsync(userId, scope.Value, AchievementConditionType.DiceFumble, currentStat: 1);
+            }
+
+            var totalDice = await this.dbContext.SessionDiceRolls
+                .Where(d => d.UserId == userId)
+                .SumAsync(d => d.Count);
+
+            await this.AwardMatchingAsync(userId, scope.Value, AchievementConditionType.DiceRolls, totalDice);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Achievement evaluation failed after a dice roll (user {UserId}, session {SessionId})", userId, sessionId);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task OnSessionAttendedAsync(int userId, int sessionId)
+    {
+        try
+        {
+            var scope = await this.ResolveSessionScopeAsync(sessionId);
+            if (scope is null)
+            {
+                return;
+            }
+
+            var sessionsAttended = await this.dbContext.SessionParticipants
+                .Where(p => p.WorldCharacter.Character.UserId == userId)
+                .Select(p => p.SessionId)
+                .Distinct()
+                .CountAsync();
+
+            await this.AwardMatchingAsync(userId, scope.Value, AchievementConditionType.SessionsAttended, sessionsAttended);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Achievement evaluation failed after session attendance (user {UserId}, session {SessionId})", userId, sessionId);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task OnTradeAcceptedAsync(int userId, int sessionId)
+    {
+        try
+        {
+            var scope = await this.ResolveSessionScopeAsync(sessionId);
+            if (scope is null)
+            {
+                return;
+            }
+
+            var tradesCompleted = await this.dbContext.SessionTrades
+                .Where(t => t.Status == TradeStatus.Accepted && (t.FromUserId == userId || t.ToUserId == userId))
+                .CountAsync();
+
+            await this.AwardMatchingAsync(userId, scope.Value, AchievementConditionType.TradesCompleted, tradesCompleted);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Achievement evaluation failed after a trade (user {UserId}, session {SessionId})", userId, sessionId);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task OnCombatEndedAsync(int combatId)
+    {
+        try
+        {
+            var combat = await this.dbContext.Combats
+                .Include(c => c.Groups)
+                    .ThenInclude(g => g.Participants)
+                .FirstOrDefaultAsync(c => c.Id == combatId);
+
+            if (combat is null)
+            {
+                return;
+            }
+
+            var scope = await this.ResolveSessionScopeAsync(combat.SessionId, combat.ChapterId);
+            if (scope is null)
+            {
+                return;
+            }
+
+            var participants = combat.Groups.SelectMany(g => g.Participants).ToList();
+            var playerUserIds = participants
+                .Where(p => p.IsPlayerCharacter && p.UserId.HasValue)
+                .Select(p => p.UserId!.Value)
+                .Distinct()
+                .ToList();
+
+            foreach (var userId in playerUserIds)
+            {
+                var survivedThisCombat = participants.Any(p => p.UserId == userId && p.CurrentHp > 0);
+                if (!survivedThisCombat)
+                {
+                    continue;
+                }
+
+                var survivedCount = await this.CountSurvivedCombatsAsync(userId);
+                await this.AwardMatchingAsync(userId, scope.Value, AchievementConditionType.CombatSurvived, survivedCount);
+
+                var wonThisCombat = !string.IsNullOrWhiteSpace(combat.VictorySide)
+                    && combat.Groups.Any(g => g.Name == combat.VictorySide && g.Participants.Any(p => p.UserId == userId && p.CurrentHp > 0));
+
+                if (wonThisCombat)
+                {
+                    var wonCount = await this.CountWonCombatsAsync(userId);
+                    await this.AwardMatchingAsync(userId, scope.Value, AchievementConditionType.CombatWon, wonCount);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Achievement evaluation failed after combat {CombatId} ended", combatId);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the (world, campaign, chapter) scope a session belongs to.
+    /// </summary>
+    private async Task<Scope?> ResolveSessionScopeAsync(int sessionId, int? explicitChapterId = null)
+    {
+        var session = await this.dbContext.Sessions
+            .AsNoTracking()
+            .Include(s => s.Campaign)
+            .FirstOrDefaultAsync(s => s.Id == sessionId);
+
+        if (session?.Campaign is null)
+        {
+            return null;
+        }
+
+        return new Scope(session.Campaign.WorldId, session.CampaignId, explicitChapterId ?? session.CurrentChapterId);
+    }
+
+    private async Task<int> CountSurvivedCombatsAsync(int userId) =>
+        await this.dbContext.CombatParticipants
+            .Where(p => p.UserId == userId && p.CurrentHp > 0 && p.Combat.Status == CombatEndedStatus)
+            .Select(p => p.CombatId)
+            .Distinct()
+            .CountAsync();
+
+    private async Task<int> CountWonCombatsAsync(int userId) =>
+        await this.dbContext.CombatParticipants
+            .Where(p => p.UserId == userId
+                && p.CurrentHp > 0
+                && p.Combat.Status == CombatEndedStatus
+                && p.Combat.VictorySide != null
+                && p.Group.Name == p.Combat.VictorySide)
+            .Select(p => p.CombatId)
+            .Distinct()
+            .CountAsync();
+
+    /// <summary>
+    /// Awards every active automatic achievement in the given scope that matches the
+    /// condition type, whose threshold is met, and that the user has not yet unlocked.
+    /// </summary>
+    private async Task AwardMatchingAsync(int userId, Scope scope, AchievementConditionType type, int currentStat)
+    {
+        var candidates = await this.dbContext.Achievements
+            .Where(a => a.IsActive && a.IsAutomatic && a.AutomaticCondition != null
+                && ((a.Level == AchievementLevel.World && a.WorldId == scope.WorldId)
+                    || (a.Level == AchievementLevel.Campaign && a.CampaignId == scope.CampaignId)
+                    || (a.Level == AchievementLevel.Chapter && scope.ChapterId != null && a.ChapterId == scope.ChapterId)))
+            .ToListAsync();
+
+        foreach (var achievement in candidates)
+        {
+            if (!AchievementCondition.TryParse(achievement.AutomaticCondition, out var condition) || condition.Type != type)
+            {
+                continue;
+            }
+
+            if (currentStat < condition.Threshold)
+            {
+                continue;
+            }
+
+            var alreadyUnlocked = await this.dbContext.UserAchievements
+                .AnyAsync(ua => ua.UserId == userId && ua.AchievementId == achievement.Id);
+            if (alreadyUnlocked)
+            {
+                continue;
+            }
+
+            this.dbContext.UserAchievements.Add(new UserAchievement
+            {
+                UserId = userId,
+                AchievementId = achievement.Id,
+                UnlockedAt = DateTime.UtcNow,
+                IsManuallyAwarded = false
+            });
+            await this.dbContext.SaveChangesAsync();
+
+            await this.notificationService.CreateNotificationAsync(new CreateNotificationDto
+            {
+                UserId = userId,
+                Type = NotificationType.AchievementUnlocked,
+                Title = "Succès débloqué !",
+                Message = $"Vous avez débloqué le succès « {achievement.Name} ».",
+                RelatedEntityId = achievement.Id,
+                RelatedEntityType = "Achievement"
+            });
+
+            this.logger.LogInformation(
+                "Automatic achievement {AchievementId} unlocked for user {UserId} (condition {Condition})",
+                achievement.Id, userId, achievement.AutomaticCondition);
+        }
+    }
+
+    private readonly record struct Scope(int WorldId, int CampaignId, int? ChapterId);
+}

--- a/Cdm/Cdm.Business.Common/Services/CombatService.cs
+++ b/Cdm/Cdm.Business.Common/Services/CombatService.cs
@@ -20,8 +20,11 @@ using Microsoft.Extensions.Logging;
 /// <param name="logger">Logger instance.</param>
 public class CombatService(
     AppDbContext dbContext,
+    IAchievementEvaluationService achievementEvaluation,
     ILogger<CombatService> logger) : ICombatService
 {
+    private readonly IAchievementEvaluationService achievementEvaluation = achievementEvaluation;
+
     private readonly AppDbContext dbContext = dbContext;
     private readonly ILogger<CombatService> logger = logger;
 
@@ -494,6 +497,9 @@ public class CombatService(
                 "Combat {CombatId} ended. Victory: {VictorySide}",
                 combatId,
                 request.VictorySide ?? "none");
+
+            // Award any automatic achievement based on combat outcome (won / survived).
+            await this.achievementEvaluation.OnCombatEndedAsync(combatId);
 
             return await this.LoadCombatDtoAsync(combatId);
         }

--- a/Cdm/Cdm.Business.Common/Services/SessionService.cs
+++ b/Cdm/Cdm.Business.Common/Services/SessionService.cs
@@ -17,11 +17,12 @@ using Microsoft.Extensions.Logging;
 /// <summary>
 /// Service for managing game sessions.
 /// </summary>
-public class SessionService(AppDbContext dbContext, ILogger<SessionService> logger, INotificationService notificationService) : ISessionService
+public class SessionService(AppDbContext dbContext, ILogger<SessionService> logger, INotificationService notificationService, IAchievementEvaluationService achievementEvaluation) : ISessionService
 {
     private readonly AppDbContext dbContext = dbContext;
     private readonly ILogger<SessionService> logger = logger;
     private readonly INotificationService notificationService = notificationService;
+    private readonly IAchievementEvaluationService achievementEvaluation = achievementEvaluation;
 
     /// <inheritdoc/>
     public async Task<SessionDto?> StartSessionAsync(StartSessionDto dto, int userId)
@@ -291,6 +292,9 @@ public class SessionService(AppDbContext dbContext, ILogger<SessionService> logg
 
             participant.Status = SessionParticipantStatus.Joined;
             await this.dbContext.SaveChangesAsync();
+
+            // Award any automatic achievement based on session attendance.
+            await this.achievementEvaluation.OnSessionAttendedAsync(userId, sessionId);
 
             return await this.BuildSessionDtoAsync(sessionId);
         }

--- a/Cdm/Cdm.Business.Common/Services/TradeService.cs
+++ b/Cdm/Cdm.Business.Common/Services/TradeService.cs
@@ -20,10 +20,12 @@ using Microsoft.Extensions.Logging;
 public class TradeService(
     AppDbContext dbContext,
     INotificationService notificationService,
+    IAchievementEvaluationService achievementEvaluation,
     ILogger<TradeService> logger) : ITradeService
 {
     private readonly AppDbContext dbContext = dbContext;
     private readonly INotificationService notificationService = notificationService;
+    private readonly IAchievementEvaluationService achievementEvaluation = achievementEvaluation;
     private readonly ILogger<TradeService> logger = logger;
 
     /// <inheritdoc/>
@@ -116,6 +118,13 @@ public class TradeService(
             trade.Status = accept ? TradeStatus.Accepted : TradeStatus.Declined;
             trade.RespondedAt = DateTime.UtcNow;
             await this.dbContext.SaveChangesAsync();
+
+            // An accepted trade may unlock trade-based automatic achievements for both parties.
+            if (accept)
+            {
+                await this.achievementEvaluation.OnTradeAcceptedAsync(trade.FromUserId, trade.SessionId);
+                await this.achievementEvaluation.OnTradeAcceptedAsync(trade.ToUserId, trade.SessionId);
+            }
 
             await this.notificationService.CreateNotificationAsync(new CreateNotificationDto
             {

--- a/Cdm/Cdm.Common/Enums/AchievementConditionType.cs
+++ b/Cdm/Cdm.Common/Enums/AchievementConditionType.cs
@@ -1,0 +1,31 @@
+namespace Cdm.Common.Enums;
+
+/// <summary>
+/// The set of conditions that can automatically unlock an achievement.
+/// Stored on <c>Achievement.AutomaticCondition</c> as a code, optionally suffixed
+/// with a threshold (e.g. <c>"SessionsAttended:5"</c>). Conditions without a natural
+/// threshold (a critical hit) ignore the suffix.
+/// </summary>
+public enum AchievementConditionType
+{
+    /// <summary>Rolled a natural 20 on a d20 during a session.</summary>
+    DiceCritical = 0,
+
+    /// <summary>Rolled a natural 1 on a d20 during a session.</summary>
+    DiceFumble = 1,
+
+    /// <summary>Rolled at least N dice in total across all sessions (threshold).</summary>
+    DiceRolls = 2,
+
+    /// <summary>Participated in at least N sessions (threshold; N = 1 means first session).</summary>
+    SessionsAttended = 3,
+
+    /// <summary>Won at least N combats (threshold).</summary>
+    CombatWon = 4,
+
+    /// <summary>Survived at least N combats (threshold).</summary>
+    CombatSurvived = 5,
+
+    /// <summary>Completed at least N accepted object trades (threshold).</summary>
+    TradesCompleted = 6
+}

--- a/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor
@@ -74,5 +74,50 @@ else
                 </div>
             </EditForm>
         </div>
+
+        <!-- Succès -->
+        <div class="cdm-card">
+            <h3 class="card-title" style="margin-bottom: var(--spacing-lg);">
+                <i class="bi bi-trophy"></i> Mes succès
+                @if (MyAchievements.Count > 0)
+                {
+                    <span class="status-badge" style="margin-left: var(--spacing-sm);">@MyAchievements.Count</span>
+                }
+            </h3>
+
+            @if (MyAchievements.Count == 0)
+            {
+                <p style="color: var(--color-text-muted); font-style: italic;">
+                    Aucun succès débloqué pour l'instant. Participez à des sessions pour en gagner !
+                </p>
+            }
+            else
+            {
+                <div style="display: flex; flex-direction: column; gap: var(--spacing-sm);">
+                    @foreach (var ua in MyAchievements.OrderByDescending(a => a.UnlockedAt))
+                    {
+                        <div class="cdm-card" style="border-left: 3px solid @RarityColor(ua.Rarity); padding: var(--spacing-sm);">
+                            <div style="display: flex; align-items: center; gap: var(--spacing-sm);">
+                                <i class="bi bi-trophy-fill" style="color: @RarityColor(ua.Rarity); font-size: 1.4rem;"></i>
+                                <div style="flex: 1;">
+                                    <div style="display: flex; align-items: center; gap: var(--spacing-xs);">
+                                        <strong>@ua.AchievementName</strong>
+                                        <span class="status-badge">@RarityLabel(ua.Rarity)</span>
+                                        @if (!ua.IsManuallyAwarded)
+                                        {
+                                            <span class="status-badge" title="Débloqué automatiquement"><i class="bi bi-magic"></i></span>
+                                        }
+                                    </div>
+                                    <div style="font-size: var(--font-size-sm); color: var(--color-text-muted);">@ua.AchievementDescription</div>
+                                    <div style="font-size: var(--font-size-xs); color: var(--color-text-muted);">
+                                        Débloqué le @ua.UnlockedAt.ToLocalTime().ToString("dd/MM/yyyy")
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
+        </div>
     </div>
 }

--- a/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor.cs
@@ -1,7 +1,9 @@
+using Cdm.Business.Abstraction.DTOs;
 using Cdm.Business.Abstraction.DTOs.Models;
 using Cdm.Business.Abstraction.DTOs.ViewModels;
 using Cdm.Web.Resources;
 using Cdm.Web.Services;
+using Cdm.Web.Services.ApiClients;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.Localization;
@@ -11,11 +13,13 @@ namespace Cdm.Web.Components.Pages.Profile;
 public partial class Profile
 {
     [Inject] private ProfileApiClient ProfileClient { get; set; } = default!;
+    [Inject] private AchievementApiClient AchievementClient { get; set; } = default!;
     [Inject] private AuthenticationStateProvider AuthProvider { get; set; } = default!;
     [Inject] private IStringLocalizer<AppStrings> L { get; set; } = default!;
 
     private ProfileResponse? UserProfile;
     private UpdateProfileRequest UpdateModel { get; set; } = new();
+    private List<UserAchievementDto> MyAchievements { get; set; } = new();
     private bool IsLoading = true;
     private bool IsSaving = false;
     private string ErrorMessage = string.Empty;
@@ -39,6 +43,8 @@ public partial class Profile
             {
                 UpdateModel = new UpdateProfileRequest { Username = UserProfile.Username };
             }
+
+            MyAchievements = await AchievementClient.GetMyAchievementsAsync();
         }
         catch { /* ignore */ }
         finally
@@ -74,6 +80,22 @@ public partial class Profile
             IsSaving = false;
         }
     }
+
+    private static string RarityLabel(Cdm.Common.Enums.AchievementRarity rarity) => rarity switch
+    {
+        Cdm.Common.Enums.AchievementRarity.Rare => "Rare",
+        Cdm.Common.Enums.AchievementRarity.Epic => "Épique",
+        Cdm.Common.Enums.AchievementRarity.Legendary => "Légendaire",
+        _ => "Commun"
+    };
+
+    private static string RarityColor(Cdm.Common.Enums.AchievementRarity rarity) => rarity switch
+    {
+        Cdm.Common.Enums.AchievementRarity.Rare => "#3b82f6",
+        Cdm.Common.Enums.AchievementRarity.Epic => "#a855f7",
+        Cdm.Common.Enums.AchievementRarity.Legendary => "#f59e0b",
+        _ => "#9ca3af"
+    };
 
     private static string BuildInitials(string name)
     {

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/WorldDetail.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/WorldDetail.razor
@@ -1190,6 +1190,44 @@ else
                         <label class="form-label">Récompense (optionnel)</label>
                         <input type="text" class="form-control" @bind="NewAchievement.RewardDescription" placeholder="Description de la récompense..." />
                     </div>
+                    <div class="form-row" style="display: flex; gap: var(--spacing-sm); margin-bottom: var(--spacing-sm);">
+                        <div class="form-group" style="flex: 1;">
+                            <label class="form-label">Attribution</label>
+                            <select class="form-control" @bind="NewAchievement.IsAutomatic">
+                                <option value="false">Manuelle (le MJ décerne)</option>
+                                <option value="true">Automatique (condition)</option>
+                            </select>
+                        </div>
+                        @if (NewAchievement.IsAutomatic)
+                        {
+                            <div class="form-group" style="flex: 1;">
+                                <label class="form-label">Condition automatique</label>
+                                <select class="form-control" @bind="NewAchievement.AutomaticCondition">
+                                    <option value="">— Choisir une condition —</option>
+                                    <optgroup label="Dés">
+                                        <option value="DiceCritical">Réussite critique (20 naturel)</option>
+                                        <option value="DiceFumble">Échec critique (1 naturel)</option>
+                                        <option value="DiceRolls:50">Lancer 50 dés au total</option>
+                                        <option value="DiceRolls:200">Lancer 200 dés au total</option>
+                                    </optgroup>
+                                    <optgroup label="Sessions">
+                                        <option value="SessionsAttended:1">Participer à sa 1re session</option>
+                                        <option value="SessionsAttended:5">Participer à 5 sessions</option>
+                                        <option value="SessionsAttended:10">Participer à 10 sessions</option>
+                                    </optgroup>
+                                    <optgroup label="Combat">
+                                        <option value="CombatWon:1">Remporter un 1er combat</option>
+                                        <option value="CombatWon:5">Remporter 5 combats</option>
+                                        <option value="CombatSurvived:5">Survivre à 5 combats</option>
+                                    </optgroup>
+                                    <optgroup label="Échanges">
+                                        <option value="TradesCompleted:1">Réaliser un 1er échange</option>
+                                        <option value="TradesCompleted:10">Réaliser 10 échanges</option>
+                                    </optgroup>
+                                </select>
+                            </div>
+                        }
+                    </div>
                     <div style="display: flex; gap: var(--spacing-sm);">
                         <button class="btn btn-primary btn-sm" @onclick="CreateAchievement" disabled="@IsSaving">
                             <i class="bi bi-check"></i> Créer


### PR DESCRIPTION
…ofil

Implémente le déclenchement des succès par conditions (jusque-là AutomaticCondition était stocké mais jamais évalué) et l'affichage des succès dans le profil joueur.

Moteur :
- Enum AchievementConditionType + parseur AchievementCondition ("Type" ou "Type:seuil").
- AchievementEvaluationService : résout le périmètre (session→campagne→monde), calcule les stats cumulées et décerne les succès automatiques non encore débloqués (best-effort : n'interrompt jamais l'action déclenchante).

Déclencheurs câblés :
- Dés (SessionHub.RollDice)   : critique 20, échec 1, N dés lancés.
- Sessions (SessionService)   : participation à N sessions.
- Échanges (TradeService)     : N échanges acceptés (les deux parties).
- Combat (CombatService)      : combats remportés / survécus.

UI :
- Formulaire de création (WorldDetail) : choix Manuel/Automatique + liste déroulante de conditions (dés, sessions, combat, échanges).
- Profil : nouvelle carte « Mes succès » (rareté, date, badge auto).

Tests : 6 tests du moteur (crit, seuils, dédup, sessions, échanges).
Vérifié : build Release /warnaserror OK, dotnet test = 83/83 verts.