### PR TITLE
fix(tests): stabilise le flake EF in-memory (sérialisation + bases un…

### DIFF
--- a/Cdm/Cdm.Business.Common.Tests/Services/AchievementEvaluationServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/AchievementEvaluationServiceTests.cs
@@ -30,7 +30,7 @@ public class AchievementEvaluationServiceTests
     private const int SessionId = 10;
 
     private static DbContextOptions<AppDbContext> NewOptions(string name) =>
-        new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase(name).Options;
+        new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase($"{name}-{System.Guid.NewGuid()}").Options;
 
     private AchievementEvaluationService CreateService(AppDbContext context) =>
         new(context, this.notificationServiceMock.Object, this.loggerMock.Object);

--- a/Cdm/Cdm.Business.Common.Tests/Services/CombatServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/CombatServiceTests.cs
@@ -31,7 +31,7 @@ public class CombatServiceTests
     private const int SessionId = 10;
 
     private static DbContextOptions<AppDbContext> NewOptions(string name) =>
-        new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase(name).Options;
+        new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase($"{name}-{System.Guid.NewGuid()}").Options;
 
     private CombatService CreateService(AppDbContext context) =>
         new(context, this.achievementEvaluationMock.Object, this.loggerMock.Object);

--- a/Cdm/Cdm.Business.Common.Tests/Services/SessionServiceHistoryTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/SessionServiceHistoryTests.cs
@@ -26,7 +26,7 @@ public class SessionServiceHistoryTests
 
     private static DbContextOptions<AppDbContext> NewOptions(string name) =>
         new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(databaseName: name)
+            .UseInMemoryDatabase(databaseName: $"{name}-{System.Guid.NewGuid()}")
             .Options;
 
     private SessionService CreateService(AppDbContext context) =>

--- a/Cdm/Cdm.Business.Common.Tests/Services/StatisticsServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/StatisticsServiceTests.cs
@@ -22,7 +22,7 @@ public class StatisticsServiceTests
     private readonly Mock<ILogger<StatisticsService>> loggerMock = new();
 
     private static DbContextOptions<AppDbContext> NewOptions(string name) =>
-        new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase(name).Options;
+        new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase($"{name}-{System.Guid.NewGuid()}").Options;
 
     private StatisticsService CreateService(AppDbContext context) => new(context, this.loggerMock.Object);
 

--- a/Cdm/Cdm.Business.Common.Tests/Services/TradeServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/TradeServiceTests.cs
@@ -30,7 +30,7 @@ public class TradeServiceTests
 
     private static DbContextOptions<AppDbContext> NewOptions(string name) =>
         new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(databaseName: name)
+            .UseInMemoryDatabase(databaseName: $"{name}-{System.Guid.NewGuid()}")
             .Options;
 
     private TradeService CreateService(AppDbContext context) =>

--- a/Cdm/Cdm.Business.Common.Tests/xunit.runner.json
+++ b/Cdm/Cdm.Business.Common.Tests/xunit.runner.json
@@ -1,3 +1,4 @@
 {
-    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "parallelizeTestCollections": false
 }

--- a/Cdm/Cdm.Common.Tests/xunit.runner.json
+++ b/Cdm/Cdm.Common.Tests/xunit.runner.json
@@ -2,5 +2,6 @@
   "methodDisplay": "method",
   "methodDisplayOptions": {
     "useOperatorMonikers": true
-  }
+  },
+  "parallelizeTestCollections": false
 }


### PR DESCRIPTION
…iques)

Le provider EF Core in-memory n'est pas sûr en accès concurrent ; l'exécution parallèle des classes de tests provoquait un échec intermittent (observé sur AchievementEvaluationServiceTests).

- xunit.runner.json : parallelizeTestCollections=false (autorité en xUnit v3) sur les deux projets de tests.
- Noms de base in-memory rendus uniques par GUID dans les helpers NewOptions (isolation totale de chaque contexte, y compris entre exécutions).

Vérifié : 12 exécutions consécutives de la suite sans aucun échec de test ; build Release /warnaserror OK, dotnet test = 126/126 verts.