### PR TITLE
feat(history): sessions passées groupées par campagne + mondes rejoints

### DIFF
--- a/Cdm/Cdm.Web/Components/Pages/Sessions/Sessions.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/Sessions.razor
@@ -78,29 +78,41 @@ else
     {
         <h3 style="font-size: var(--font-size-md); color: var(--color-text-secondary); margin-bottom: var(--spacing-md);">
             <i class="bi bi-clock-history"></i>
-            Historique
+            Historique par campagne
         </h3>
-        <div class="cards-grid">
-            @foreach (var session in pastSessions.OrderByDescending(s => s.StartedAt))
-            {
-                <div class="cdm-card" style="opacity: 0.8;">
-                    <div class="card-header-row">
-                        <span class="status-badge @GetSessionStatusClass(session.Status)">@GetSessionStatusLabel(session.Status)</span>
-                        @if (IsGm(session))
-                        {
-                            <span style="font-size: var(--font-size-xs); color: var(--color-text-muted);">MJ</span>
-                        }
-                    </div>
-                    <h3 class="card-title">@session.CampaignName</h3>
-                    <div class="card-meta">
-                        <span><i class="bi bi-calendar3"></i> @session.StartedAt.ToString("dd/MM/yyyy")</span>
-                        @if (session.EndedAt.HasValue)
-                        {
-                            <span><i class="bi bi-hourglass"></i> @((session.EndedAt.Value - session.StartedAt).TotalHours.ToString("F1"))h</span>
-                        }
-                    </div>
+        @foreach (var campaignGroup in pastSessions
+            .GroupBy(s => s.CampaignName)
+            .OrderBy(g => g.Key))
+        {
+            <div style="margin-bottom: var(--spacing-lg);">
+                <h4 style="font-size: var(--font-size-sm); color: var(--color-text-muted); margin-bottom: var(--spacing-sm);">
+                    <i class="bi bi-map"></i> @campaignGroup.Key
+                    <span style="color: var(--color-text-muted);">— @campaignGroup.Count() session(s)</span>
+                </h4>
+                <div class="cards-grid">
+                    @foreach (var session in campaignGroup.OrderByDescending(s => s.StartedAt))
+                    {
+                        <div class="cdm-card" style="opacity: 0.8;">
+                            <div class="card-header-row">
+                                <span class="status-badge @GetSessionStatusClass(session.Status)">@GetSessionStatusLabel(session.Status)</span>
+                                @if (IsGm(session))
+                                {
+                                    <span style="font-size: var(--font-size-xs); color: var(--color-text-muted);">MJ</span>
+                                }
+                            </div>
+                            <h3 class="card-title">@session.CampaignName</h3>
+                            <div class="card-meta">
+                                <span><i class="bi bi-calendar3"></i> @session.StartedAt.ToString("dd/MM/yyyy")</span>
+                                @if (session.EndedAt.HasValue)
+                                {
+                                    <span><i class="bi bi-hourglass"></i> @((session.EndedAt.Value - session.StartedAt).TotalHours.ToString("F1"))h</span>
+                                }
+                                <span><i class="bi bi-people"></i> @session.Participants.Count() joueur(s)</span>
+                            </div>
+                        </div>
+                    }
                 </div>
-            }
-        </div>
+            </div>
+        }
     }
 }

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/Worlds.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/Worlds.razor
@@ -25,7 +25,7 @@ else if (!string.IsNullOrEmpty(ErrorMessage))
         @ErrorMessage
     </div>
 }
-else if (WorldsList.Count == 0)
+else if (WorldsList.Count == 0 && JoinedWorlds.Count == 0)
 {
     <AppEmptyState Icon="bi-globe2"
                    Title="@L["Worlds_Empty"]"
@@ -40,6 +40,12 @@ else if (WorldsList.Count == 0)
 }
 else
 {
+    @if (WorldsList.Count > 0)
+    {
+        <h3 style="font-size: var(--font-size-md); color: var(--color-text-secondary); margin-bottom: var(--spacing-md);">
+            <i class="bi bi-shield-fill"></i> Mes mondes (MJ)
+        </h3>
+    }
     <div class="cards-grid">
         @foreach (var world in WorldsList)
         {
@@ -76,6 +82,36 @@ else
             </AppThemeWrapper>
         }
     </div>
+
+    @if (JoinedWorlds.Count > 0)
+    {
+        <h3 style="font-size: var(--font-size-md); color: var(--color-text-secondary); margin: var(--spacing-xl) 0 var(--spacing-md);">
+            <i class="bi bi-people-fill"></i> Mondes rejoints
+        </h3>
+        <div class="cards-grid">
+            @foreach (var world in JoinedWorlds)
+            {
+                <AppThemeWrapper GameType="@world.GameType">
+                    <div class="cdm-card world-card" style="cursor: pointer;"
+                         @onclick="() => NavigateToWorld(world.Id)">
+                        <div class="card-header-row">
+                            <AppGameBadge GameType="@world.GameType" />
+                            <span class="status-badge" style="background: var(--color-info); color: white; opacity: 0.9;">Joueur</span>
+                        </div>
+                        <h3 class="card-title">@world.Name</h3>
+                        @if (!string.IsNullOrEmpty(world.Description))
+                        {
+                            <p class="card-description">@world.Description</p>
+                        }
+                        <div class="card-meta">
+                            <span><i class="bi bi-map"></i> @world.CampaignCount @L["Nav_Campaigns"].ToString().ToLower()</span>
+                            <span><i class="bi bi-people"></i> @world.CharacterCount @L["Nav_Characters"].ToString().ToLower()</span>
+                        </div>
+                    </div>
+                </AppThemeWrapper>
+            }
+        </div>
+    }
 }
 
 <AppConfirmDialog @ref="DeleteDialog"

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/Worlds.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/Worlds.razor.cs
@@ -14,6 +14,7 @@ public partial class Worlds
     [Inject] private IStringLocalizer<AppStrings> L { get; set; } = default!;
 
     private List<WorldDto> WorldsList { get; set; } = new();
+    private List<WorldDto> JoinedWorlds { get; set; } = new();
     private bool IsLoading = true;
     private string ErrorMessage = string.Empty;
     private WorldDto? WorldToDelete;
@@ -30,7 +31,14 @@ public partial class Worlds
         ErrorMessage = string.Empty;
         try
         {
-            WorldsList = await WorldClient.GetMyWorldsAsync();
+            var ownedTask = WorldClient.GetMyWorldsAsync();
+            var allTask = WorldClient.GetAllMyWorldsAsync();
+            await Task.WhenAll(ownedTask, allTask);
+
+            WorldsList = ownedTask.Result;
+            // Joined worlds = worlds the user takes part in as a player, i.e. not owned.
+            var ownedIds = WorldsList.Select(w => w.Id).ToHashSet();
+            JoinedWorlds = allTask.Result.Where(w => !ownedIds.Contains(w.Id)).ToList();
         }
         catch
         {


### PR DESCRIPTION
Item « Historique » de la roadmap (100% front, réutilise les services existants).

- Sessions : la section « Historique » regroupe désormais les sessions passées par campagne (en-tête + compteur), triées par date, avec le nombre de joueurs.
- Mondes : nouvelle section « Mondes rejoints » listant les mondes où l'utilisateur participe en tant que joueur (dérivés par différence entre GetAllMyWorlds et GetMyWorlds), distincts de « Mes mondes (MJ) ».

Vérifié : build Release /warnaserror OK, dotnet test = 121/121 verts.