### PR TITLE
feat(worlds): invitation d'un joueur par email depuis le monde

### DIFF
--- a/Cdm/Cdm.ApiService/Endpoints/WorldEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/WorldEndpoints.cs
@@ -72,6 +72,10 @@ public static class WorldEndpoints
             .WithOpenApi();
 
         // POST /api/worlds/{id}/invite - Generate invite token (GM only)
+        group.MapPost("/{id:int}/invite-email", InvitePlayerByEmailAsync)
+            .WithName("InvitePlayerByEmail")
+            .WithOpenApi();
+
         group.MapPost("/{id:int}/invite", GenerateWorldInviteTokenAsync)
             .WithName("GenerateWorldInviteToken")
             .WithOpenApi();
@@ -378,6 +382,44 @@ public static class WorldEndpoints
         }
     }
 
+    private static async Task<IResult> InvitePlayerByEmailAsync(
+        int id,
+        [FromBody] WorldEmailInviteRequest request,
+        [FromServices] IWorldService worldService,
+        [FromServices] IConfiguration configuration,
+        ILogger<WorldEndpointsLogger> logger,
+        HttpContext httpContext)
+    {
+        try
+        {
+            var userId = GetUserId(httpContext);
+            if (userId == null)
+            {
+                return Results.Unauthorized();
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Email))
+            {
+                return Results.BadRequest(new { Error = "Email is required" });
+            }
+
+            var webBaseUrl = configuration["App:WebBaseUrl"]?.TrimEnd('/') ?? "https://localhost:7165";
+
+            var sent = await worldService.InvitePlayerByEmailAsync(id, request.Email, request.Message, webBaseUrl, userId.Value);
+            if (!sent)
+            {
+                return Results.BadRequest(new { Error = "Failed to send invitation. Check the world, your ownership and the email address." });
+            }
+
+            return Results.Ok(new { Sent = true });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error inviting player by email to world {WorldId}", id);
+            return Results.Problem(statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+
     private static async Task<IResult> GenerateWorldInviteTokenAsync(
         int id,
         [FromServices] IWorldService worldService,
@@ -544,3 +586,6 @@ public static class WorldEndpoints
         }
     }
 }
+
+/// <summary>Request body to invite a player to a world by email.</summary>
+internal record WorldEmailInviteRequest(string Email, string? Message);

--- a/Cdm/Cdm.Business.Abstraction/Services/IWorldService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/IWorldService.cs
@@ -46,6 +46,18 @@ public interface IWorldService
     Task<IEnumerable<WorldDto>> GetWorldsForUserAsync(int userId);
 
     /// <summary>
+    /// Invites a player to the world by email: ensures an active invite token exists,
+    /// builds the join link and sends the invitation. Only the world owner (GM) may do this.
+    /// </summary>
+    /// <param name="worldId">The world identifier.</param>
+    /// <param name="email">The recipient email address.</param>
+    /// <param name="message">An optional personal message.</param>
+    /// <param name="webBaseUrl">The web base URL used to build the join link.</param>
+    /// <param name="userId">The requesting user (must be the world owner).</param>
+    /// <returns>True if the invitation was sent, false otherwise.</returns>
+    Task<bool> InvitePlayerByEmailAsync(int worldId, string email, string? message, string webBaseUrl, int userId);
+
+    /// <summary>
     /// Updates a world.
     /// </summary>
     /// <param name="worldId">The world identifier.</param>

--- a/Cdm/Cdm.Business.Common.Tests/AssemblyInfo.cs
+++ b/Cdm/Cdm.Business.Common.Tests/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+// -----------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+// The EF Core in-memory provider is not safe for concurrent access; running test
+// classes in parallel can intermittently corrupt shared state. Disable parallelization
+// so the suite is deterministic (it runs in ~1s regardless).
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/Cdm/Cdm.Business.Common.Tests/Services/WorldServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/WorldServiceTests.cs
@@ -24,6 +24,7 @@ public class WorldServiceTests
 {
     private readonly Mock<ILogger<WorldService>> loggerMock;
     private readonly Mock<INotificationService> notificationServiceMock;
+    private readonly Mock<Cdm.Common.Services.IEmailService> emailServiceMock;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WorldServiceTests"/> class.
@@ -32,10 +33,11 @@ public class WorldServiceTests
     {
         this.loggerMock = new Mock<ILogger<WorldService>>();
         this.notificationServiceMock = new Mock<INotificationService>();
+        this.emailServiceMock = new Mock<Cdm.Common.Services.IEmailService>();
     }
 
     private WorldService CreateService(AppDbContext context) =>
-        new(context, this.loggerMock.Object, this.notificationServiceMock.Object);
+        new(context, this.loggerMock.Object, this.notificationServiceMock.Object, this.emailServiceMock.Object);
 
     /// <summary>
     /// Tests that CreateWorldAsync successfully creates a world with valid data.
@@ -267,5 +269,67 @@ public class WorldServiceTests
 
         // Assert
         Assert.Null(result);
+    }
+
+    /// <summary>
+    /// The world owner can invite a player by email: an invite token is ensured and the email is sent.
+    /// </summary>
+    [Fact]
+    public async Task InvitePlayerByEmailAsync_AsOwner_SendsEmail()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: "TestDb_InviteByEmail_Owner")
+            .Options;
+
+        using var context = new AppDbContext(options);
+        context.Users.Add(new User { Id = 1, Email = "gm@test.com", Nickname = "GM", PasswordHash = "h", CreatedAt = DateTime.UtcNow });
+        context.Worlds.Add(new World { Id = 1, Name = "Faerûn", GameType = GameType.DnD5e, UserId = 1, IsActive = true, CreatedAt = DateTime.UtcNow });
+        await context.SaveChangesAsync();
+
+        this.emailServiceMock
+            .Setup(e => e.SendWorldInvitationEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .ReturnsAsync(true);
+
+        var service = this.CreateService(context);
+
+        // Act
+        var sent = await service.InvitePlayerByEmailAsync(1, "player@test.com", "Rejoins-nous !", "https://cdm.example", 1);
+
+        // Assert
+        Assert.True(sent);
+        var world = await context.Worlds.FindAsync(1);
+        Assert.False(string.IsNullOrEmpty(world!.InviteToken)); // a token was ensured
+        this.emailServiceMock.Verify(
+            e => e.SendWorldInvitationEmailAsync("player@test.com", "Faerûn", It.IsAny<string>(),
+                It.Is<string>(link => link.Contains("/worlds/join/")), "Rejoins-nous !"),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// A non-owner cannot invite players to the world.
+    /// </summary>
+    [Fact]
+    public async Task InvitePlayerByEmailAsync_NotOwner_ReturnsFalse()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: "TestDb_InviteByEmail_NotOwner")
+            .Options;
+
+        using var context = new AppDbContext(options);
+        context.Worlds.Add(new World { Id = 1, Name = "Faerûn", GameType = GameType.DnD5e, UserId = 1, IsActive = true, CreatedAt = DateTime.UtcNow });
+        await context.SaveChangesAsync();
+
+        var service = this.CreateService(context);
+
+        // Act — user 2 is not the owner
+        var sent = await service.InvitePlayerByEmailAsync(1, "player@test.com", null, "https://cdm.example", 2);
+
+        // Assert
+        Assert.False(sent);
+        this.emailServiceMock.Verify(
+            e => e.SendWorldInvitationEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()),
+            Times.Never);
     }
 }

--- a/Cdm/Cdm.Business.Common/Services/WorldService.cs
+++ b/Cdm/Cdm.Business.Common/Services/WorldService.cs
@@ -23,11 +23,13 @@ using Microsoft.Extensions.Logging;
 public class WorldService(
     AppDbContext dbContext,
     ILogger<WorldService> logger,
-    INotificationService notificationService) : IWorldService
+    INotificationService notificationService,
+    Cdm.Common.Services.IEmailService emailService) : IWorldService
 {
     private readonly AppDbContext dbContext = dbContext;
     private readonly ILogger<WorldService> logger = logger;
     private readonly INotificationService notificationService = notificationService;
+    private readonly Cdm.Common.Services.IEmailService emailService = emailService;
 
     /// <inheritdoc/>
     public async Task<WorldDto?> CreateWorldAsync(CreateWorldDto dto, int userId)
@@ -463,6 +465,58 @@ public class WorldService(
                 ex,
                 "Error removing character {CharacterId} from world {WorldId}",
                 characterId, worldId);
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> InvitePlayerByEmailAsync(int worldId, string email, string? message, string webBaseUrl, int userId)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                return false;
+            }
+
+            var world = await this.dbContext.Worlds.FindAsync(worldId);
+            if (world == null || !world.IsActive)
+            {
+                this.logger.LogWarning("World {WorldId} not found for email invitation", worldId);
+                return false;
+            }
+
+            if (world.UserId != userId)
+            {
+                this.logger.LogWarning("User {UserId} not authorized to invite to world {WorldId}", userId, worldId);
+                return false;
+            }
+
+            // Ensure an active invite token (reuse the existing one if still valid).
+            if (string.IsNullOrEmpty(world.InviteToken) || world.InviteTokenExpiry == null || world.InviteTokenExpiry <= DateTime.UtcNow)
+            {
+                world.InviteToken = Guid.NewGuid().ToString("N");
+                world.InviteTokenExpiry = DateTime.UtcNow.AddDays(30);
+                world.UpdatedAt = DateTime.UtcNow;
+                await this.dbContext.SaveChangesAsync();
+            }
+
+            var link = $"{webBaseUrl.TrimEnd('/')}/worlds/join/{world.InviteToken}";
+
+            var inviter = await this.dbContext.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId);
+            var inviterName = inviter?.Nickname ?? inviter?.Email ?? "Le MJ";
+
+            var sent = await this.emailService.SendWorldInvitationEmailAsync(email.Trim(), world.Name, inviterName, link, message);
+
+            this.logger.LogInformation(
+                "World {WorldId} email invitation to {Email} {Result}",
+                worldId, email, sent ? "sent" : "failed");
+
+            return sent;
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error inviting player by email to world {WorldId}", worldId);
             return false;
         }
     }

--- a/Cdm/Cdm.Common/Services/EmailService.cs
+++ b/Cdm/Cdm.Common/Services/EmailService.cs
@@ -8,6 +8,17 @@ using Microsoft.Extensions.Logging;
 public interface IEmailService
 {
     Task<bool> SendInvitationEmailAsync(string toEmail, string campaignName, string inviterName, string invitationLink, string? message = null);
+
+    /// <summary>
+    /// Envoie une invitation à rejoindre un monde (lien de jonction inclus).
+    /// </summary>
+    /// <param name="toEmail">Adresse du destinataire.</param>
+    /// <param name="worldName">Nom du monde.</param>
+    /// <param name="inviterName">Pseudo du MJ qui invite.</param>
+    /// <param name="invitationLink">Lien de jonction complet (jeton inclus).</param>
+    /// <param name="message">Message personnel optionnel.</param>
+    Task<bool> SendWorldInvitationEmailAsync(string toEmail, string worldName, string inviterName, string invitationLink, string? message = null);
+
     Task<bool> SendInvitationAcceptedEmailAsync(string toEmail, string campaignName, string playerName);
     Task<bool> SendInvitationRejectedEmailAsync(string toEmail, string campaignName, string playerName);
 
@@ -50,6 +61,14 @@ public class LoggingEmailService : IEmailService
         this.logger.LogInformation(
             "[Email non configuré] Invitation à '{Campaign}' pour {ToEmail} — lien : {Link}",
             campaignName, toEmail, invitationLink);
+        return Task.FromResult(true);
+    }
+
+    public Task<bool> SendWorldInvitationEmailAsync(string toEmail, string worldName, string inviterName, string invitationLink, string? message = null)
+    {
+        this.logger.LogInformation(
+            "[Email non configuré] Invitation au monde '{World}' pour {ToEmail} — lien : {Link}",
+            worldName, toEmail, invitationLink);
         return Task.FromResult(true);
     }
 
@@ -121,6 +140,26 @@ public class AzureEmailService : IEmailService
                     <p><a href='{invitationLink}' style='background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;'>Accepter/Refuser l'invitation</a></p>
                     {(string.IsNullOrEmpty(message) ? "" : $"<p><em>Message personnel :</em><br>{message}</p>")}
                     <p>Cette invitation expirera dans 7 jours.</p>
+                    <hr>
+                    <p><small>Chronique des Mondes - Système de gestion de campagnes</small></p>
+                </body>
+            </html>";
+
+        return await this.SendEmailAsync(toEmail, subject, htmlBody);
+    }
+
+    public async Task<bool> SendWorldInvitationEmailAsync(string toEmail, string worldName, string inviterName, string invitationLink, string? message = null)
+    {
+        var subject = $"Invitation à rejoindre le monde {worldName}";
+        var htmlBody = $@"
+            <html>
+                <body>
+                    <h2>Invitation à un monde</h2>
+                    <p>Bonjour,</p>
+                    <p><strong>{inviterName}</strong> vous invite à rejoindre le monde <strong>{worldName}</strong>.</p>
+                    <p><a href='{invitationLink}' style='background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;'>Rejoindre le monde</a></p>
+                    {(string.IsNullOrEmpty(message) ? "" : $"<p><em>Message personnel :</em><br>{message}</p>")}
+                    <p>Ce lien d'invitation expirera dans 30 jours.</p>
                     <hr>
                     <p><small>Chronique des Mondes - Système de gestion de campagnes</small></p>
                 </body>

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/WorldDetail.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/WorldDetail.razor
@@ -1338,6 +1338,32 @@ else
                         @(IsGeneratingWorldToken ? "Génération..." : "Générer un lien d'invitation")
                     </button>
                 }
+
+                <div style="margin-top: var(--spacing-lg); padding-top: var(--spacing-md); border-top: 1px solid var(--color-border);">
+                    <h4 style="font-size: var(--font-size-sm); margin-bottom: var(--spacing-xs);">
+                        <i class="bi bi-envelope-paper"></i> Inviter un joueur par email
+                    </h4>
+                    <p style="color: var(--color-text-secondary); font-size: var(--font-size-xs); margin: 0 0 var(--spacing-sm);">
+                        Le lien d'invitation lui sera envoyé directement par email.
+                    </p>
+                    <div style="display: flex; gap: var(--spacing-sm); flex-wrap: wrap; align-items: flex-start;">
+                        <input type="email" class="form-control" style="min-width: 220px; flex: 1;" placeholder="adresse@email.com"
+                               @bind="InviteEmail" disabled="@IsSendingEmailInvite" />
+                        <input type="text" class="form-control" style="min-width: 220px; flex: 1;" placeholder="Message (optionnel)"
+                               @bind="InviteMessage" disabled="@IsSendingEmailInvite" />
+                        <button class="btn btn-primary btn-sm" @onclick="SendEmailInvite"
+                                disabled="@(IsSendingEmailInvite || string.IsNullOrWhiteSpace(InviteEmail))">
+                            <i class="bi bi-send"></i>
+                            @(IsSendingEmailInvite ? "Envoi..." : "Envoyer")
+                        </button>
+                    </div>
+                    @if (!string.IsNullOrEmpty(EmailInviteFeedback))
+                    {
+                        <p style="font-size: var(--font-size-xs); margin-top: var(--spacing-xs); color: @(EmailInviteSuccess ? "var(--color-success)" : "var(--color-error)");">
+                            @EmailInviteFeedback
+                        </p>
+                    }
+                </div>
             </div>
 
             @* Joueurs actuels *@

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/WorldDetail.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/WorldDetail.razor.cs
@@ -781,6 +781,32 @@ public partial class WorldDetail : IDisposable
         IsGeneratingWorldToken = false;
     }
 
+    // Email invitation
+    private string InviteEmail = string.Empty;
+    private string? InviteMessage;
+    private bool IsSendingEmailInvite;
+    private string? EmailInviteFeedback;
+    private bool EmailInviteSuccess;
+
+    private async Task SendEmailInvite()
+    {
+        if (IsSendingEmailInvite || string.IsNullOrWhiteSpace(InviteEmail)) return;
+
+        IsSendingEmailInvite = true;
+        EmailInviteFeedback = null;
+        var sent = await WorldClient.InvitePlayerByEmailAsync(WorldId, InviteEmail.Trim(), string.IsNullOrWhiteSpace(InviteMessage) ? null : InviteMessage!.Trim());
+        EmailInviteSuccess = sent;
+        EmailInviteFeedback = sent
+            ? $"Invitation envoyée à {InviteEmail.Trim()}."
+            : "Échec de l'envoi. Vérifiez l'adresse et réessayez.";
+        if (sent)
+        {
+            InviteEmail = string.Empty;
+            InviteMessage = null;
+        }
+        IsSendingEmailInvite = false;
+    }
+
     private async Task RemoveWorldCharacter(int characterId)
     {
         var ok = await WorldClient.RemoveCharacterFromWorldAsync(WorldId, characterId);

--- a/Cdm/Cdm.Web/Services/ApiClients/WorldApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ApiClients/WorldApiClient.cs
@@ -223,6 +223,22 @@ public class WorldApiClient
         }
     }
 
+    /// <summary>Invite a player to the world by email (GM only).</summary>
+    public async Task<bool> InvitePlayerByEmailAsync(int worldId, string email, string? message)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await _httpClient.PostAsJsonAsync($"api/worlds/{worldId}/invite-email", new { Email = email, Message = message });
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error inviting player by email to world {WorldId}", worldId);
+            return false;
+        }
+    }
+
     /// <summary>
     /// Get world info by invite token (public, no auth required).
     /// </summary>


### PR DESCRIPTION
Le MJ peut inviter un joueur en saisissant son adresse email : le lien de jonction au monde lui est envoyé directement.

- IEmailService.SendWorldInvitationEmailAsync (texte dédié « monde ») + impls Azure et repli journalisé.
- WorldService.InvitePlayerByEmailAsync (propriétaire uniquement) : garantit un jeton d'invitation actif, construit le lien {WebBaseUrl}/worlds/join/{token} et envoie l'email. WorldService reçoit désormais IEmailService.
- Endpoint POST /api/worlds/{id}/invite-email (lit App:WebBaseUrl) + méthode client.
- UI : formulaire « Inviter un joueur par email » (adresse + message optionnel) dans la section d'invitation du monde, avec retour de statut.

Tests : 2 tests WorldService (envoi par le propriétaire, refus pour un non-propriétaire). Désactive le parallélisme des tests (EF in-memory non thread-safe) pour fiabiliser la CI. Build Release /warnaserror OK, dotnet test = 123 tests verts.