### PR TITLE
feat(dnd): calcul auto de la CA et des PV + règles D&D partagées

### DIFF
--- a/Cdm/Cdm.Business.DnD5e/Services/DndCharacterService.cs
+++ b/Cdm/Cdm.Business.DnD5e/Services/DndCharacterService.cs
@@ -261,15 +261,7 @@ public class DndCharacterService(AppDbContext dbContext, ILogger<DndCharacterSer
         return stats;
     }
 
-    private static int CalculateProficiencyBonus(int level) => level switch
-    {
-        >= 1 and <= 4 => 2,
-        >= 5 and <= 8 => 3,
-        >= 9 and <= 12 => 4,
-        >= 13 and <= 16 => 5,
-        >= 17 and <= 20 => 6,
-        _ => 2
-    };
+    private static int CalculateProficiencyBonus(int level) => Cdm.Common.DndRules.ProficiencyBonus(level);
 
     private static DndInventoryItemDto MapInventoryItem(DndInventoryItem i) => new()
     {

--- a/Cdm/Cdm.Business.DnD5e/Services/DndNpcService.cs
+++ b/Cdm/Cdm.Business.DnD5e/Services/DndNpcService.cs
@@ -163,15 +163,7 @@ public class DndNpcService(AppDbContext dbContext, ILogger<DndNpcService> logger
         return JsonSerializer.Serialize(stats, JsonOpts);
     }
 
-    private static int CalculateProficiencyBonus(int level) => level switch
-    {
-        >= 1 and <= 4 => 2,
-        >= 5 and <= 8 => 3,
-        >= 9 and <= 12 => 4,
-        >= 13 and <= 16 => 5,
-        >= 17 and <= 20 => 6,
-        _ => 2
-    };
+    private static int CalculateProficiencyBonus(int level) => Cdm.Common.DndRules.ProficiencyBonus(level);
 
     private static DndNpcDto MapToDto(NonPlayerCharacter npc)
     {

--- a/Cdm/Cdm.Common.Tests/DndRulesTests.cs
+++ b/Cdm/Cdm.Common.Tests/DndRulesTests.cs
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="DndRulesTests.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Common.Tests;
+
+using Cdm.Common;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="DndRules"/>.
+/// </summary>
+public class DndRulesTests
+{
+    [Theory]
+    [InlineData(1, 2)]
+    [InlineData(4, 2)]
+    [InlineData(5, 3)]
+    [InlineData(8, 3)]
+    [InlineData(9, 4)]
+    [InlineData(12, 4)]
+    [InlineData(13, 5)]
+    [InlineData(16, 5)]
+    [InlineData(17, 6)]
+    [InlineData(20, 6)]
+    public void ProficiencyBonus_MatchesTable(int level, int expected)
+    {
+        Assert.Equal(expected, DndRules.ProficiencyBonus(level));
+    }
+
+    [Theory]
+    [InlineData(0, 10)]
+    [InlineData(3, 13)]
+    [InlineData(-1, 9)]
+    public void UnarmoredArmorClass_IsTenPlusDex(int dexMod, int expected)
+    {
+        Assert.Equal(expected, DndRules.UnarmoredArmorClass(dexMod));
+    }
+
+    /// <summary>Level 1 fighter (d10) with +2 CON => 10 + 2 = 12.</summary>
+    [Fact]
+    public void AverageHitPoints_Level1_UsesFullHitDiePlusCon()
+    {
+        Assert.Equal(12, DndRules.AverageHitPoints(hitDie: 10, constitutionModifier: 2, level: 1));
+    }
+
+    /// <summary>Level 3 fighter (d10) with +2 CON => 12 (L1) + 2 * (6 + 2) = 12 + 16 = 28.</summary>
+    [Fact]
+    public void AverageHitPoints_HigherLevel_AddsAveragePerLevel()
+    {
+        Assert.Equal(28, DndRules.AverageHitPoints(hitDie: 10, constitutionModifier: 2, level: 3));
+    }
+
+    [Theory]
+    [InlineData(0, 2, 1)]
+    [InlineData(8, 0, 0)]
+    public void AverageHitPoints_InvalidInputs_ReturnZero(int hitDie, int conMod, int level)
+    {
+        Assert.Equal(0, DndRules.AverageHitPoints(hitDie, conMod, level));
+    }
+}

--- a/Cdm/Cdm.Common/DndRules.cs
+++ b/Cdm/Cdm.Common/DndRules.cs
@@ -1,0 +1,60 @@
+// -----------------------------------------------------------------------
+// <copyright file="DndRules.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Common;
+
+/// <summary>
+/// Shared, pure D&amp;D 5e rule calculations, so the same formulas are used across the
+/// character wizard, the character sheet and the API services (no duplication/drift).
+/// </summary>
+public static class DndRules
+{
+    /// <summary>
+    /// Proficiency bonus for a given character level (D&amp;D 5e: +2 at levels 1-4, up to +6 at 17-20).
+    /// </summary>
+    /// <param name="level">The character level.</param>
+    /// <returns>The proficiency bonus.</returns>
+    public static int ProficiencyBonus(int level) => level switch
+    {
+        <= 4 => 2,
+        <= 8 => 3,
+        <= 12 => 4,
+        <= 16 => 5,
+        _ => 6
+    };
+
+    /// <summary>
+    /// Unarmored armor class: 10 + Dexterity modifier.
+    /// </summary>
+    /// <param name="dexterityModifier">The Dexterity modifier.</param>
+    /// <returns>The base armor class without armor.</returns>
+    public static int UnarmoredArmorClass(int dexterityModifier) => 10 + dexterityModifier;
+
+    /// <summary>
+    /// Average maximum hit points: the full hit die at level 1, then the average roll
+    /// (<c>hitDie / 2 + 1</c>) for each subsequent level, plus the Constitution modifier per level.
+    /// </summary>
+    /// <param name="hitDie">The class hit die (e.g. 8 for a d8).</param>
+    /// <param name="constitutionModifier">The Constitution modifier.</param>
+    /// <param name="level">The character level.</param>
+    /// <returns>The suggested maximum hit points (at least 1).</returns>
+    public static int AverageHitPoints(int hitDie, int constitutionModifier, int level)
+    {
+        if (hitDie <= 0 || level <= 0)
+        {
+            return 0;
+        }
+
+        var perLevelAverage = (hitDie / 2) + 1;
+        var hitPoints = hitDie + constitutionModifier; // level 1 gets the max hit die
+        if (level > 1)
+        {
+            hitPoints += (level - 1) * (perLevelAverage + constitutionModifier);
+        }
+
+        return Math.Max(1, hitPoints);
+    }
+}

--- a/Cdm/Cdm.Web/Components/Pages/Characters/WorldCharacterDndDetail.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/WorldCharacterDndDetail.razor
@@ -204,6 +204,11 @@ else
                                        style="width:44px; text-align:center; font-size:var(--font-size-sm); background:var(--color-bg-primary); border:1px solid var(--color-primary); border-radius:var(--radius-sm); color:var(--color-text-primary); padding:2px;" />
                             </div>
                             <div style="font-size:10px; color:var(--color-text-muted); margin-top:2px;">PV</div>
+                            <button type="button" class="btn btn-ghost btn-sm" style="margin-top:2px; font-size:10px; padding:1px 6px;"
+                                    title="Calculer les PV max (dé de vie de la classe + Constitution)"
+                                    @onclick="AutoComputeHitPoints">
+                                <i class="bi bi-magic"></i> Auto
+                            </button>
                         </div>
                         <div style="display: flex; flex-direction: column; align-items: center; background: var(--color-bg-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--spacing-sm);">
                             <i class="bi bi-shield-fill" style="color: var(--color-info); margin-bottom: var(--spacing-xs);"></i>
@@ -211,6 +216,11 @@ else
                                    @onchange="@(e => Stats.ArmorClass = int.TryParse(e.Value?.ToString(), out var v) ? v : Stats.ArmorClass)"
                                    style="width:48px; text-align:center; font-size:var(--font-size-sm); background:var(--color-bg-primary); border:1px solid var(--color-primary); border-radius:var(--radius-sm); color:var(--color-text-primary); padding:2px;" />
                             <div style="font-size:10px; color:var(--color-text-muted); margin-top:2px;">CA</div>
+                            <button type="button" class="btn btn-ghost btn-sm" style="margin-top:2px; font-size:10px; padding:1px 6px;"
+                                    title="Calculer la CA sans armure (10 + mod. Dextérité)"
+                                    @onclick="AutoComputeArmorClass">
+                                <i class="bi bi-magic"></i> Auto
+                            </button>
                         </div>
                         <div style="display: flex; flex-direction: column; align-items: center; background: var(--color-bg-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--spacing-sm);">
                             <i class="bi bi-lightning-fill" style="color: var(--color-warning); margin-bottom: var(--spacing-xs);"></i>

--- a/Cdm/Cdm.Web/Components/Pages/Characters/WorldCharacterDndDetail.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/WorldCharacterDndDetail.razor.cs
@@ -29,6 +29,7 @@ public partial class WorldCharacterDndDetail
     // Reference data
     private List<DndItemDto> AvailableItems = new();
     private List<DndSpellDto> AvailableSpells = new();
+    private List<DndClassDto> AvailableClasses = new();
 
     // ── Stats edit ────────────────────────────────────────────────────────
 
@@ -91,8 +92,9 @@ public partial class WorldCharacterDndDetail
             var spellsTask = DndClient.GetCharacterSpellsAsync(WorldCharacterId);
             var itemsTask = DndClient.GetItemsAsync();
             var spellsRefTask = DndClient.GetSpellsAsync();
+            var classesTask = DndClient.GetClassesAsync();
 
-            await Task.WhenAll(wcTask, statsTask, inventoryTask, spellsTask, itemsTask, spellsRefTask);
+            await Task.WhenAll(wcTask, statsTask, inventoryTask, spellsTask, itemsTask, spellsRefTask, classesTask);
 
             WorldCharacter = wcTask.Result;
             Stats = statsTask.Result ?? new DndCharacterStatsDto { WorldCharacterId = WorldCharacterId };
@@ -101,6 +103,7 @@ public partial class WorldCharacterDndDetail
             CharacterSpells = spellsTask.Result;
             AvailableItems = itemsTask.Result;
             AvailableSpells = spellsRefTask.Result;
+            AvailableClasses = classesTask.Result;
         }
         catch
         {
@@ -119,6 +122,30 @@ public partial class WorldCharacterDndDetail
     private static string Fmt(int mod) => mod >= 0 ? $"+{mod}" : $"{mod}";
 
     private int ProfBonus => CalcProfBonus(Stats.Level ?? 1);
+
+    /// <summary>Sets the armor class to its unarmored value (10 + Dexterity modifier).</summary>
+    private void AutoComputeArmorClass()
+    {
+        Stats.ArmorClass = Cdm.Common.DndRules.UnarmoredArmorClass(Stats.DexterityModifier ?? 0);
+    }
+
+    /// <summary>Sets the maximum hit points from the class hit die, Constitution and level.</summary>
+    private void AutoComputeHitPoints()
+    {
+        var hitDie = AvailableClasses
+            .FirstOrDefault(c => string.Equals(c.Name, Stats.CharacterClass, StringComparison.OrdinalIgnoreCase))?.HitDie ?? 0;
+        if (hitDie <= 0)
+        {
+            return;
+        }
+
+        var max = Cdm.Common.DndRules.AverageHitPoints(hitDie, Stats.ConstitutionModifier ?? 0, Stats.Level ?? 1);
+        Stats.MaxHitPoints = max;
+        if (!Stats.CurrentHitPoints.HasValue || Stats.CurrentHitPoints > max)
+        {
+            Stats.CurrentHitPoints = max;
+        }
+    }
 
     private static int CalcProfBonus(int level) =>
         level switch { <= 4 => 2, <= 8 => 3, <= 12 => 4, <= 16 => 5, _ => 6 };

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/DndCharacterWizard.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/DndCharacterWizard.razor.cs
@@ -307,8 +307,7 @@ public partial class DndCharacterWizard
         return (SelectedClass.HitDie + (Stats.Level.Value - 1) * (SelectedClass.HitDie / 2 + 1) + conMod * Stats.Level.Value).ToString();
     }
 
-    private static int GetProficiencyBonus(int level) =>
-        level switch { <= 4 => 2, <= 8 => 3, <= 12 => 4, <= 16 => 5, _ => 6 };
+    private static int GetProficiencyBonus(int level) => Cdm.Common.DndRules.ProficiencyBonus(level);
 
     // ── Step 3 — Inventory ───────────────────────────────────────────────
 


### PR DESCRIPTION
Tranche « D&D 5e avancé » : auto-calcul de la classe d'armure et des points de vie sur la fiche, et consolidation des règles dupliquées.

- DndRules (Cdm.Common) : helper pur et testé — bonus de maîtrise selon le niveau, CA sans armure (10 + mod. DEX), PV moyens (dé de vie plein au niveau 1 puis moyenne par niveau + mod. Constitution).
- Fiche personnage : boutons « Auto » sous PV et CA qui pré-remplissent les valeurs (CA = 10 + DEX ; PV = dé de vie de la classe + Constitution + niveau).
- Consolide les 3 implémentations dupliquées du bonus de maîtrise (DndCharacterService, DndNpcService, DndCharacterWizard) vers DndRules.ProficiencyBonus.

Note : les jets de sauvegarde et le bonus de maîtrise étaient déjà calculés/affichés.
Restent, pour ce même item : sous-classes et montée de niveau (flux dédié).

Tests : 17 tests DndRules. Build Release /warnaserror OK, dotnet test = 119/119 verts.