### PR TITLE
feat(dnd): branche la fiche D&D au lanceur de dés en session

### DIFF
--- a/Cdm/Cdm.Common.Tests/DiceNotationTests.cs
+++ b/Cdm/Cdm.Common.Tests/DiceNotationTests.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="DiceNotationTests.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Common.Tests;
+
+using Cdm.Common;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="DiceNotation"/>.
+/// </summary>
+public class DiceNotationTests
+{
+    [Theory]
+    [InlineData("1d8", 1, 8, 0)]
+    [InlineData("2d6", 2, 6, 0)]
+    [InlineData("2d6+3", 2, 6, 3)]
+    [InlineData("1d10-1", 1, 10, -1)]
+    [InlineData(" 3 D 4 + 2 ", 3, 4, 2)]
+    public void TryParse_ValidNotation_ReturnsExpression(string notation, int count, int faces, int bonus)
+    {
+        var ok = DiceNotation.TryParse(notation, out var expr);
+
+        Assert.True(ok);
+        Assert.Equal(count, expr.Count);
+        Assert.Equal(faces, expr.Faces);
+        Assert.Equal(bonus, expr.FlatBonus);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("d20")]
+    [InlineData("0d6")]
+    [InlineData("1d0")]
+    [InlineData("1d6+")]
+    public void TryParse_InvalidNotation_ReturnsFalse(string? notation)
+    {
+        var ok = DiceNotation.TryParse(notation, out _);
+        Assert.False(ok);
+    }
+}

--- a/Cdm/Cdm.Common/DiceNotation.cs
+++ b/Cdm/Cdm.Common/DiceNotation.cs
@@ -1,0 +1,65 @@
+// -----------------------------------------------------------------------
+// <copyright file="DiceNotation.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Common;
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Parses standard dice-damage notation such as <c>"1d8"</c>, <c>"2d6+3"</c> or <c>"1d10-1"</c>.
+/// </summary>
+public static partial class DiceNotation
+{
+    /// <summary>
+    /// A parsed dice expression.
+    /// </summary>
+    /// <param name="Count">Number of dice.</param>
+    /// <param name="Faces">Number of faces per die.</param>
+    /// <param name="FlatBonus">Flat modifier baked into the notation (may be negative or zero).</param>
+    public readonly record struct DiceExpression(int Count, int Faces, int FlatBonus);
+
+    [GeneratedRegex(@"^\s*(\d+)\s*[dD]\s*(\d+)\s*([+-]\s*\d+)?\s*$")]
+    private static partial Regex DicePattern();
+
+    /// <summary>
+    /// Attempts to parse a dice-notation string (e.g. <c>"2d6+3"</c>).
+    /// </summary>
+    /// <param name="notation">The notation to parse.</param>
+    /// <param name="expression">The parsed expression when successful.</param>
+    /// <returns><c>true</c> if the notation was valid.</returns>
+    public static bool TryParse(string? notation, out DiceExpression expression)
+    {
+        expression = default;
+        if (string.IsNullOrWhiteSpace(notation))
+        {
+            return false;
+        }
+
+        var match = DicePattern().Match(notation);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var count = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+        var faces = int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
+        if (count <= 0 || faces <= 0)
+        {
+            return false;
+        }
+
+        var flatBonus = 0;
+        if (match.Groups[3].Success)
+        {
+            var raw = match.Groups[3].Value.Replace(" ", string.Empty);
+            flatBonus = int.Parse(raw, CultureInfo.InvariantCulture);
+        }
+
+        expression = new DiceExpression(count, faces, flatBonus);
+        return true;
+    }
+}

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor
@@ -292,10 +292,15 @@ else if (Session != null)
                                 }
                                 else if (entry.Type == "dice" && entry.Results != null)
                                 {
+                                    @if (!string.IsNullOrWhiteSpace(entry.Reason))
+                                    {
+                                        <span class="chat-entry-text" style="font-weight: 600;">@entry.Reason</span>
+                                    }
                                     <div class="chat-entry-dice">
-                                        <span class="chat-dice-type">@entry.DiceType</span>
+                                        <span class="chat-dice-type">@(entry.Modifier != 0 ? $"{entry.Results.Length}{entry.DiceType}{(entry.Modifier > 0 ? $"+{entry.Modifier}" : entry.Modifier.ToString())}" : entry.DiceType)</span>
                                         <span>→</span>
                                         <span class="chat-dice-result">@string.Join(", ", entry.Results)</span>
+                                        <span style="color: var(--color-text-muted); font-size: var(--font-size-xs);">(Total: @(entry.Results.Sum() + entry.Modifier))</span>
                                     </div>
                                 }
                             </div>

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor.cs
@@ -128,7 +128,7 @@ public partial class SessionGm : IAsyncDisposable
         foreach (var m in history.Messages)
             entries.Add(new ChatEntry("text", m.UserName, m.Message, null, null, m.SentAt));
         foreach (var d in history.DiceRolls)
-            entries.Add(new ChatEntry("dice", d.UserName, null, d.DiceType, d.Results, d.RolledAt));
+            entries.Add(new ChatEntry("dice", d.UserName, null, d.DiceType, d.Results, d.RolledAt, d.Reason, d.Modifier));
 
         ChatEntries = entries.OrderBy(e => e.Timestamp).ToList();
     }
@@ -156,7 +156,7 @@ public partial class SessionGm : IAsyncDisposable
 
         _hub.On<HubDiceDto>("DiceRolled", dto =>
         {
-            ChatEntries.Add(new ChatEntry("dice", dto.UserName ?? "?", null, dto.DiceType, dto.Results, dto.Timestamp));
+            ChatEntries.Add(new ChatEntry("dice", dto.UserName ?? "?", null, dto.DiceType, dto.Results, dto.Timestamp, dto.Reason, dto.Modifier));
             InvokeAsync(StateHasChanged);
         });
 
@@ -450,7 +450,7 @@ public partial class SessionGm : IAsyncDisposable
             await _hub.DisposeAsync();
     }
 
-    private record ChatEntry(string Type, string UserName, string? Text, string? DiceType, int[]? Results, DateTime Timestamp);
+    private record ChatEntry(string Type, string UserName, string? Text, string? DiceType, int[]? Results, DateTime Timestamp, string? Reason = null, int Modifier = 0);
     private record HubMessageDto(int UserId, string? UserName, string? Message, DateTime Timestamp);
     private record HubDiceDto(int UserId, string? UserName, string? DiceType, int Count, int[]? Results, int Modifier, int Total, string? Reason, DateTime Timestamp);
 }

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor
@@ -249,14 +249,15 @@ else if (Session != null)
                                 }
                                 else if (entry.Type == "dice" && entry.Results != null)
                                 {
+                                    @if (!string.IsNullOrWhiteSpace(entry.Reason))
+                                    {
+                                        <span class="chat-entry-text" style="font-weight: 600;">@entry.Reason</span>
+                                    }
                                     <div class="chat-entry-dice">
-                                        <span class="chat-dice-type">@entry.DiceType</span>
+                                        <span class="chat-dice-type">@(entry.Modifier != 0 ? $"{entry.Results.Length}{entry.DiceType}{(entry.Modifier > 0 ? $"+{entry.Modifier}" : entry.Modifier.ToString())}" : entry.DiceType)</span>
                                         <span>→</span>
                                         <span class="chat-dice-result">@string.Join(", ", entry.Results)</span>
-                                        @if (entry.Results.Length > 1)
-                                        {
-                                            <span style="color: var(--color-text-muted); font-size: var(--font-size-xs);">(Total: @entry.Results.Sum())</span>
-                                        }
+                                        <span style="color: var(--color-text-muted); font-size: var(--font-size-xs);">(Total: @(entry.Results.Sum() + entry.Modifier))</span>
                                     </div>
                                 }
                             </div>
@@ -292,6 +293,45 @@ else if (Session != null)
                             </button>
                         }
                     </div>
+
+                    @if (IsDndCharacter && (Weapons.Count > 0 || DamageSpells.Count > 0))
+                    {
+                        <div style="margin-top: var(--spacing-sm); border-top: 1px solid var(--color-border); padding-top: var(--spacing-sm); display: flex; flex-direction: column; gap: var(--spacing-xs);">
+                            <label class="form-label" style="font-size: var(--font-size-xs);">Depuis ma fiche</label>
+                            @if (Weapons.Count > 0)
+                            {
+                                <select class="form-control" style="font-size: var(--font-size-sm);" @onchange="OnWeaponSelected">
+                                    <option value="0">⚔️ Arme (dégâts)…</option>
+                                    @foreach (var w in Weapons)
+                                    {
+                                        <option value="@w.Id">@w.Name — @w.DamageDice</option>
+                                    }
+                                </select>
+                            }
+                            @if (DamageSpells.Count > 0)
+                            {
+                                <select class="form-control" style="font-size: var(--font-size-sm);" @onchange="OnSpellSelected">
+                                    <option value="0">✨ Sort (dégâts)…</option>
+                                    @foreach (var s in DamageSpells)
+                                    {
+                                        <option value="@s.Id">@s.Name — @s.DamageDice</option>
+                                    }
+                                </select>
+                            }
+
+                            <div style="display: flex; align-items: center; gap: var(--spacing-xs); flex-wrap: wrap;">
+                                <input type="number" class="form-control" style="width: 55px; font-size: var(--font-size-sm);" @bind="CustomCount" min="1" max="20" title="Nombre de dés" />
+                                <span>d</span>
+                                <input type="number" class="form-control" style="width: 60px; font-size: var(--font-size-sm);" @bind="CustomFaces" min="2" max="100" title="Faces" />
+                                <span>+</span>
+                                <input type="number" class="form-control" style="width: 60px; font-size: var(--font-size-sm);" @bind="CustomModifier" title="Modificateur" />
+                            </div>
+                            <input class="form-control" style="font-size: var(--font-size-sm);" placeholder="Raison (optionnel)" @bind="CustomReason" />
+                            <button class="btn btn-primary btn-sm" @onclick="RollCustom" disabled="@(!IsHubConnected || IsRollingCustom)">
+                                <i class="bi bi-dice-5"></i> Lancer @CustomCount d@(CustomFaces)@(CustomModifier != 0 ? (CustomModifier > 0 ? $" +{CustomModifier}" : $" {CustomModifier}") : "")
+                            </button>
+                        </div>
+                    }
                 </div>
 
                 <!-- Échanges d'objets -->

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor.cs
@@ -1,4 +1,6 @@
 using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.DTOs.DnD5e;
+using Cdm.Common;
 using Cdm.Common.Enums;
 using Cdm.Web.Resources;
 using Cdm.Web.Services.ApiClients;
@@ -21,6 +23,7 @@ public partial class SessionPlayer : IAsyncDisposable
     [Inject] private SessionApiClient SessionClient { get; set; } = default!;
     [Inject] private WorldApiClient WorldClient { get; set; } = default!;
     [Inject] private CombatApiClient CombatClient { get; set; } = default!;
+    [Inject] private DndApiClient DndClient { get; set; } = default!;
     [Inject] private NavigationContextService NavContext { get; set; } = default!;
     [Inject] private AuthenticationStateProvider AuthStateProvider { get; set; } = default!;
     [Inject] private NavigationManager Nav { get; set; } = default!;
@@ -50,6 +53,19 @@ public partial class SessionPlayer : IAsyncDisposable
     private List<ChatEntry> ChatEntries { get; set; } = new();
     private string ChatInput = "";
     private int? RollingDie;
+
+    // D&D 5e "roll from sheet" support
+    private DndCharacterStatsDto? DndStats;
+    private List<DndInventoryItemDto> Weapons { get; set; } = new();
+    private List<DndCharacterSpellDto> DamageSpells { get; set; } = new();
+    private bool IsDndCharacter => MyCharacter?.GameType == Cdm.Common.Enums.GameType.DnD5e;
+
+    // Editable custom roll (pre-filled when a weapon/spell is selected)
+    private int CustomCount = 1;
+    private int CustomFaces = 20;
+    private int CustomModifier;
+    private string? CustomReason;
+    private bool IsRollingCustom;
 
     // Trades (object exchanges)
     private List<SessionTradeDto> PendingTrades { get; set; } = new();
@@ -114,6 +130,7 @@ public partial class SessionPlayer : IAsyncDisposable
         // so live events only ever append to an already-complete history (no duplicates).
         await LoadHistoryAsync();
         await LoadTradesAsync();
+        await LoadDndSheetAsync();
 
         await ConnectToHubAsync();
     }
@@ -121,6 +138,26 @@ public partial class SessionPlayer : IAsyncDisposable
     private async Task LoadTradesAsync()
     {
         PendingTrades = await SessionClient.GetPendingTradesAsync(SessionId);
+    }
+
+    /// <summary>
+    /// Loads the D&D weapons and damage spells of the player's character so rolls can be
+    /// pre-filled from the sheet. No-op for non-D&D characters.
+    /// </summary>
+    private async Task LoadDndSheetAsync()
+    {
+        if (!IsDndCharacter || MyCharacter == null)
+        {
+            return;
+        }
+
+        DndStats = await DndClient.GetCharacterStatsAsync(MyCharacter.Id);
+
+        var inventory = await DndClient.GetInventoryAsync(MyCharacter.Id);
+        Weapons = inventory.Where(i => !string.IsNullOrWhiteSpace(i.DamageDice)).ToList();
+
+        var spells = await DndClient.GetCharacterSpellsAsync(MyCharacter.Id);
+        DamageSpells = spells.Where(s => !string.IsNullOrWhiteSpace(s.DamageDice)).ToList();
     }
 
     private async Task LoadHistoryAsync()
@@ -132,7 +169,7 @@ public partial class SessionPlayer : IAsyncDisposable
         foreach (var m in history.Messages)
             entries.Add(new ChatEntry("text", m.UserName, m.Message, null, null, m.SentAt));
         foreach (var d in history.DiceRolls)
-            entries.Add(new ChatEntry("dice", d.UserName, null, d.DiceType, d.Results, d.RolledAt));
+            entries.Add(new ChatEntry("dice", d.UserName, null, d.DiceType, d.Results, d.RolledAt, d.Reason, d.Modifier));
 
         ChatEntries = entries.OrderBy(e => e.Timestamp).ToList();
     }
@@ -160,7 +197,7 @@ public partial class SessionPlayer : IAsyncDisposable
 
         _hub.On<HubDiceDto>("DiceRolled", dto =>
         {
-            ChatEntries.Add(new ChatEntry("dice", dto.UserName ?? "?", null, dto.DiceType, dto.Results, dto.Timestamp));
+            ChatEntries.Add(new ChatEntry("dice", dto.UserName ?? "?", null, dto.DiceType, dto.Results, dto.Timestamp, dto.Reason, dto.Modifier));
             InvokeAsync(StateHasChanged);
         });
 
@@ -238,6 +275,89 @@ public partial class SessionPlayer : IAsyncDisposable
             Toast.ShowWarning("Jet effectué localement : il n'a pas été partagé à la table.", "Dés");
         }
         RollingDie = null;
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Pre-fills the custom roll from a weapon's damage dice + Strength modifier (melee default).
+    /// </summary>
+    private void OnWeaponSelected(ChangeEventArgs e)
+    {
+        if (!int.TryParse(e.Value?.ToString(), out var id) || id <= 0)
+        {
+            return;
+        }
+
+        var weapon = Weapons.FirstOrDefault(w => w.Id == id);
+        if (weapon == null || !DiceNotation.TryParse(weapon.DamageDice, out var expr))
+        {
+            return;
+        }
+
+        CustomCount = expr.Count;
+        CustomFaces = expr.Faces;
+        // Damage bonus = flat bonus in the notation + the character's Strength modifier.
+        CustomModifier = expr.FlatBonus + (DndStats?.StrengthModifier ?? 0);
+        CustomReason = $"{weapon.Name} (dégâts)";
+    }
+
+    /// <summary>
+    /// Pre-fills the custom roll from a spell's damage dice.
+    /// </summary>
+    private void OnSpellSelected(ChangeEventArgs e)
+    {
+        if (!int.TryParse(e.Value?.ToString(), out var id) || id <= 0)
+        {
+            return;
+        }
+
+        var spell = DamageSpells.FirstOrDefault(s => s.Id == id);
+        if (spell == null || !DiceNotation.TryParse(spell.DamageDice, out var expr))
+        {
+            return;
+        }
+
+        CustomCount = expr.Count;
+        CustomFaces = expr.Faces;
+        CustomModifier = expr.FlatBonus;
+        CustomReason = $"{spell.Name} (dégâts)";
+    }
+
+    /// <summary>
+    /// Rolls the editable custom expression (count dice of the chosen faces + modifier)
+    /// and shares it with its reason.
+    /// </summary>
+    private async Task RollCustom()
+    {
+        if (_hub == null || !IsHubConnected || IsRollingCustom)
+        {
+            return;
+        }
+
+        var count = Math.Clamp(CustomCount, 1, 20);
+        var faces = Math.Clamp(CustomFaces, 2, 100);
+
+        IsRollingCustom = true;
+        StateHasChanged();
+
+        var results = new int[count];
+        for (var i = 0; i < count; i++)
+        {
+            results[i] = Random.Shared.Next(1, faces + 1);
+        }
+
+        try
+        {
+            await _hub.InvokeAsync("RollDice", SessionId, $"D{faces}", count, results, CustomModifier, CustomReason);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Partage du jet personnalisé impossible (session {SessionId})", SessionId);
+            ChatEntries.Add(new ChatEntry("dice", CurrentUserName ?? "Joueur", null, $"D{faces}", results, DateTime.UtcNow, CustomReason, CustomModifier));
+            Toast.ShowWarning("Jet effectué localement : il n'a pas été partagé à la table.", "Dés");
+        }
+
+        IsRollingCustom = false;
         StateHasChanged();
     }
 
@@ -399,7 +519,7 @@ public partial class SessionPlayer : IAsyncDisposable
         public int Qty { get; set; } = 1;
     }
 
-    private record ChatEntry(string Type, string UserName, string? Text, string? DiceType, int[]? Results, DateTime Timestamp);
+    private record ChatEntry(string Type, string UserName, string? Text, string? DiceType, int[]? Results, DateTime Timestamp, string? Reason = null, int Modifier = 0);
     private record HubMessageDto(int UserId, string? UserName, string? Message, DateTime Timestamp);
     private record HubDiceDto(int UserId, string? UserName, string? DiceType, int Count, int[]? Results, int Modifier, int Total, string? Reason, DateTime Timestamp);
 }


### PR DESCRIPTION
Le joueur peut désormais lancer les dégâts d'une arme ou d'un sort directement depuis sa fiche : la sélection pré-remplit les dés et le modificateur.

- DiceNotation (Cdm.Common) : parseur testable de "1d8", "2d6+3", "1d10-1".
- Page joueur : charge armes (inventaire) et sorts à dégâts + stats D&D ; sélecteurs « arme / sort » qui pré-remplissent un jet éditable (nb dés, faces, modificateur = bonus plat + mod. Force pour les armes) avec une raison, partagé via le hub (signature count/results/modifier/reason déjà supportée).
- Chat des dés (joueur + MJ) : affiche la raison, l'expression avec modificateur et le total (dés + modificateur), à la volée et au rechargement d'historique.

Tests : 13 tests DiceNotation. Build Release /warnaserror OK, dotnet test = 96/96 verts.