### PR TITLE
feat(dnd): sélection de sous-classe + montée de niveau sur la fiche

### DIFF
--- a/Cdm/Cdm.Web/Components/Pages/Characters/WorldCharacterDndDetail.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/WorldCharacterDndDetail.razor
@@ -50,7 +50,7 @@ else
                         @if (!string.IsNullOrEmpty(Stats.CharacterClass))
                         {
                             <span class="card-meta-badge" style="background: var(--color-primary); color: white;">
-                                <i class="bi bi-shield-fill"></i> @Stats.CharacterClass@(Stats.Subclass != null ? $" ({Stats.Subclass})" : "")
+                                <i class="bi bi-shield-fill"></i> @Stats.CharacterClass@(!string.IsNullOrEmpty(Stats.Subclass) ? $" ({Stats.Subclass})" : "")
                             </span>
                         }
                         @if (Stats.Level.HasValue)
@@ -235,7 +235,28 @@ else
                                    @onchange="@(e => Stats.Level = int.TryParse(e.Value?.ToString(), out var v) ? v : Stats.Level)"
                                    style="width:48px; text-align:center; font-size:var(--font-size-sm); background:var(--color-bg-primary); border:1px solid var(--color-primary); border-radius:var(--radius-sm); color:var(--color-text-primary); padding:2px;" />
                             <div style="font-size:10px; color:var(--color-text-muted); margin-top:2px;">Niveau</div>
+                            <button type="button" class="btn btn-ghost btn-sm" style="margin-top:2px; font-size:10px; padding:1px 6px;"
+                                    title="Monter d'un niveau (bonus de maîtrise + PV recalculés)"
+                                    disabled="@((Stats.Level ?? 1) >= 20)"
+                                    @onclick="LevelUp">
+                                <i class="bi bi-arrow-up-circle"></i> Niveau +1
+                            </button>
                         </div>
+                        @if (CurrentClassSubclasses.Count > 0)
+                        {
+                            <div style="display: flex; flex-direction: column; align-items: center; background: var(--color-bg-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--spacing-sm);">
+                                <i class="bi bi-diagram-3-fill" style="color: var(--color-primary); margin-bottom: var(--spacing-xs);"></i>
+                                <select @bind="Stats.Subclass"
+                                        style="max-width:130px; font-size:var(--font-size-sm); background:var(--color-bg-primary); border:1px solid var(--color-primary); border-radius:var(--radius-sm); color:var(--color-text-primary); padding:2px;">
+                                    <option value="">— Aucune —</option>
+                                    @foreach (var sub in CurrentClassSubclasses)
+                                    {
+                                        <option value="@sub">@sub</option>
+                                    }
+                                </select>
+                                <div style="font-size:10px; color:var(--color-text-muted); margin-top:2px;">Sous-classe</div>
+                            </div>
+                        }
                         <div style="display: flex; flex-direction: column; align-items: center; background: var(--color-bg-secondary); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--spacing-sm);">
                             <i class="bi bi-book" style="color: var(--color-violet-500, var(--color-primary)); margin-bottom: var(--spacing-xs);"></i>
                             <input type="number" value="@Stats.ExperiencePoints"

--- a/Cdm/Cdm.Web/Components/Pages/Characters/WorldCharacterDndDetail.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/WorldCharacterDndDetail.razor.cs
@@ -129,11 +129,18 @@ public partial class WorldCharacterDndDetail
         Stats.ArmorClass = Cdm.Common.DndRules.UnarmoredArmorClass(Stats.DexterityModifier ?? 0);
     }
 
+    /// <summary>The hit die of the character's current class (0 if unknown).</summary>
+    private int CurrentClassHitDie => AvailableClasses
+        .FirstOrDefault(c => string.Equals(c.Name, Stats.CharacterClass, StringComparison.OrdinalIgnoreCase))?.HitDie ?? 0;
+
+    /// <summary>The available subclasses of the character's current class.</summary>
+    private List<string> CurrentClassSubclasses => AvailableClasses
+        .FirstOrDefault(c => string.Equals(c.Name, Stats.CharacterClass, StringComparison.OrdinalIgnoreCase))?.Subclasses ?? new();
+
     /// <summary>Sets the maximum hit points from the class hit die, Constitution and level.</summary>
     private void AutoComputeHitPoints()
     {
-        var hitDie = AvailableClasses
-            .FirstOrDefault(c => string.Equals(c.Name, Stats.CharacterClass, StringComparison.OrdinalIgnoreCase))?.HitDie ?? 0;
+        var hitDie = CurrentClassHitDie;
         if (hitDie <= 0)
         {
             return;
@@ -145,6 +152,31 @@ public partial class WorldCharacterDndDetail
         {
             Stats.CurrentHitPoints = max;
         }
+    }
+
+    /// <summary>
+    /// Advances the character by one level (max 20): the proficiency bonus follows automatically,
+    /// and the max HP gains an average hit-die roll (+ Constitution), also added to current HP.
+    /// </summary>
+    private void LevelUp()
+    {
+        var newLevel = Math.Min(20, (Stats.Level ?? 1) + 1);
+        if (newLevel == Stats.Level)
+        {
+            return;
+        }
+
+        var hitDie = CurrentClassHitDie;
+        if (hitDie > 0)
+        {
+            var oldMax = Stats.MaxHitPoints ?? 0;
+            var newMax = Cdm.Common.DndRules.AverageHitPoints(hitDie, Stats.ConstitutionModifier ?? 0, newLevel);
+            var gain = Math.Max(0, newMax - oldMax);
+            Stats.MaxHitPoints = newMax;
+            Stats.CurrentHitPoints = (Stats.CurrentHitPoints ?? 0) + gain;
+        }
+
+        Stats.Level = newLevel;
     }
 
     private static int CalcProfBonus(int level) =>


### PR DESCRIPTION
Complète l'item « D&D 5e avancé » de la roadmap.

- Sous-classe : sélecteur (mode édition) listant les sous-classes de la classe du personnage (issues des données de référence DndClass).
- Montée de niveau : bouton « Niveau +1 » (max 20) qui incrémente le niveau et recalcule les PV max via DndRules (gain moyen du dé de vie + Constitution), ajouté aussi aux PV actuels ; le bonus de maîtrise suit automatiquement.
- Corrige l'affichage de la sous-classe vide.

La logique de calcul (PV moyens par niveau) est couverte par les tests DndRules. Build Release /warnaserror OK, dotnet test = 121/121 verts.