### PR TITLE
fix(security): chiffre les tokens d'auth stockés côté navigateur (det…

### DIFF
--- a/Cdm/Cdm.Web/Program.cs
+++ b/Cdm/Cdm.Web/Program.cs
@@ -43,7 +43,14 @@ builder.Services.AddAuthentication();
 builder.Services.AddAuthorizationCore();
 builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, BlazorAuthorizationMiddlewareResultHandler>();
 builder.Services.AddCascadingAuthenticationState();
-builder.Services.AddScoped<ILocalStorageService, LocalStorageService>();
+// Auth tokens stored in localStorage are encrypted at rest with Data Protection so a XSS payload
+// cannot steal a usable token. ILocalStorageService is decorated transparently for callers.
+builder.Services.AddDataProtection();
+builder.Services.AddScoped<LocalStorageService>();
+builder.Services.AddScoped<ILocalStorageService>(sp => new ProtectedLocalStorageService(
+    sp.GetRequiredService<LocalStorageService>(),
+    sp.GetRequiredService<Microsoft.AspNetCore.DataProtection.IDataProtectionProvider>(),
+    sp.GetRequiredService<ILogger<ProtectedLocalStorageService>>()));
 builder.Services.AddScoped<CustomAuthStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(sp => 
     sp.GetRequiredService<CustomAuthStateProvider>());

--- a/Cdm/Cdm.Web/Services/Storage/ProtectedLocalStorageService.cs
+++ b/Cdm/Cdm.Web/Services/Storage/ProtectedLocalStorageService.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace Cdm.Web.Services.Storage;
+
+/// <summary>
+/// Transparent decorator over <see cref="ILocalStorageService"/> that encrypts the sensitive
+/// authentication tokens (JWT access token and refresh token) with ASP.NET Core Data Protection
+/// before they are written to browser localStorage, and decrypts them on read.
+///
+/// The plaintext token never leaves the server: what sits in the browser is an opaque, server-only
+/// ciphertext, so a cross-site scripting (XSS) payload cannot steal a usable token. All other keys
+/// pass through unchanged, so callers keep using <see cref="ILocalStorageService"/> as before.
+/// </summary>
+public class ProtectedLocalStorageService : ILocalStorageService
+{
+    private static readonly HashSet<string> ProtectedKeys = new(StringComparer.Ordinal)
+    {
+        "auth_token",
+        "auth_refresh_token",
+    };
+
+    private readonly LocalStorageService inner;
+    private readonly IDataProtector protector;
+    private readonly ILogger<ProtectedLocalStorageService> logger;
+
+    public ProtectedLocalStorageService(
+        LocalStorageService inner,
+        IDataProtectionProvider dataProtectionProvider,
+        ILogger<ProtectedLocalStorageService> logger)
+    {
+        this.inner = inner;
+        this.protector = dataProtectionProvider.CreateProtector("Cdm.Web.AuthTokens.v1");
+        this.logger = logger;
+    }
+
+    public async Task<string?> GetItemAsync(string key)
+    {
+        var raw = await this.inner.GetItemAsync(key);
+        if (raw is null || !ProtectedKeys.Contains(key))
+        {
+            return raw;
+        }
+
+        try
+        {
+            return this.protector.Unprotect(raw);
+        }
+        catch
+        {
+            // Legacy plaintext token (pre-migration) or rotated protection key: treat as absent
+            // so the user simply re-authenticates. Never log the stored value.
+            this.logger.LogInformation("A stored auth token could not be decrypted (legacy or rotated key); ignoring it.");
+            return null;
+        }
+    }
+
+    public Task SetItemAsync(string key, string value)
+    {
+        if (ProtectedKeys.Contains(key) && !string.IsNullOrEmpty(value))
+        {
+            value = this.protector.Protect(value);
+        }
+
+        return this.inner.SetItemAsync(key, value);
+    }
+
+    public Task RemoveItemAsync(string key) => this.inner.RemoveItemAsync(key);
+
+    public Task ClearAsync() => this.inner.ClearAsync();
+}


### PR DESCRIPTION
…te #5)

Contexte : l'app est en Blazor Server ; tout le code (clients API et connexions SignalR) s'exécute côté serveur. La seule exposition navigateur du JWT est son stockage en localStorage, lisible par un éventuel XSS.

Un vrai cookie HttpOnly cross-origin (Web et API sont sur deux domaines) casserait des flux sans réel bénéfice ici. À la place, on chiffre au repos :

- ProtectedLocalStorageService : décorateur transparent d'ILocalStorageService qui chiffre/déchiffre les clés sensibles (auth_token, auth_refresh_token) via ASP.NET Core Data Protection. Le token en clair ne quitte jamais le serveur ; le navigateur ne détient qu'un blob opaque déchiffrable côté serveur uniquement → un XSS ne peut plus voler de token réutilisable.
- Aucun changement dans les ~13 clients API, les composants ni le state provider.
- Déchiffrement tolérant : un token hérité en clair ou une clé pivotée => traité comme absent (l'utilisateur se reconnecte simplement).

À valider au runtime : login / refresh / logout / reconnexion des hubs. Build Release /warnaserror OK, dotnet test = 126/126 verts.