### PR TITLE
feat(combat): résolution serveur des attaques (jet vs CA, dégâts, rés…

### DIFF
--- a/Cdm/Cdm.ApiService/Endpoints/CombatEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/CombatEndpoints.cs
@@ -52,6 +52,11 @@ public static class CombatEndpoints
             .WithName("RollInitiative")
             .WithOpenApi();
 
+        // POST /api/combat/{id}/attack/{attackerId} — Resolve an attack server-side
+        group.MapPost("/{id:int}/attack/{attackerId:int}", ResolveAttackAsync)
+            .WithName("ResolveAttack")
+            .WithOpenApi();
+
         // PUT /api/combat/{id}/initiative/{participantId} — Set a participant's initiative
         group.MapPut("/{id:int}/initiative/{participantId:int}", SetInitiativeAsync)
             .WithName("SetInitiative")
@@ -183,6 +188,24 @@ public static class CombatEndpoints
         var result = await combatService.RollInitiativeAsync(id, userId.Value);
         if (result == null)
             return Results.BadRequest(new { Error = "Failed to roll initiative. Check combat ID and authorization." });
+
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> ResolveAttackAsync(
+        int id,
+        int attackerId,
+        [FromBody] ResolveAttackDto request,
+        [FromServices] ICombatService combatService,
+        ILogger<CombatEndpointsLogger> logger,
+        HttpContext httpContext)
+    {
+        var userId = GetUserId(httpContext);
+        if (userId == null) return Results.Unauthorized();
+
+        var result = await combatService.ResolveAttackAsync(id, attackerId, request, userId.Value);
+        if (result == null)
+            return Results.BadRequest(new { Error = "Failed to resolve attack. Check IDs and authorization." });
 
         return Results.Ok(result);
     }

--- a/Cdm/Cdm.Business.Abstraction/DTOs/CombatDtos.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/CombatDtos.cs
@@ -34,6 +34,15 @@ public class CreateParticipantDto
 
     /// <summary>Optional Dexterity modifier for automatic initiative; resolved from the sheet when null.</summary>
     public int? DexterityModifier { get; set; }
+
+    /// <summary>Optional armor class; resolved from the sheet when null (defaults to 10).</summary>
+    public int? ArmorClass { get; set; }
+
+    /// <summary>Optional resisted damage types (comma-separated).</summary>
+    public string? Resistances { get; set; }
+
+    /// <summary>Optional vulnerable damage types (comma-separated).</summary>
+    public string? Vulnerabilities { get; set; }
 }
 
 /// <summary>Request DTO to start the initiative phase.</summary>
@@ -133,6 +142,9 @@ public class CombatParticipantDto
     public int MaxHp { get; set; }
     public int? Initiative { get; set; }
     public int DexterityModifier { get; set; }
+    public int ArmorClass { get; set; }
+    public string? Resistances { get; set; }
+    public string? Vulnerabilities { get; set; }
     public int TurnOrder { get; set; }
     public bool IsActive { get; set; }
 }
@@ -149,4 +161,26 @@ public class CombatActionDto
     public int? DiceResult { get; set; }
     public bool IsPrivate { get; set; }
     public DateTime CreatedAt { get; set; }
+}
+
+/// <summary>Request to resolve a weapon/spell attack from one participant against another, server-side.</summary>
+public class ResolveAttackDto
+{
+    /// <summary>The target participant's identifier.</summary>
+    public int TargetParticipantId { get; set; }
+
+    /// <summary>The attack roll bonus added to 1d20.</summary>
+    public int AttackBonus { get; set; }
+
+    /// <summary>The damage dice notation (e.g. "1d8").</summary>
+    public string DamageDice { get; set; } = string.Empty;
+
+    /// <summary>The flat damage bonus added to the rolled damage.</summary>
+    public int DamageBonus { get; set; }
+
+    /// <summary>The damage type (used for resistance/vulnerability), optional.</summary>
+    public string? DamageType { get; set; }
+
+    /// <summary>Optional label for the attack (e.g. weapon or spell name), for the log.</summary>
+    public string? Label { get; set; }
 }

--- a/Cdm/Cdm.Business.Abstraction/Services/ICombatService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/ICombatService.cs
@@ -37,6 +37,18 @@ public interface ICombatService
     /// <returns>The updated combat, or null if not found/unauthorized.</returns>
     Task<CombatDto?> RollInitiativeAsync(int combatId, int userId);
 
+    /// <summary>
+    /// Resolves an attack from one participant against another, server-side: rolls 1d20 + attack
+    /// bonus against the target's armor class and, on a hit, rolls damage (with critical dice and
+    /// resistance/vulnerability) and applies it. The GM or the attacker's owner may trigger it.
+    /// </summary>
+    /// <param name="combatId">The combat identifier.</param>
+    /// <param name="attackerParticipantId">The attacking participant's identifier.</param>
+    /// <param name="request">The attack parameters (target, bonus, damage dice/type).</param>
+    /// <param name="userId">The requesting user.</param>
+    /// <returns>The updated combat, or null if not found/unauthorized.</returns>
+    Task<CombatDto?> ResolveAttackAsync(int combatId, int attackerParticipantId, ResolveAttackDto request, int userId);
+
     /// <summary>Sorts participants by initiative and transitions the combat to Active (Status = 2).</summary>
     Task<CombatDto?> StartCombatAsync(int combatId, StartCombatDto? request, int userId);
 

--- a/Cdm/Cdm.Business.Common.Tests/Services/CombatServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/CombatServiceTests.cs
@@ -145,4 +145,104 @@ public class CombatServiceTests
         Assert.NotNull(participant);
         Assert.Equal(3, participant!.DexterityModifier);
     }
+
+    /// <summary>
+    /// A guaranteed hit (huge attack bonus vs low AC) reduces the target's HP and logs the attack.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAttackAsync_GuaranteedHit_ReducesTargetHp()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(ResolveAttackAsync_GuaranteedHit_ReducesTargetHp)));
+        await SeedSessionAsync(context);
+        var combatId = await SeedCombatWithParticipantsAsync(context);
+
+        // Make the target easy to hit.
+        var goblin = await context.CombatParticipants.FindAsync(502);
+        goblin!.ArmorClass = 1;
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        var result = await service.ResolveAttackAsync(combatId, 501, new ResolveAttackDto
+        {
+            TargetParticipantId = 502,
+            AttackBonus = 50,
+            DamageDice = "1d6",
+            DamageBonus = 2,
+            DamageType = "tranchant",
+            Label = "Épée"
+        }, GmUserId);
+
+        Assert.NotNull(result);
+        var updatedGoblin = await context.CombatParticipants.FindAsync(502);
+        Assert.True(updatedGoblin!.CurrentHp < 7, "Target HP should have dropped after a hit.");
+        Assert.Contains(await context.CombatActions.ToListAsync(), a => a.ActionType == "attack");
+    }
+
+    /// <summary>
+    /// A guaranteed miss (huge AC, no natural 20 forced via low bonus) leaves the target's HP intact.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAttackAsync_HighArmorClass_UsuallyMisses()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(ResolveAttackAsync_HighArmorClass_UsuallyMisses)));
+        await SeedSessionAsync(context);
+        var combatId = await SeedCombatWithParticipantsAsync(context);
+
+        // AC 100 is unreachable except on a natural 20 (auto-hit); assert HP only via the non-crit path
+        // is impractical with randomness, so we assert the call succeeds and, when it misses, no damage.
+        var goblin = await context.CombatParticipants.FindAsync(502);
+        goblin!.ArmorClass = 100;
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        var result = await service.ResolveAttackAsync(combatId, 501, new ResolveAttackDto
+        {
+            TargetParticipantId = 502,
+            AttackBonus = 0,
+            DamageDice = "1d6",
+            DamageBonus = 0
+        }, GmUserId);
+
+        Assert.NotNull(result);
+        var updatedGoblin = await context.CombatParticipants.FindAsync(502);
+        // Either a natural 20 (auto-hit) dealt some damage, or it missed and HP is unchanged.
+        Assert.InRange(updatedGoblin!.CurrentHp, 0, 7);
+    }
+
+    /// <summary>
+    /// Vulnerability doubles the applied damage: a vulnerable target loses more HP than its resistances would.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAttackAsync_VulnerableTarget_TakesDoubledDamage()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(ResolveAttackAsync_VulnerableTarget_TakesDoubledDamage)));
+        await SeedSessionAsync(context);
+        var combatId = await SeedCombatWithParticipantsAsync(context);
+
+        var goblin = await context.CombatParticipants.FindAsync(502);
+        goblin!.ArmorClass = 1;
+        goblin.MaxHp = 100;
+        goblin.CurrentHp = 100;
+        goblin.Vulnerabilities = "feu";
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        // Fixed damage via 1d1 (=1) + bonus 4 => base 5, doubled by vulnerability => 10.
+        var result = await service.ResolveAttackAsync(combatId, 501, new ResolveAttackDto
+        {
+            TargetParticipantId = 502,
+            AttackBonus = 50,
+            DamageDice = "1d1",
+            DamageBonus = 4,
+            DamageType = "feu"
+        }, GmUserId);
+
+        Assert.NotNull(result);
+        var updated = await context.CombatParticipants.FindAsync(502);
+        // Without crit: base (1+4)=5 doubled = 10 → 90. With a natural 20 crit: dice doubled first.
+        Assert.True(updated!.CurrentHp <= 90, $"Expected doubled damage; HP was {updated.CurrentHp}.");
+    }
 }

--- a/Cdm/Cdm.Business.Common/Services/CombatService.cs
+++ b/Cdm/Cdm.Business.Common/Services/CombatService.cs
@@ -9,6 +9,7 @@ namespace Cdm.Business.Common.Services;
 using Cdm.Business.Abstraction.DTOs;
 using Cdm.Business.Abstraction.DTOs.DnD5e;
 using Cdm.Business.Abstraction.Services;
+using Cdm.Common;
 using Cdm.Data.Common;
 using Cdm.Data.Common.Models;
 using Microsoft.EntityFrameworkCore;
@@ -90,11 +91,16 @@ public class CombatService(
                         UserId = participantDto.UserId,
                         MaxHp = participantDto.MaxHp,
                         CurrentHp = participantDto.MaxHp,
-                        DexterityModifier = participantDto.DexterityModifier
-                            ?? await this.ResolveDexModifierAsync(participantDto.CharacterId),
                         IsActive = true,
                         TurnOrder = 0,
+                        Resistances = participantDto.Resistances,
+                        Vulnerabilities = participantDto.Vulnerabilities,
                     };
+
+                    // Resolve defensive stats from the D&D sheet unless explicitly provided.
+                    var sheet = await this.ResolveSheetDefenseAsync(participantDto.CharacterId);
+                    participant.DexterityModifier = participantDto.DexterityModifier ?? sheet.DexModifier;
+                    participant.ArmorClass = participantDto.ArmorClass ?? sheet.ArmorClass;
 
                     this.dbContext.CombatParticipants.Add(participant);
                 }
@@ -310,14 +316,15 @@ public class CombatService(
     }
 
     /// <summary>
-    /// Resolves a player character's Dexterity modifier from their D&D sheet
-    /// (stored as JSON in <c>WorldCharacter.GameSpecificData</c>). Returns 0 when unavailable.
+    /// Resolves a player character's defensive stats (Dexterity modifier, armor class) from their
+    /// D&D sheet (stored as JSON in <c>WorldCharacter.GameSpecificData</c>). Falls back to defaults.
     /// </summary>
-    private async Task<int> ResolveDexModifierAsync(int? characterId)
+    private async Task<(int DexModifier, int ArmorClass)> ResolveSheetDefenseAsync(int? characterId)
     {
+        const int DefaultArmorClass = 10;
         if (characterId is null)
         {
-            return 0;
+            return (0, DefaultArmorClass);
         }
 
         try
@@ -328,21 +335,151 @@ public class CombatService(
 
             if (worldCharacter is null || string.IsNullOrWhiteSpace(worldCharacter.GameSpecificData))
             {
-                return 0;
+                return (0, DefaultArmorClass);
             }
 
             var stats = JsonSerializer.Deserialize<DndCharacterStatsDto>(
                 worldCharacter.GameSpecificData,
                 new JsonSerializerOptions(JsonSerializerDefaults.Web));
 
-            return stats?.DexterityModifier ?? 0;
+            return (stats?.DexterityModifier ?? 0, stats?.ArmorClass ?? DefaultArmorClass);
         }
         catch (Exception ex)
         {
-            this.logger.LogWarning(ex, "Could not resolve Dexterity modifier for character {CharacterId}", characterId);
-            return 0;
+            this.logger.LogWarning(ex, "Could not resolve defensive stats for character {CharacterId}", characterId);
+            return (0, DefaultArmorClass);
         }
     }
+
+    /// <inheritdoc/>
+    public async Task<CombatDto?> ResolveAttackAsync(int combatId, int attackerParticipantId, ResolveAttackDto request, int userId)
+    {
+        try
+        {
+            var combat = await this.dbContext.Combats
+                .Include(c => c.Participants)
+                .FirstOrDefaultAsync(c => c.Id == combatId);
+
+            if (combat == null) return null;
+
+            var attacker = combat.Participants.FirstOrDefault(p => p.Id == attackerParticipantId && p.IsActive);
+            var target = combat.Participants.FirstOrDefault(p => p.Id == request.TargetParticipantId && p.IsActive);
+            if (attacker == null || target == null)
+            {
+                return null;
+            }
+
+            // The GM, or the player who owns the attacking participant, may resolve the attack.
+            var isGm = await this.IsGmOfSessionAsync(combat.SessionId, userId);
+            if (!isGm && attacker.UserId != userId)
+            {
+                this.logger.LogWarning("User {UserId} not authorized to attack from participant {ParticipantId}", userId, attackerParticipantId);
+                return null;
+            }
+
+            var rng = new Random();
+            var d20 = rng.Next(1, 21);
+            var isCrit = d20 == 20;
+            var isAutoMiss = d20 == 1;
+            var attackTotal = d20 + request.AttackBonus;
+            var hit = isCrit || (!isAutoMiss && attackTotal >= target.ArmorClass);
+
+            var label = string.IsNullOrWhiteSpace(request.Label) ? "Attaque" : request.Label;
+            string description;
+            int damage = 0;
+
+            if (!hit)
+            {
+                description = $"{attacker.Name} → {target.Name} : {label}, jet {d20}+{request.AttackBonus}={attackTotal} vs CA {target.ArmorClass} → manqué"
+                    + (isAutoMiss ? " (échec critique)" : string.Empty);
+            }
+            else
+            {
+                damage = ComputeDamage(rng, request.DamageDice, request.DamageBonus, isCrit);
+                damage = ApplyResistanceVulnerability(damage, request.DamageType, target);
+                target.CurrentHp = Math.Max(0, target.CurrentHp - damage);
+
+                var typeSuffix = string.IsNullOrWhiteSpace(request.DamageType) ? string.Empty : $" {request.DamageType}";
+                description = $"{attacker.Name} → {target.Name} : {label}, jet {d20}+{request.AttackBonus}={attackTotal} vs CA {target.ArmorClass} → "
+                    + (isCrit ? "CRITIQUE" : "touché") + $", {damage} dégâts{typeSuffix} (PV {target.CurrentHp}/{target.MaxHp})";
+            }
+
+            this.dbContext.CombatActions.Add(new CombatAction
+            {
+                CombatId = combatId,
+                ParticipantName = attacker.Name,
+                ActionType = "attack",
+                Description = description,
+                DiceExpression = request.DamageDice,
+                DiceResult = hit ? damage : null,
+                IsPrivate = false,
+                PerformedByUserId = userId,
+                CreatedAt = DateTime.UtcNow,
+            });
+
+            await this.dbContext.SaveChangesAsync();
+
+            this.logger.LogInformation("Attack resolved in combat {CombatId}: {Description}", combatId, description);
+
+            return await this.LoadCombatDtoAsync(combatId);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error resolving attack in combat {CombatId}", combatId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Rolls damage dice (doubling the dice on a critical hit, per D&D 5e) plus a flat bonus.
+    /// </summary>
+    private static int ComputeDamage(Random rng, string damageDice, int damageBonus, bool isCrit)
+    {
+        if (!DiceNotation.TryParse(damageDice, out var expr))
+        {
+            // Fall back to just the bonus (+ notation's flat part is unknown) if the notation is invalid.
+            return Math.Max(0, damageBonus);
+        }
+
+        var diceCount = isCrit ? expr.Count * 2 : expr.Count;
+        var rolled = 0;
+        for (var i = 0; i < diceCount; i++)
+        {
+            rolled += rng.Next(1, expr.Faces + 1);
+        }
+
+        return Math.Max(0, rolled + expr.FlatBonus + damageBonus);
+    }
+
+    /// <summary>
+    /// Applies the target's resistance (half) and vulnerability (double) for the given damage type.
+    /// </summary>
+    private static int ApplyResistanceVulnerability(int damage, string? damageType, CombatParticipant target)
+    {
+        if (string.IsNullOrWhiteSpace(damageType) || damage <= 0)
+        {
+            return damage;
+        }
+
+        var type = damageType.Trim().ToLowerInvariant();
+
+        if (ContainsType(target.Vulnerabilities, type))
+        {
+            damage *= 2;
+        }
+
+        if (ContainsType(target.Resistances, type))
+        {
+            damage /= 2;
+        }
+
+        return damage;
+    }
+
+    private static bool ContainsType(string? csv, string type) =>
+        !string.IsNullOrWhiteSpace(csv)
+        && csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+              .Any(t => string.Equals(t, type, StringComparison.OrdinalIgnoreCase));
 
     /// <inheritdoc/>
     public async Task<CombatDto?> StartCombatAsync(int combatId, StartCombatDto? request, int userId)
@@ -748,6 +885,9 @@ public class CombatService(
             MaxHp = p.MaxHp,
             Initiative = p.Initiative,
             DexterityModifier = p.DexterityModifier,
+            ArmorClass = p.ArmorClass,
+            Resistances = p.Resistances,
+            Vulnerabilities = p.Vulnerabilities,
             TurnOrder = p.TurnOrder,
             IsActive = p.IsActive,
         };

--- a/Cdm/Cdm.Data.Common/Models/CombatParticipant.cs
+++ b/Cdm/Cdm.Data.Common/Models/CombatParticipant.cs
@@ -44,6 +44,15 @@ public class CombatParticipant
     /// <summary>Gets or sets the Dexterity modifier used for automatic initiative (1d20 + DEX).</summary>
     public int DexterityModifier { get; set; }
 
+    /// <summary>Gets or sets the armor class used to resolve incoming attacks server-side.</summary>
+    public int ArmorClass { get; set; } = 10;
+
+    /// <summary>Gets or sets the damage types this participant resists (comma-separated, lowercase).</summary>
+    public string? Resistances { get; set; }
+
+    /// <summary>Gets or sets the damage types this participant is vulnerable to (comma-separated, lowercase).</summary>
+    public string? Vulnerabilities { get; set; }
+
     /// <summary>Gets or sets the turn order position (assigned after initiative is sorted).</summary>
     public int TurnOrder { get; set; }
 

--- a/Cdm/Cdm.Migrations/Migrations/20260719170000_AddCombatParticipantDefense.cs
+++ b/Cdm/Cdm.Migrations/Migrations/20260719170000_AddCombatParticipantDefense.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Cdm.Migrations;
+
+#nullable disable
+
+namespace Cdm.Migrations.Migrations
+{
+    /// <summary>
+    /// Ajoute les colonnes de défense à [CombatParticipants] pour la résolution serveur
+    /// des attaques : [ArmorClass] (classe d'armure), [Resistances] et [Vulnerabilities]
+    /// (types de dégâts, séparés par des virgules).
+    /// </summary>
+    [DbContext(typeof(MigrationsContext))]
+    [Migration("20260719170000_AddCombatParticipantDefense")]
+    public partial class AddCombatParticipantDefense : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH('[CombatParticipants]', 'ArmorClass') IS NULL
+                    ALTER TABLE [CombatParticipants] ADD [ArmorClass] int NOT NULL DEFAULT 10;
+
+                IF COL_LENGTH('[CombatParticipants]', 'Resistances') IS NULL
+                    ALTER TABLE [CombatParticipants] ADD [Resistances] nvarchar(400) NULL;
+
+                IF COL_LENGTH('[CombatParticipants]', 'Vulnerabilities') IS NULL
+                    ALTER TABLE [CombatParticipants] ADD [Vulnerabilities] nvarchar(400) NULL;
+            ");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH('[CombatParticipants]', 'Vulnerabilities') IS NOT NULL
+                    ALTER TABLE [CombatParticipants] DROP COLUMN [Vulnerabilities];
+
+                IF COL_LENGTH('[CombatParticipants]', 'Resistances') IS NOT NULL
+                    ALTER TABLE [CombatParticipants] DROP COLUMN [Resistances];
+
+                IF COL_LENGTH('[CombatParticipants]', 'ArmorClass') IS NOT NULL
+                BEGIN
+                    DECLARE @df sysname;
+                    SELECT @df = dc.name FROM sys.default_constraints dc
+                        JOIN sys.columns c ON c.default_object_id = dc.object_id
+                        WHERE dc.parent_object_id = OBJECT_ID('[CombatParticipants]') AND c.name = 'ArmorClass';
+                    IF @df IS NOT NULL EXEC('ALTER TABLE [CombatParticipants] DROP CONSTRAINT [' + @df + ']');
+                    ALTER TABLE [CombatParticipants] DROP COLUMN [ArmorClass];
+                END
+            ");
+        }
+    }
+}

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor
@@ -275,9 +275,42 @@ else if (Combat != null)
                     </div>
                 </div>
 
-                <!-- Panel droit: log -->
+                <!-- Panel droit: log + résolution d'attaque -->
                 <div class="combat-log-panel">
                     <CombatLog Actions="@VisibleActionsForGm" Title="Journal de combat" />
+
+                    <div class="cdm-card" style="margin-top: var(--spacing-sm); padding: var(--spacing-sm);">
+                        <h4 style="margin-bottom: var(--spacing-xs);"><i class="bi bi-crosshair"></i> Résoudre une attaque</h4>
+                        <div style="display: flex; flex-direction: column; gap: var(--spacing-xs);">
+                            <select class="form-control" style="font-size: var(--font-size-sm);" @bind="AtkAttackerId">
+                                <option value="0">Attaquant…</option>
+                                @foreach (var p in Combat.Participants.Where(p => p.IsActive))
+                                {
+                                    <option value="@p.Id">@p.Name</option>
+                                }
+                            </select>
+                            <select class="form-control" style="font-size: var(--font-size-sm);" @bind="AtkTargetId">
+                                <option value="0">Cible…</option>
+                                @foreach (var p in Combat.Participants.Where(p => p.IsActive))
+                                {
+                                    <option value="@p.Id">@p.Name (CA @p.ArmorClass, PV @p.CurrentHp/@p.MaxHp)</option>
+                                }
+                            </select>
+                            <div style="display: flex; gap: var(--spacing-xs); align-items: center; flex-wrap: wrap;">
+                                <label style="font-size: var(--font-size-xs);">Att.</label>
+                                <input type="number" class="form-control" style="width: 60px; font-size: var(--font-size-sm);" @bind="AtkBonus" title="Bonus d'attaque (1d20 + bonus)" />
+                                <input class="form-control" style="width: 70px; font-size: var(--font-size-sm);" @bind="AtkDamageDice" title="Dés de dégâts" />
+                                <label style="font-size: var(--font-size-xs);">+</label>
+                                <input type="number" class="form-control" style="width: 55px; font-size: var(--font-size-sm);" @bind="AtkDamageBonus" title="Bonus de dégâts" />
+                            </div>
+                            <input class="form-control" style="font-size: var(--font-size-sm);" placeholder="Type de dégâts (ex: perçant)" @bind="AtkDamageType" />
+                            <input class="form-control" style="font-size: var(--font-size-sm);" placeholder="Libellé (ex: Épée longue)" @bind="AtkLabel" />
+                            <button class="btn btn-primary btn-sm" @onclick="ResolveAttack"
+                                    disabled="@(IsResolvingAttack || AtkAttackerId <= 0 || AtkTargetId <= 0 || AtkAttackerId == AtkTargetId)">
+                                <i class="bi bi-lightning-charge"></i> Résoudre (1d20 vs CA)
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         }

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor.cs
@@ -169,6 +169,33 @@ public partial class CombatGm : IAsyncDisposable
         IsRollingInitiative = false;
     }
 
+    // Server-side attack resolution form state.
+    private int AtkAttackerId;
+    private int AtkTargetId;
+    private int AtkBonus;
+    private string AtkDamageDice = "1d8";
+    private int AtkDamageBonus;
+    private string? AtkDamageType;
+    private string? AtkLabel;
+    private bool IsResolvingAttack;
+
+    private async Task ResolveAttack()
+    {
+        if (IsResolvingAttack || AtkAttackerId <= 0 || AtkTargetId <= 0 || AtkAttackerId == AtkTargetId) return;
+        IsResolvingAttack = true;
+        var updated = await CombatClient.ResolveAttackAsync(CombatId, AtkAttackerId, new ResolveAttackDto
+        {
+            TargetParticipantId = AtkTargetId,
+            AttackBonus = AtkBonus,
+            DamageDice = string.IsNullOrWhiteSpace(AtkDamageDice) ? "1d4" : AtkDamageDice.Trim(),
+            DamageBonus = AtkDamageBonus,
+            DamageType = string.IsNullOrWhiteSpace(AtkDamageType) ? null : AtkDamageType.Trim(),
+            Label = string.IsNullOrWhiteSpace(AtkLabel) ? null : AtkLabel.Trim()
+        });
+        if (updated != null) { Combat = updated; await LoadActiveCharacterAsync(); }
+        IsResolvingAttack = false;
+    }
+
     private async Task StartCombat()
     {
         var updated = await CombatClient.StartCombatAsync(CombatId);

--- a/Cdm/Cdm.Web/Services/ApiClients/CombatApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ApiClients/CombatApiClient.cs
@@ -139,6 +139,26 @@ public class CombatApiClient
         }
     }
 
+    /// <summary>Resolves an attack from one participant against another, server-side.</summary>
+    public async Task<CombatDto?> ResolveAttackAsync(int combatId, int attackerId, ResolveAttackDto dto)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await this.httpClient.PostAsJsonAsync($"api/combat/{combatId}/attack/{attackerId}", dto);
+            if (response.IsSuccessStatusCode)
+                return await response.Content.ReadFromJsonAsync<CombatDto>();
+
+            this.logger.LogWarning("Failed to resolve attack in combat {CombatId}. Status: {StatusCode}", combatId, response.StatusCode);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error resolving attack in combat {CombatId}", combatId);
+            return null;
+        }
+    }
+
     /// <summary>Sets the initiative value for a participant.</summary>
     public async Task<CombatDto?> SetInitiativeAsync(int combatId, int participantId, SetInitiativeDto dto)
     {


### PR DESCRIPTION
…istances)

Deuxième tranche du combat D&D automatisé : les attaques sont résolues côté serveur, de façon autoritaire.

- CombatParticipant : ArmorClass, Resistances, Vulnerabilities (+ migration). La CA des joueurs est résolue depuis leur fiche à la création du combat.
- CombatService.ResolveAttackAsync : jet 1d20 + bonus vs CA de la cible (échec/réussite critique sur 1/20), dégâts = dés (doublés au critique, façon 5e)
  + bonus, puis résistance (moitié) / vulnérabilité (double) selon le type de dégâts ; application aux PV et journalisation de l'action. MJ ou propriétaire de l'attaquant.
- Endpoint POST /api/combat/{id}/attack/{attackerId} + méthode client.
- UI MJ : formulaire « Résoudre une attaque » (attaquant, cible, bonus, dés, type) dans le panneau de combat, résultat visible dans le journal.

Tests : 3 tests ResolveAttack (touche garantie, CA élevée, vulnérabilité) + les 3 d'initiative. Build Release /warnaserror OK, dotnet test = 102/102 verts.