### PR TITLE
feat(stats): statistiques de dés du joueur

### DIFF
--- a/Cdm/Cdm.ApiService/Endpoints/StatisticsEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/StatisticsEndpoints.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------
+// <copyright file="StatisticsEndpoints.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.ApiService.Endpoints;
+
+using Cdm.Business.Abstraction.Services;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+/// <summary>
+/// Statistics and reporting endpoints.
+/// </summary>
+public static class StatisticsEndpoints
+{
+    private sealed class StatisticsEndpointsLogger { }
+
+    /// <summary>
+    /// Maps statistics endpoints to the application.
+    /// </summary>
+    public static void MapStatisticsEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/statistics")
+            .WithTags("Statistics")
+            .RequireAuthorization();
+
+        // GET /api/statistics/dice - dice statistics for the current user
+        group.MapGet("/dice", GetMyDiceStatsAsync)
+            .WithName("GetMyDiceStats")
+            .WithOpenApi();
+    }
+
+    private static async Task<IResult> GetMyDiceStatsAsync(
+        [FromServices] IStatisticsService statisticsService,
+        ILogger<StatisticsEndpointsLogger> logger,
+        HttpContext httpContext)
+    {
+        try
+        {
+            var claim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
+            if (claim == null || !int.TryParse(claim.Value, out var userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            var stats = await statisticsService.GetDiceStatsForUserAsync(userId);
+            return Results.Ok(stats);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error retrieving dice statistics");
+            return Results.Problem(statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+}

--- a/Cdm/Cdm.ApiService/Program.cs
+++ b/Cdm/Cdm.ApiService/Program.cs
@@ -164,6 +164,7 @@ builder.Services.AddScoped<IWorldService, WorldService>();
 builder.Services.AddScoped<IChapterService, ChapterService>();
 builder.Services.AddScoped<IEventService, EventService>();
 builder.Services.AddScoped<IAchievementService, AchievementService>();
+builder.Services.AddScoped<IStatisticsService, StatisticsService>();
 builder.Services.AddScoped<IAchievementEvaluationService, AchievementEvaluationService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<ISessionService, SessionService>();
@@ -242,6 +243,7 @@ app.MapSessionEndpoints();
 app.MapNpcEndpoints();
 app.MapCombatEndpoints();
 app.MapDndEndpoints();
+app.MapStatisticsEndpoints();
 
 // Map SignalR hubs
 app.MapHub<Cdm.ApiService.Hubs.SessionHub>("/hubs/session");

--- a/Cdm/Cdm.Business.Abstraction/DTOs/DiceStatsDto.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/DiceStatsDto.cs
@@ -1,0 +1,60 @@
+// -----------------------------------------------------------------------
+// <copyright file="DiceStatsDto.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.DTOs;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Aggregated dice-roll statistics for a user, built from persisted session rolls.
+/// </summary>
+public class DiceStatsDto
+{
+    /// <summary>Gets or sets the number of roll actions (rows), regardless of dice count.</summary>
+    public int TotalRolls { get; set; }
+
+    /// <summary>Gets or sets the total number of individual dice thrown.</summary>
+    public int TotalDiceThrown { get; set; }
+
+    /// <summary>Gets or sets the average value of an individual die face across all rolls (0 if none).</summary>
+    public double OverallAverage { get; set; }
+
+    /// <summary>Gets or sets the number of d20 dice thrown.</summary>
+    public int D20Count { get; set; }
+
+    /// <summary>Gets or sets the number of natural 20s rolled on d20.</summary>
+    public int Natural20Count { get; set; }
+
+    /// <summary>Gets or sets the number of natural 1s rolled on d20.</summary>
+    public int Natural1Count { get; set; }
+
+    /// <summary>Gets the critical-hit rate on d20 (natural 20s / d20 thrown), as a percentage.</summary>
+    public double CritRate => D20Count > 0 ? (double)Natural20Count / D20Count * 100 : 0;
+
+    /// <summary>Gets the fumble rate on d20 (natural 1s / d20 thrown), as a percentage.</summary>
+    public double FumbleRate => D20Count > 0 ? (double)Natural1Count / D20Count * 100 : 0;
+
+    /// <summary>Gets or sets the number of distinct sessions the user rolled in (participation).</summary>
+    public int SessionsWithRolls { get; set; }
+
+    /// <summary>Gets or sets per-dice-type breakdown.</summary>
+    public List<DiceTypeStatDto> PerDiceType { get; set; } = new();
+}
+
+/// <summary>
+/// Per-dice-type roll statistics.
+/// </summary>
+public class DiceTypeStatDto
+{
+    /// <summary>Gets or sets the dice type (e.g. "D20").</summary>
+    public string DiceType { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the number of dice of this type thrown.</summary>
+    public int DiceThrown { get; set; }
+
+    /// <summary>Gets or sets the average individual result for this dice type.</summary>
+    public double Average { get; set; }
+}

--- a/Cdm/Cdm.Business.Abstraction/Services/IStatisticsService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/IStatisticsService.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------
+// <copyright file="IStatisticsService.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.Services;
+
+using System.Threading.Tasks;
+using Cdm.Business.Abstraction.DTOs;
+
+/// <summary>
+/// Service producing gameplay statistics and reports.
+/// </summary>
+public interface IStatisticsService
+{
+    /// <summary>
+    /// Computes aggregated dice-roll statistics for a user from their persisted session rolls.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <returns>The dice statistics (empty stats if the user has never rolled).</returns>
+    Task<DiceStatsDto> GetDiceStatsForUserAsync(int userId);
+}

--- a/Cdm/Cdm.Business.Common.Tests/Services/StatisticsServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/StatisticsServiceTests.cs
@@ -1,0 +1,115 @@
+// -----------------------------------------------------------------------
+// <copyright file="StatisticsServiceTests.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Tests.Services;
+
+using Cdm.Business.Common.Services;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="StatisticsService"/>.
+/// </summary>
+public class StatisticsServiceTests
+{
+    private readonly Mock<ILogger<StatisticsService>> loggerMock = new();
+
+    private static DbContextOptions<AppDbContext> NewOptions(string name) =>
+        new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase(name).Options;
+
+    private StatisticsService CreateService(AppDbContext context) => new(context, this.loggerMock.Object);
+
+    private static SessionDiceRoll Roll(int userId, int sessionId, string diceType, string results) => new()
+    {
+        UserId = userId,
+        SessionId = sessionId,
+        UserName = "Joueur",
+        DiceType = diceType,
+        Count = results.Split(',').Length,
+        Results = results,
+        Total = 0,
+        RolledAt = DateTime.UtcNow
+    };
+
+    /// <summary>
+    /// A user with no rolls gets empty statistics.
+    /// </summary>
+    [Fact]
+    public async Task GetDiceStatsForUserAsync_NoRolls_ReturnsEmpty()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(GetDiceStatsForUserAsync_NoRolls_ReturnsEmpty)));
+        var service = this.CreateService(context);
+
+        var stats = await service.GetDiceStatsForUserAsync(1);
+
+        Assert.Equal(0, stats.TotalRolls);
+        Assert.Equal(0, stats.TotalDiceThrown);
+        Assert.Equal(0, stats.OverallAverage);
+        Assert.Equal(0, stats.CritRate);
+    }
+
+    /// <summary>
+    /// Dice statistics aggregate counts, average, natural 20/1 on d20, sessions and per-type breakdown,
+    /// and ignore other users' rolls.
+    /// </summary>
+    [Fact]
+    public async Task GetDiceStatsForUserAsync_AggregatesCorrectly()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(GetDiceStatsForUserAsync_AggregatesCorrectly)));
+
+        // User 1: two d20 rolls (20, 1) across two sessions + one 2d6 (3,5). User 2's roll must be ignored.
+        context.SessionDiceRolls.AddRange(
+            Roll(1, 10, "D20", "20"),
+            Roll(1, 11, "D20", "1"),
+            Roll(1, 10, "D6", "3,5"),
+            Roll(2, 10, "D20", "20"));
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        var stats = await service.GetDiceStatsForUserAsync(1);
+
+        Assert.Equal(3, stats.TotalRolls);           // three roll rows for user 1
+        Assert.Equal(4, stats.TotalDiceThrown);      // 1 + 1 + 2
+        Assert.Equal(2, stats.D20Count);
+        Assert.Equal(1, stats.Natural20Count);
+        Assert.Equal(1, stats.Natural1Count);
+        Assert.Equal(50.0, stats.CritRate);          // 1 of 2 d20
+        Assert.Equal(50.0, stats.FumbleRate);
+        Assert.Equal(2, stats.SessionsWithRolls);    // sessions 10 and 11
+        // Overall average over faces 20,1,3,5 = 29/4 = 7.25
+        Assert.Equal(7.25, stats.OverallAverage);
+        // Per-type: D20 (2 dice) and D6 (2 dice)
+        Assert.Contains(stats.PerDiceType, t => t.DiceType == "D20" && t.DiceThrown == 2);
+        Assert.Contains(stats.PerDiceType, t => t.DiceType == "D6" && t.DiceThrown == 2 && t.Average == 4.0);
+    }
+
+    /// <summary>
+    /// Dice types are normalised so "d20" and "D20" aggregate together.
+    /// </summary>
+    [Fact]
+    public async Task GetDiceStatsForUserAsync_NormalisesDiceTypeCase()
+    {
+        using var context = new AppDbContext(NewOptions(nameof(GetDiceStatsForUserAsync_NormalisesDiceTypeCase)));
+        context.SessionDiceRolls.AddRange(
+            Roll(1, 10, "d20", "15"),
+            Roll(1, 10, "D20", "20"));
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        var stats = await service.GetDiceStatsForUserAsync(1);
+
+        Assert.Single(stats.PerDiceType);
+        Assert.Equal("D20", stats.PerDiceType[0].DiceType);
+        Assert.Equal(2, stats.D20Count);
+        Assert.Equal(1, stats.Natural20Count);
+    }
+}

--- a/Cdm/Cdm.Business.Common/Services/StatisticsService.cs
+++ b/Cdm/Cdm.Business.Common/Services/StatisticsService.cs
@@ -1,0 +1,124 @@
+// -----------------------------------------------------------------------
+// <copyright file="StatisticsService.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Services;
+
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.Services;
+using Cdm.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Produces gameplay statistics from persisted session data.
+/// </summary>
+public class StatisticsService(AppDbContext dbContext, ILogger<StatisticsService> logger) : IStatisticsService
+{
+    private readonly AppDbContext dbContext = dbContext;
+    private readonly ILogger<StatisticsService> logger = logger;
+
+    /// <inheritdoc/>
+    public async Task<DiceStatsDto> GetDiceStatsForUserAsync(int userId)
+    {
+        var stats = new DiceStatsDto();
+
+        try
+        {
+            var rolls = await this.dbContext.SessionDiceRolls
+                .AsNoTracking()
+                .Where(r => r.UserId == userId)
+                .Select(r => new { r.SessionId, r.DiceType, r.Results })
+                .ToListAsync();
+
+            if (rolls.Count == 0)
+            {
+                return stats;
+            }
+
+            stats.TotalRolls = rolls.Count;
+            stats.SessionsWithRolls = rolls.Select(r => r.SessionId).Distinct().Count();
+
+            long overallSum = 0;
+            var perType = new Dictionary<string, (int Count, long Sum)>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var roll in rolls)
+            {
+                var faces = ParseResults(roll.Results);
+                if (faces.Length == 0)
+                {
+                    continue;
+                }
+
+                var type = NormalizeDiceType(roll.DiceType);
+                stats.TotalDiceThrown += faces.Length;
+                overallSum += faces.Sum();
+
+                var existing = perType.TryGetValue(type, out var acc) ? acc : (0, 0L);
+                perType[type] = (existing.Item1 + faces.Length, existing.Item2 + faces.Sum());
+
+                if (string.Equals(type, "D20", StringComparison.OrdinalIgnoreCase))
+                {
+                    stats.D20Count += faces.Length;
+                    stats.Natural20Count += faces.Count(f => f == 20);
+                    stats.Natural1Count += faces.Count(f => f == 1);
+                }
+            }
+
+            stats.OverallAverage = stats.TotalDiceThrown > 0
+                ? Math.Round((double)overallSum / stats.TotalDiceThrown, 2)
+                : 0;
+
+            stats.PerDiceType = perType
+                .Select(kv => new DiceTypeStatDto
+                {
+                    DiceType = kv.Key,
+                    DiceThrown = kv.Value.Count,
+                    Average = kv.Value.Count > 0 ? Math.Round((double)kv.Value.Sum / kv.Value.Count, 2) : 0
+                })
+                .OrderByDescending(t => t.DiceThrown)
+                .ToList();
+
+            return stats;
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error computing dice statistics for user {UserId}", userId);
+            return stats;
+        }
+    }
+
+    /// <summary>
+    /// Parses the comma-separated individual die results, ignoring malformed entries.
+    /// </summary>
+    private static int[] ParseResults(string? results)
+    {
+        if (string.IsNullOrWhiteSpace(results))
+        {
+            return [];
+        }
+
+        return results
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(part => int.TryParse(part, out var value) ? value : (int?)null)
+            .Where(v => v.HasValue)
+            .Select(v => v!.Value)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Normalizes a dice type to the "D&lt;faces&gt;" upper-case form (e.g. "d20" → "D20").
+    /// </summary>
+    private static string NormalizeDiceType(string? diceType)
+    {
+        if (string.IsNullOrWhiteSpace(diceType))
+        {
+            return "?";
+        }
+
+        var trimmed = diceType.Trim().ToUpperInvariant();
+        return trimmed.StartsWith('D') ? trimmed : $"D{trimmed}";
+    }
+}

--- a/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor
@@ -119,5 +119,57 @@ else
                 </div>
             }
         </div>
+
+        <!-- Statistiques de dés -->
+        <div class="cdm-card">
+            <h3 class="card-title" style="margin-bottom: var(--spacing-lg);">
+                <i class="bi bi-dice-5"></i> Statistiques de dés
+            </h3>
+
+            @if (DiceStats == null || DiceStats.TotalRolls == 0)
+            {
+                <p style="color: var(--color-text-muted); font-style: italic;">
+                    Aucun jet enregistré pour l'instant. Lancez des dés en session pour voir vos statistiques !
+                </p>
+            }
+            else
+            {
+                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: var(--spacing-md); margin-bottom: var(--spacing-lg);">
+                    <div style="text-align: center;">
+                        <div style="font-size: var(--font-size-xl); font-weight: 700; color: var(--color-primary);">@DiceStats.TotalDiceThrown</div>
+                        <div style="font-size: var(--font-size-xs); color: var(--color-text-muted);">dés lancés</div>
+                    </div>
+                    <div style="text-align: center;">
+                        <div style="font-size: var(--font-size-xl); font-weight: 700; color: var(--color-primary);">@DiceStats.OverallAverage.ToString("0.0")</div>
+                        <div style="font-size: var(--font-size-xs); color: var(--color-text-muted);">moyenne</div>
+                    </div>
+                    <div style="text-align: center;">
+                        <div style="font-size: var(--font-size-xl); font-weight: 700; color: var(--color-success);">@DiceStats.Natural20Count</div>
+                        <div style="font-size: var(--font-size-xs); color: var(--color-text-muted);">20 naturels (@DiceStats.CritRate.ToString("0.0")%)</div>
+                    </div>
+                    <div style="text-align: center;">
+                        <div style="font-size: var(--font-size-xl); font-weight: 700; color: var(--color-error);">@DiceStats.Natural1Count</div>
+                        <div style="font-size: var(--font-size-xs); color: var(--color-text-muted);">1 naturels (@DiceStats.FumbleRate.ToString("0.0")%)</div>
+                    </div>
+                    <div style="text-align: center;">
+                        <div style="font-size: var(--font-size-xl); font-weight: 700; color: var(--color-primary);">@DiceStats.SessionsWithRolls</div>
+                        <div style="font-size: var(--font-size-xs); color: var(--color-text-muted);">sessions jouées</div>
+                    </div>
+                </div>
+
+                @if (DiceStats.PerDiceType.Count > 0)
+                {
+                    <h4 style="font-size: var(--font-size-sm); color: var(--color-text-secondary); margin-bottom: var(--spacing-sm);">Par type de dé</h4>
+                    <div style="display: flex; flex-wrap: wrap; gap: var(--spacing-sm);">
+                        @foreach (var t in DiceStats.PerDiceType)
+                        {
+                            <span class="status-badge" style="background: var(--color-bg-tertiary);">
+                                @t.DiceType : @t.DiceThrown lancé(s), moy. @t.Average.ToString("0.0")
+                            </span>
+                        }
+                    </div>
+                }
+            }
+        </div>
     </div>
 }

--- a/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor.cs
@@ -14,12 +14,14 @@ public partial class Profile
 {
     [Inject] private ProfileApiClient ProfileClient { get; set; } = default!;
     [Inject] private AchievementApiClient AchievementClient { get; set; } = default!;
+    [Inject] private StatisticsApiClient StatisticsClient { get; set; } = default!;
     [Inject] private AuthenticationStateProvider AuthProvider { get; set; } = default!;
     [Inject] private IStringLocalizer<AppStrings> L { get; set; } = default!;
 
     private ProfileResponse? UserProfile;
     private UpdateProfileRequest UpdateModel { get; set; } = new();
     private List<UserAchievementDto> MyAchievements { get; set; } = new();
+    private DiceStatsDto? DiceStats;
     private bool IsLoading = true;
     private bool IsSaving = false;
     private string ErrorMessage = string.Empty;
@@ -45,6 +47,7 @@ public partial class Profile
             }
 
             MyAchievements = await AchievementClient.GetMyAchievementsAsync();
+            DiceStats = await StatisticsClient.GetMyDiceStatsAsync();
         }
         catch { /* ignore */ }
         finally

--- a/Cdm/Cdm.Web/Program.cs
+++ b/Cdm/Cdm.Web/Program.cs
@@ -170,6 +170,18 @@ builder.Services.AddScoped<AchievementApiClient>(sp =>
 
 builder.Services.AddHttpClient("AchievementApiClient", ConfigureApiClient);
 
+// Register StatisticsApiClient with scoped lifetime
+builder.Services.AddScoped<StatisticsApiClient>(sp =>
+{
+    var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
+    var httpClient = httpClientFactory.CreateClient("StatisticsApiClient");
+    var localStorage = sp.GetRequiredService<ILocalStorageService>();
+    var logger = sp.GetRequiredService<ILogger<StatisticsApiClient>>();
+    return new StatisticsApiClient(httpClient, logger, localStorage);
+});
+
+builder.Services.AddHttpClient("StatisticsApiClient", ConfigureApiClient);
+
 // Register NotificationApiClient with scoped lifetime
 builder.Services.AddScoped<NotificationApiClient>(sp =>
 {

--- a/Cdm/Cdm.Web/Services/ApiClients/StatisticsApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ApiClients/StatisticsApiClient.cs
@@ -1,0 +1,47 @@
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Web.Services.Storage;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace Cdm.Web.Services.ApiClients;
+
+/// <summary>
+/// HTTP client for statistics endpoints.
+/// </summary>
+public class StatisticsApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<StatisticsApiClient> _logger;
+    private readonly ILocalStorageService _localStorage;
+
+    public StatisticsApiClient(HttpClient httpClient, ILogger<StatisticsApiClient> logger, ILocalStorageService localStorage)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _localStorage = localStorage;
+    }
+
+    private async Task AddAuthHeaderAsync()
+    {
+        var token = await _localStorage.GetItemAsync("auth_token");
+        if (!string.IsNullOrEmpty(token))
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    /// <summary>Get the current user's dice statistics.</summary>
+    public async Task<DiceStatsDto?> GetMyDiceStatsAsync()
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await _httpClient.GetAsync("api/statistics/dice");
+            if (!response.IsSuccessStatusCode) return null;
+            return await response.Content.ReadFromJsonAsync<DiceStatsDto>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching dice statistics");
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Item « Statistiques & rapports » (volet dés) de la roadmap, à partir des jets persistés (SessionDiceRolls).

- StatisticsService.GetDiceStatsForUserAsync : total de dés, moyenne globale, 20/1 naturels sur d20 (+ taux de critique/échec), sessions jouées et détail par type de dé. Parsing tolérant des résultats et normalisation du type (d20/D20).
- Endpoint GET /api/statistics/dice (utilisateur courant) + StatisticsApiClient.
- Profil : nouvelle carte « Statistiques de dés » (tuiles + détail par type).

Tests : 3 tests StatisticsService (vide, agrégation crit/échec/moyenne/sessions, normalisation de casse). Build Release /warnaserror OK, dotnet test = 124/124 verts.