### PR TITLE
feat(combat): initiative automatique côté serveur (1d20 + mod. DEX)

### DIFF
--- a/Cdm/Cdm.ApiService/Endpoints/CombatEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/CombatEndpoints.cs
@@ -47,6 +47,11 @@ public static class CombatEndpoints
             .WithName("StartInitiativePhase")
             .WithOpenApi();
 
+        // POST /api/combat/{id}/initiative/roll — Auto-roll initiative (1d20 + DEX) for all
+        group.MapPost("/{id:int}/initiative/roll", RollInitiativeAsync)
+            .WithName("RollInitiative")
+            .WithOpenApi();
+
         // PUT /api/combat/{id}/initiative/{participantId} — Set a participant's initiative
         group.MapPut("/{id:int}/initiative/{participantId:int}", SetInitiativeAsync)
             .WithName("SetInitiative")
@@ -162,6 +167,22 @@ public static class CombatEndpoints
         var result = await combatService.SetInitiativeAsync(id, participantId, request, userId.Value);
         if (result == null)
             return Results.BadRequest(new { Error = "Failed to set initiative. Check participant ID and authorization." });
+
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> RollInitiativeAsync(
+        int id,
+        [FromServices] ICombatService combatService,
+        ILogger<CombatEndpointsLogger> logger,
+        HttpContext httpContext)
+    {
+        var userId = GetUserId(httpContext);
+        if (userId == null) return Results.Unauthorized();
+
+        var result = await combatService.RollInitiativeAsync(id, userId.Value);
+        if (result == null)
+            return Results.BadRequest(new { Error = "Failed to roll initiative. Check combat ID and authorization." });
 
         return Results.Ok(result);
     }

--- a/Cdm/Cdm.Business.Abstraction/DTOs/CombatDtos.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/CombatDtos.cs
@@ -31,6 +31,9 @@ public class CreateParticipantDto
     public int? NpcId { get; set; }
     public int? UserId { get; set; }
     public int MaxHp { get; set; }
+
+    /// <summary>Optional Dexterity modifier for automatic initiative; resolved from the sheet when null.</summary>
+    public int? DexterityModifier { get; set; }
 }
 
 /// <summary>Request DTO to start the initiative phase.</summary>
@@ -129,6 +132,7 @@ public class CombatParticipantDto
     public int CurrentHp { get; set; }
     public int MaxHp { get; set; }
     public int? Initiative { get; set; }
+    public int DexterityModifier { get; set; }
     public int TurnOrder { get; set; }
     public bool IsActive { get; set; }
 }

--- a/Cdm/Cdm.Business.Abstraction/Services/ICombatService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/ICombatService.cs
@@ -28,6 +28,15 @@ public interface ICombatService
     /// <summary>Sets the initiative value for a single participant.</summary>
     Task<CombatDto?> SetInitiativeAsync(int combatId, int participantId, SetInitiativeDto request, int userId);
 
+    /// <summary>
+    /// Auto-rolls initiative for every active participant (1d20 + Dexterity modifier), server-side.
+    /// Only the GM of the session may trigger it.
+    /// </summary>
+    /// <param name="combatId">The combat identifier.</param>
+    /// <param name="userId">The requesting user (must be GM).</param>
+    /// <returns>The updated combat, or null if not found/unauthorized.</returns>
+    Task<CombatDto?> RollInitiativeAsync(int combatId, int userId);
+
     /// <summary>Sorts participants by initiative and transitions the combat to Active (Status = 2).</summary>
     Task<CombatDto?> StartCombatAsync(int combatId, StartCombatDto? request, int userId);
 

--- a/Cdm/Cdm.Business.Common.Tests/Services/CombatServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/CombatServiceTests.cs
@@ -1,0 +1,148 @@
+// -----------------------------------------------------------------------
+// <copyright file="CombatServiceTests.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Tests.Services;
+
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.Services;
+using Cdm.Business.Common.Services;
+using Cdm.Common.Enums;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="CombatService"/> automatic initiative and Dexterity resolution.
+/// </summary>
+public class CombatServiceTests
+{
+    private readonly Mock<IAchievementEvaluationService> achievementEvaluationMock = new();
+    private readonly Mock<ILogger<CombatService>> loggerMock = new();
+
+    private const int GmUserId = 1;
+    private const int WorldId = 1;
+    private const int CampaignId = 5;
+    private const int SessionId = 10;
+
+    private static DbContextOptions<AppDbContext> NewOptions(string name) =>
+        new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase(name).Options;
+
+    private CombatService CreateService(AppDbContext context) =>
+        new(context, this.achievementEvaluationMock.Object, this.loggerMock.Object);
+
+    private static async Task SeedSessionAsync(AppDbContext context)
+    {
+        context.Users.Add(new User { Id = GmUserId, Email = "gm@test.com", Nickname = "MJ", PasswordHash = "h", CreatedAt = DateTime.UtcNow });
+        context.Worlds.Add(new World { Id = WorldId, Name = "Monde", GameType = GameType.DnD5e, UserId = GmUserId, CreatedAt = DateTime.UtcNow });
+        context.Campaigns.Add(new Campaign { Id = CampaignId, Name = "Campagne", WorldId = WorldId, CreatedBy = GmUserId, CreatedAt = DateTime.UtcNow });
+        context.Sessions.Add(new Session { Id = SessionId, CampaignId = CampaignId, StartedById = GmUserId, StartedAt = DateTime.UtcNow });
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task<int> SeedCombatWithParticipantsAsync(AppDbContext context)
+    {
+        var combat = new Combat { Id = 30, SessionId = SessionId, Status = 0, StartedById = GmUserId, StartedAt = DateTime.UtcNow, CreatedAt = DateTime.UtcNow };
+        context.Combats.Add(combat);
+        var group = new CombatGroup { Id = 40, CombatId = 30, Name = "Héros" };
+        context.CombatGroups.Add(group);
+        context.CombatParticipants.AddRange(
+            new CombatParticipant { Id = 501, CombatId = 30, GroupId = 40, Name = "Roublard", IsPlayerCharacter = true, UserId = 2, MaxHp = 20, CurrentHp = 20, DexterityModifier = 3, IsActive = true },
+            new CombatParticipant { Id = 502, CombatId = 30, GroupId = 40, Name = "Gobelin", IsPlayerCharacter = false, MaxHp = 7, CurrentHp = 7, DexterityModifier = 0, IsActive = true });
+        await context.SaveChangesAsync();
+        return combat.Id;
+    }
+
+    /// <summary>
+    /// The GM auto-rolls initiative: every active participant gets a value within [1 + DEX, 20 + DEX].
+    /// </summary>
+    [Fact]
+    public async Task RollInitiativeAsync_AsGm_SetsInitiativeWithinRange()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(RollInitiativeAsync_AsGm_SetsInitiativeWithinRange)));
+        await SeedSessionAsync(context);
+        var combatId = await SeedCombatWithParticipantsAsync(context);
+        var service = this.CreateService(context);
+
+        var result = await service.RollInitiativeAsync(combatId, GmUserId);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.Status); // Initiative phase
+
+        var rogue = await context.CombatParticipants.FindAsync(501);
+        var goblin = await context.CombatParticipants.FindAsync(502);
+        Assert.NotNull(rogue!.Initiative);
+        Assert.InRange(rogue.Initiative!.Value, 1 + 3, 20 + 3);
+        Assert.NotNull(goblin!.Initiative);
+        Assert.InRange(goblin.Initiative!.Value, 1, 20);
+    }
+
+    /// <summary>
+    /// A non-GM cannot auto-roll initiative.
+    /// </summary>
+    [Fact]
+    public async Task RollInitiativeAsync_NotGm_ReturnsNull()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(RollInitiativeAsync_NotGm_ReturnsNull)));
+        await SeedSessionAsync(context);
+        var combatId = await SeedCombatWithParticipantsAsync(context);
+        var service = this.CreateService(context);
+
+        var result = await service.RollInitiativeAsync(combatId, 999);
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// When a player participant carries no explicit Dexterity modifier, the service resolves it
+    /// from their D&D sheet (WorldCharacter.GameSpecificData JSON).
+    /// </summary>
+    [Fact]
+    public async Task CreateCombatAsync_ResolvesPlayerDexterityFromSheet()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(CreateCombatAsync_ResolvesPlayerDexterityFromSheet)));
+        await SeedSessionAsync(context);
+
+        // Character with Dexterity 16 => modifier +3, stored as sheet JSON on the world character.
+        context.Characters.Add(new Character { Id = 100, UserId = 2, Name = "Legolas", IsActive = true });
+        context.WorldCharacters.Add(new WorldCharacter
+        {
+            Id = 200,
+            CharacterId = 100,
+            WorldId = WorldId,
+            IsActive = true,
+            GameSpecificData = "{\"dexterity\":16}"
+        });
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        var dto = new CreateCombatDto
+        {
+            SessionId = SessionId,
+            Groups = new()
+            {
+                new CreateCombatGroupDto
+                {
+                    Name = "Héros",
+                    Participants = new()
+                    {
+                        new CreateParticipantDto { Name = "Legolas", IsPlayerCharacter = true, CharacterId = 100, MaxHp = 24 }
+                    }
+                }
+            }
+        };
+
+        var combat = await service.CreateCombatAsync(dto, GmUserId);
+
+        Assert.NotNull(combat);
+        var participant = await context.CombatParticipants.FirstOrDefaultAsync(p => p.CharacterId == 100);
+        Assert.NotNull(participant);
+        Assert.Equal(3, participant!.DexterityModifier);
+    }
+}

--- a/Cdm/Cdm.Business.Common/Services/CombatService.cs
+++ b/Cdm/Cdm.Business.Common/Services/CombatService.cs
@@ -7,11 +7,13 @@
 namespace Cdm.Business.Common.Services;
 
 using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.DTOs.DnD5e;
 using Cdm.Business.Abstraction.Services;
 using Cdm.Data.Common;
 using Cdm.Data.Common.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System.Text.Json;
 
 /// <summary>
 /// Service for managing generic combat encounters within game sessions.
@@ -88,6 +90,8 @@ public class CombatService(
                         UserId = participantDto.UserId,
                         MaxHp = participantDto.MaxHp,
                         CurrentHp = participantDto.MaxHp,
+                        DexterityModifier = participantDto.DexterityModifier
+                            ?? await this.ResolveDexModifierAsync(participantDto.CharacterId),
                         IsActive = true,
                         TurnOrder = 0,
                     };
@@ -261,6 +265,82 @@ public class CombatService(
         {
             this.logger.LogError(ex, "Error setting initiative for participant {ParticipantId}", participantId);
             return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<CombatDto?> RollInitiativeAsync(int combatId, int userId)
+    {
+        try
+        {
+            var combat = await this.dbContext.Combats
+                .Include(c => c.Participants)
+                .FirstOrDefaultAsync(c => c.Id == combatId);
+
+            if (combat == null) return null;
+
+            if (!await this.IsGmOfSessionAsync(combat.SessionId, userId))
+            {
+                this.logger.LogWarning(
+                    "User {UserId} is not authorized to roll initiative for combat {CombatId}",
+                    userId,
+                    combatId);
+                return null;
+            }
+
+            var rng = new Random();
+            foreach (var participant in combat.Participants.Where(p => p.IsActive))
+            {
+                // D&D 5e initiative: 1d20 + Dexterity modifier, resolved server-side.
+                participant.Initiative = rng.Next(1, 21) + participant.DexterityModifier;
+            }
+
+            combat.Status = 1; // Initiative
+            await this.dbContext.SaveChangesAsync();
+
+            this.logger.LogInformation("Auto-rolled initiative (1d20 + DEX) for combat {CombatId}", combatId);
+
+            return await this.LoadCombatDtoAsync(combatId);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error rolling initiative for combat {CombatId}", combatId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves a player character's Dexterity modifier from their D&D sheet
+    /// (stored as JSON in <c>WorldCharacter.GameSpecificData</c>). Returns 0 when unavailable.
+    /// </summary>
+    private async Task<int> ResolveDexModifierAsync(int? characterId)
+    {
+        if (characterId is null)
+        {
+            return 0;
+        }
+
+        try
+        {
+            var worldCharacter = await this.dbContext.WorldCharacters
+                .AsNoTracking()
+                .FirstOrDefaultAsync(wc => wc.CharacterId == characterId.Value);
+
+            if (worldCharacter is null || string.IsNullOrWhiteSpace(worldCharacter.GameSpecificData))
+            {
+                return 0;
+            }
+
+            var stats = JsonSerializer.Deserialize<DndCharacterStatsDto>(
+                worldCharacter.GameSpecificData,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+            return stats?.DexterityModifier ?? 0;
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogWarning(ex, "Could not resolve Dexterity modifier for character {CharacterId}", characterId);
+            return 0;
         }
     }
 
@@ -667,6 +747,7 @@ public class CombatService(
             CurrentHp = p.CurrentHp,
             MaxHp = p.MaxHp,
             Initiative = p.Initiative,
+            DexterityModifier = p.DexterityModifier,
             TurnOrder = p.TurnOrder,
             IsActive = p.IsActive,
         };

--- a/Cdm/Cdm.Data.Common/Models/CombatParticipant.cs
+++ b/Cdm/Cdm.Data.Common/Models/CombatParticipant.cs
@@ -41,6 +41,9 @@ public class CombatParticipant
     /// <summary>Gets or sets the initiative value (null until rolled/declared).</summary>
     public int? Initiative { get; set; }
 
+    /// <summary>Gets or sets the Dexterity modifier used for automatic initiative (1d20 + DEX).</summary>
+    public int DexterityModifier { get; set; }
+
     /// <summary>Gets or sets the turn order position (assigned after initiative is sorted).</summary>
     public int TurnOrder { get; set; }
 

--- a/Cdm/Cdm.Migrations/Migrations/20260719160000_AddCombatParticipantDexModifier.cs
+++ b/Cdm/Cdm.Migrations/Migrations/20260719160000_AddCombatParticipantDexModifier.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Cdm.Migrations;
+
+#nullable disable
+
+namespace Cdm.Migrations.Migrations
+{
+    /// <summary>
+    /// Ajoute la colonne [DexterityModifier] à [CombatParticipants] : le modificateur
+    /// de Dextérité utilisé pour l'initiative automatique (1d20 + mod. DEX).
+    /// </summary>
+    [DbContext(typeof(MigrationsContext))]
+    [Migration("20260719160000_AddCombatParticipantDexModifier")]
+    public partial class AddCombatParticipantDexModifier : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH('[CombatParticipants]', 'DexterityModifier') IS NULL
+                    ALTER TABLE [CombatParticipants] ADD [DexterityModifier] int NOT NULL DEFAULT 0;
+            ");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH('[CombatParticipants]', 'DexterityModifier') IS NOT NULL
+                BEGIN
+                    DECLARE @df sysname;
+                    SELECT @df = dc.name FROM sys.default_constraints dc
+                        JOIN sys.columns c ON c.default_object_id = dc.object_id
+                        WHERE dc.parent_object_id = OBJECT_ID('[CombatParticipants]') AND c.name = 'DexterityModifier';
+                    IF @df IS NOT NULL EXEC('ALTER TABLE [CombatParticipants] DROP CONSTRAINT [' + @df + ']');
+                    ALTER TABLE [CombatParticipants] DROP COLUMN [DexterityModifier];
+                END
+            ");
+        }
+    }
+}

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor
@@ -36,6 +36,10 @@ else if (Combat != null)
             <div style="display:flex;gap:var(--spacing-sm);">
                 @if (Combat.Status == 1)
                 {
+                    <button class="btn btn-secondary btn-sm" @onclick="RollAllInitiative" disabled="@IsRollingInitiative"
+                            title="Lance l'initiative (1d20 + modificateur de Dextérité) pour tous les participants">
+                        <i class="bi bi-dice-5"></i> Initiative auto
+                    </button>
                     <button class="btn btn-primary btn-sm" @onclick="StartCombat" disabled="@(!AllReadyForCombat)"
                             title="@(!AllReadyForCombat ? "En attente des initiatives de tous les participants" : "Lancer le combat")">
                         <i class="bi bi-swords"></i> Démarrer le combat

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor.cs
@@ -158,6 +158,17 @@ public partial class CombatGm : IAsyncDisposable
 
     // --- Actions ---
 
+    private bool IsRollingInitiative;
+
+    private async Task RollAllInitiative()
+    {
+        if (IsRollingInitiative) return;
+        IsRollingInitiative = true;
+        var updated = await CombatClient.RollInitiativeAsync(CombatId);
+        if (updated != null) Combat = updated;
+        IsRollingInitiative = false;
+    }
+
     private async Task StartCombat()
     {
         var updated = await CombatClient.StartCombatAsync(CombatId);

--- a/Cdm/Cdm.Web/Services/ApiClients/CombatApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ApiClients/CombatApiClient.cs
@@ -119,6 +119,26 @@ public class CombatApiClient
         }
     }
 
+    /// <summary>Auto-rolls initiative (1d20 + DEX) for all participants, server-side.</summary>
+    public async Task<CombatDto?> RollInitiativeAsync(int combatId)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await this.httpClient.PostAsync($"api/combat/{combatId}/initiative/roll", null);
+            if (response.IsSuccessStatusCode)
+                return await response.Content.ReadFromJsonAsync<CombatDto>();
+
+            this.logger.LogWarning("Failed to roll initiative for combat {CombatId}. Status: {StatusCode}", combatId, response.StatusCode);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error rolling initiative for combat {CombatId}", combatId);
+            return null;
+        }
+    }
+
     /// <summary>Sets the initiative value for a participant.</summary>
     public async Task<CombatDto?> SetInitiativeAsync(int combatId, int participantId, SetInitiativeDto dto)
     {


### PR DESCRIPTION
Première tranche du combat D&D automatisé : l'initiative est désormais lancée et résolue côté serveur pour tous les participants, avec le modificateur de Dextérité.

- CombatParticipant : nouveau champ DexterityModifier (+ migration idempotente).
- À la création du combat, le mod. DEX des personnages joueurs est résolu depuis leur fiche D&D (WorldCharacter.GameSpecificData) ; les NPC valent 0 par défaut, ou une valeur explicite via le DTO.
- CombatService.RollInitiativeAsync (MJ) : Initiative = 1d20 + DEX pour chaque participant actif, passage en phase d'initiative. StartCombat ordonne ensuite les tours.
- Endpoint POST /api/combat/{id}/initiative/roll + méthode client.
- UI MJ : bouton « Initiative auto » pendant la phase d'initiative.

Tests : 3 tests CombatService (fourchette 1d20+DEX, autorisation MJ, résolution de la DEX depuis la fiche). Build Release /warnaserror OK, dotnet test = 99/99 verts.

Suite prévue : résolution serveur des attaques (jet vs CA) et des dégâts.