### PR TITLE
fix(combat): permet de corriger à la main la CA et le mod. DEX d'un p…

### DIFF
--- a/Cdm/Cdm.ApiService/Endpoints/CombatEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/CombatEndpoints.cs
@@ -57,6 +57,11 @@ public static class CombatEndpoints
             .WithName("ResolveAttack")
             .WithOpenApi();
 
+        // PUT /api/combat/{id}/participants/{participantId}/defense — Override defensive stats
+        group.MapPut("/{id:int}/participants/{participantId:int}/defense", UpdateParticipantDefenseAsync)
+            .WithName("UpdateParticipantDefense")
+            .WithOpenApi();
+
         // PUT /api/combat/{id}/initiative/{participantId} — Set a participant's initiative
         group.MapPut("/{id:int}/initiative/{participantId:int}", SetInitiativeAsync)
             .WithName("SetInitiative")
@@ -206,6 +211,24 @@ public static class CombatEndpoints
         var result = await combatService.ResolveAttackAsync(id, attackerId, request, userId.Value);
         if (result == null)
             return Results.BadRequest(new { Error = "Failed to resolve attack. Check IDs and authorization." });
+
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> UpdateParticipantDefenseAsync(
+        int id,
+        int participantId,
+        [FromBody] UpdateParticipantDefenseDto request,
+        [FromServices] ICombatService combatService,
+        ILogger<CombatEndpointsLogger> logger,
+        HttpContext httpContext)
+    {
+        var userId = GetUserId(httpContext);
+        if (userId == null) return Results.Unauthorized();
+
+        var result = await combatService.UpdateParticipantDefenseAsync(id, participantId, request, userId.Value);
+        if (result == null)
+            return Results.BadRequest(new { Error = "Failed to update participant defense. Check IDs and authorization." });
 
         return Results.Ok(result);
     }

--- a/Cdm/Cdm.Business.Abstraction/DTOs/CombatDtos.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/CombatDtos.cs
@@ -184,3 +184,19 @@ public class ResolveAttackDto
     /// <summary>Optional label for the attack (e.g. weapon or spell name), for the log.</summary>
     public string? Label { get; set; }
 }
+
+/// <summary>Request to override a participant's defensive stats (armor class, DEX modifier, resistances).</summary>
+public class UpdateParticipantDefenseDto
+{
+    /// <summary>The armor class to set.</summary>
+    public int ArmorClass { get; set; }
+
+    /// <summary>The Dexterity modifier to set (used for initiative).</summary>
+    public int DexterityModifier { get; set; }
+
+    /// <summary>Resisted damage types (comma-separated), optional.</summary>
+    public string? Resistances { get; set; }
+
+    /// <summary>Vulnerable damage types (comma-separated), optional.</summary>
+    public string? Vulnerabilities { get; set; }
+}

--- a/Cdm/Cdm.Business.Abstraction/Services/ICombatService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/ICombatService.cs
@@ -49,6 +49,18 @@ public interface ICombatService
     /// <returns>The updated combat, or null if not found/unauthorized.</returns>
     Task<CombatDto?> ResolveAttackAsync(int combatId, int attackerParticipantId, ResolveAttackDto request, int userId);
 
+    /// <summary>
+    /// Overrides a participant's defensive stats (armor class, Dexterity modifier, resistances,
+    /// vulnerabilities), so the GM can correct the values auto-resolved at combat creation.
+    /// Only the GM of the session may do this.
+    /// </summary>
+    /// <param name="combatId">The combat identifier.</param>
+    /// <param name="participantId">The participant identifier.</param>
+    /// <param name="request">The new defensive stats.</param>
+    /// <param name="userId">The requesting user (must be GM).</param>
+    /// <returns>The updated combat, or null if not found/unauthorized.</returns>
+    Task<CombatDto?> UpdateParticipantDefenseAsync(int combatId, int participantId, UpdateParticipantDefenseDto request, int userId);
+
     /// <summary>Sorts participants by initiative and transitions the combat to Active (Status = 2).</summary>
     Task<CombatDto?> StartCombatAsync(int combatId, StartCombatDto? request, int userId);
 

--- a/Cdm/Cdm.Business.Common.Tests/Services/CombatServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/CombatServiceTests.cs
@@ -147,6 +147,51 @@ public class CombatServiceTests
     }
 
     /// <summary>
+    /// The GM can override a participant's armor class and Dexterity modifier after creation.
+    /// </summary>
+    [Fact]
+    public async Task UpdateParticipantDefenseAsync_AsGm_OverridesStats()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(UpdateParticipantDefenseAsync_AsGm_OverridesStats)));
+        await SeedSessionAsync(context);
+        var combatId = await SeedCombatWithParticipantsAsync(context);
+        var service = this.CreateService(context);
+
+        var result = await service.UpdateParticipantDefenseAsync(combatId, 502, new UpdateParticipantDefenseDto
+        {
+            ArmorClass = 17,
+            DexterityModifier = 2,
+            Resistances = "feu",
+            Vulnerabilities = "froid"
+        }, GmUserId);
+
+        Assert.NotNull(result);
+        var goblin = await context.CombatParticipants.FindAsync(502);
+        Assert.Equal(17, goblin!.ArmorClass);
+        Assert.Equal(2, goblin.DexterityModifier);
+        Assert.Equal("feu", goblin.Resistances);
+        Assert.Equal("froid", goblin.Vulnerabilities);
+    }
+
+    /// <summary>
+    /// A non-GM cannot override participant defensive stats.
+    /// </summary>
+    [Fact]
+    public async Task UpdateParticipantDefenseAsync_NotGm_ReturnsNull()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(UpdateParticipantDefenseAsync_NotGm_ReturnsNull)));
+        await SeedSessionAsync(context);
+        var combatId = await SeedCombatWithParticipantsAsync(context);
+        var service = this.CreateService(context);
+
+        var result = await service.UpdateParticipantDefenseAsync(combatId, 502, new UpdateParticipantDefenseDto { ArmorClass = 99, DexterityModifier = 9 }, 999);
+
+        Assert.Null(result);
+        var goblin = await context.CombatParticipants.FindAsync(502);
+        Assert.NotEqual(99, goblin!.ArmorClass);
+    }
+
+    /// <summary>
     /// A guaranteed hit (huge attack bonus vs low AC) reduces the target's HP and logs the attack.
     /// </summary>
     [Fact]

--- a/Cdm/Cdm.Business.Common/Services/CombatService.cs
+++ b/Cdm/Cdm.Business.Common/Services/CombatService.cs
@@ -430,6 +430,46 @@ public class CombatService(
         }
     }
 
+    /// <inheritdoc/>
+    public async Task<CombatDto?> UpdateParticipantDefenseAsync(int combatId, int participantId, UpdateParticipantDefenseDto request, int userId)
+    {
+        try
+        {
+            var combat = await this.dbContext.Combats
+                .Include(c => c.Participants)
+                .FirstOrDefaultAsync(c => c.Id == combatId);
+
+            if (combat == null) return null;
+
+            if (!await this.IsGmOfSessionAsync(combat.SessionId, userId))
+            {
+                this.logger.LogWarning("User {UserId} not authorized to edit participant defense in combat {CombatId}", userId, combatId);
+                return null;
+            }
+
+            var participant = combat.Participants.FirstOrDefault(p => p.Id == participantId);
+            if (participant == null) return null;
+
+            participant.ArmorClass = request.ArmorClass;
+            participant.DexterityModifier = request.DexterityModifier;
+            participant.Resistances = string.IsNullOrWhiteSpace(request.Resistances) ? null : request.Resistances.Trim();
+            participant.Vulnerabilities = string.IsNullOrWhiteSpace(request.Vulnerabilities) ? null : request.Vulnerabilities.Trim();
+
+            await this.dbContext.SaveChangesAsync();
+
+            this.logger.LogInformation(
+                "Updated defense for participant {ParticipantId} in combat {CombatId} (CA {AC}, DEX {Dex})",
+                participantId, combatId, request.ArmorClass, request.DexterityModifier);
+
+            return await this.LoadCombatDtoAsync(combatId);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error updating participant defense in combat {CombatId}", combatId);
+            return null;
+        }
+    }
+
     /// <summary>
     /// Rolls damage dice (doubling the dice on a critical hit, per D&D 5e) plus a flat bonus.
     /// </summary>

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor
@@ -72,6 +72,15 @@ else if (Combat != null)
                                 @(p.IsPlayerCharacter ? "Joueur" : "PNJ")
                             </span>
 
+                            <span class="initiative-defense-edit" style="display:inline-flex; align-items:center; gap:4px; font-size:var(--font-size-xs);" title="Corrige manuellement la CA et le modificateur de Dextérité">
+                                <label style="color:var(--color-text-muted);">CA</label>
+                                <input type="number" class="form-control" style="width:52px;" value="@p.ArmorClass"
+                                       @onchange="e => OnAcChanged(participant, e)" />
+                                <label style="color:var(--color-text-muted);">DEX</label>
+                                <input type="number" class="form-control" style="width:52px;" value="@p.DexterityModifier"
+                                       @onchange="e => OnDexChanged(participant, e)" />
+                            </span>
+
                             @if (p.Initiative.HasValue)
                             {
                                 <span class="initiative-value-display">@p.Initiative</span>

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/CombatGm.razor.cs
@@ -227,6 +227,28 @@ public partial class CombatGm : IAsyncDisposable
         await SetParticipantInitiative(participant, roll.ToString());
     }
 
+    private async Task UpdateDefense(CombatParticipantDto p, int? armorClass, int? dexModifier)
+    {
+        var updated = await CombatClient.UpdateParticipantDefenseAsync(CombatId, p.Id, new UpdateParticipantDefenseDto
+        {
+            ArmorClass = armorClass ?? p.ArmorClass,
+            DexterityModifier = dexModifier ?? p.DexterityModifier,
+            Resistances = p.Resistances,
+            Vulnerabilities = p.Vulnerabilities
+        });
+        if (updated != null) Combat = updated;
+    }
+
+    private async Task OnAcChanged(CombatParticipantDto p, ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var v)) await UpdateDefense(p, v, null);
+    }
+
+    private async Task OnDexChanged(CombatParticipantDto p, ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), out var v)) await UpdateDefense(p, null, v);
+    }
+
     private async Task RecordActionFromDice(CreateCombatActionDto action)
     {
         await CombatClient.RecordActionAsync(CombatId, action);

--- a/Cdm/Cdm.Web/Services/ApiClients/CombatApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ApiClients/CombatApiClient.cs
@@ -159,6 +159,26 @@ public class CombatApiClient
         }
     }
 
+    /// <summary>Overrides a participant's defensive stats (armor class, DEX modifier, resistances).</summary>
+    public async Task<CombatDto?> UpdateParticipantDefenseAsync(int combatId, int participantId, UpdateParticipantDefenseDto dto)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await this.httpClient.PutAsJsonAsync($"api/combat/{combatId}/participants/{participantId}/defense", dto);
+            if (response.IsSuccessStatusCode)
+                return await response.Content.ReadFromJsonAsync<CombatDto>();
+
+            this.logger.LogWarning("Failed to update defense for participant {ParticipantId}. Status: {StatusCode}", participantId, response.StatusCode);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error updating defense for participant {ParticipantId}", participantId);
+            return null;
+        }
+    }
+
     /// <summary>Sets the initiative value for a participant.</summary>
     public async Task<CombatDto?> SetInitiativeAsync(int combatId, int participantId, SetInitiativeDto dto)
     {


### PR DESCRIPTION
…articipant

Les stats de défense (CA, mod. DEX) étaient résolues automatiquement à la création du combat mais n'étaient plus modifiables ensuite. Le MJ peut désormais les corriger.

- CombatService.UpdateParticipantDefenseAsync (MJ) : met à jour CA, mod. DEX, résistances et vulnérabilités d'un participant.
- Endpoint PUT /api/combat/{id}/participants/{participantId}/defense + méthode client.
- UI MJ : champs CA / DEX éditables sur chaque ligne de la phase d'initiative.

Ainsi tout reste surchargeable à la main : l'automatisation n'est qu'un raccourci.

Tests : 2 tests (override par le MJ, refus pour un non-MJ). Build Release /warnaserror OK, dotnet test = 121/121 verts.