### PR TITLE
docs(roadmap): audit complet du code — statuts réels + reste-à-faire

### DIFF
--- a/.github/ROADMAP.md
+++ b/.github/ROADMAP.md
@@ -1,16 +1,18 @@
 # Roadmap — Chronique des Mondes
 
-> **Dernière vérification : 18 juillet 2026**, par relecture du code source et tests
-> fonctionnels réels (dont une session multi-joueurs). La roadmap précédente sous-estimait
-> fortement l'avancement : PNJ, temps réel SignalR, lanceur de dés et combat générique
-> étaient marqués « à faire » alors qu'ils étaient livrés depuis avril 2026.
+> **Dernière vérification : 20 juillet 2026**, par audit du code source (services,
+> endpoints, composants Blazor) et des tests. La révision précédente (18/07) était
+> **fortement en retard** : historique chat/dés, échanges d'équipement, succès
+> automatiques, invitation par email, D&D avancé (compétences, jets de sauvegarde,
+> CA/PV/maîtrise) et combat D&D automatisé étaient marqués « à faire » alors qu'ils
+> sont livrés.
 >
 > **Convention :**
-> - `[x]` implémenté et vérifié
+> - `[x]` implémenté et vérifié dans le code
 > - `[~]` partiellement implémenté (le détail précise ce qui manque)
 > - `[ ]` non commencé
 >
-> État des lieux complet et priorités : `docs/ETAT_DU_PROJET.md`.
+> **➡️ Ce qui reste vraiment à faire est résumé en bas de ce document.**
 
 ---
 
@@ -21,10 +23,10 @@
 - [x] Connexion sécurisée (access + refresh token)
 - [x] Déconnexion
 - [x] Protection des routes (redirection automatique si non authentifié)
-- [ ] Réinitialisation de mot de passe (email Azure Communication Services)
-- [ ] Validation d'email à l'inscription
+- [x] Réinitialisation de mot de passe (email Azure Communication Services) — pages `ForgotPassword`/`ResetPassword`
+- [x] Validation d'email à l'inscription — page `ConfirmEmail`
 
-**Statut** : Core complété. Reset password et validation email à planifier.
+**Statut** : Complété.
 
 ---
 
@@ -41,7 +43,7 @@
 
 ### Mondes
 - [x] Création de monde (nom, description, GameType, visibilité)
-- [x] Liste des mondes de l'utilisateur
+- [x] Liste des mondes de l'utilisateur (+ mondes rejoints)
 - [x] Modification et suppression de monde
 - [x] Vue détail d'un monde (aperçu, personnages, campagnes)
 - [x] Système d'invitation : lien URL unique + QR code
@@ -54,231 +56,145 @@
 ### Personnages
 - [x] Création de personnage de base (nom, prénom, description, avatar)
 - [x] Modification et suppression de personnage de base
-- [x] Liste des personnages avec statut (disponible/verrouillé)
+- [x] Liste des personnages avec statut (base / copie de monde)
 - [x] Personnage de monde (copie adaptée au monde, données JSON GameType)
-- [x] Données D&D 5e basiques : classe, race, background, 6 caractéristiques, inventaire
+- [x] Données D&D 5e : classe, sous-classe, race, background, 6 caractéristiques, inventaire
 - [x] Vue et modification du personnage de monde par le joueur
 
-**Statut** : Basique complété. Voir "Planifié" pour D&D avancé.
+**Statut** : Complété.
 
 ---
 
-### Campagnes
-- [x] Création de campagne (nom, description, monde parent, visibilité)
-- [x] Modification et suppression de campagne
-- [x] Liste des campagnes (les siennes + publiques)
-- [x] Lien d'invitation de campagne
+### Campagnes / Chapitres / Sessions / Notifications / Interface
+- [x] Campagnes : CRUD, liste, lien d'invitation
+- [x] Chapitres : CRUD, numérotation, réorganisation drag-and-drop, arborescence
+- [x] Sessions : lancement MJ, vues MJ/Joueur, inventaire en session
+- [x] Notifications in-app : badge non-lus, invitation monde, lancement session, liens d'action
+- [x] Design system, thèmes par GameType, clair/sombre, dual-sidebar, responsive, i18n fr/en
 
 **Statut** : Complété.
 
 ---
 
-### Chapitres
-- [x] Création de chapitre (titre, contenu texte)
-- [x] Modification et suppression de chapitre
-- [x] Numérotation séquentielle et ordre
-- [x] Navigation arborescente dans la vue campagne
-
-**Statut** : Complété.
-
----
-
-### Sessions
-- [x] Lancement de session par le MJ
-- [x] Notifications in-app aux participants lors du lancement
-- [x] Vue MJ : liste participants, fiches personnages cliquables, stats D&D
-- [x] Vue Joueur : rejoindre session, 3 onglets (Personnage / Inventaire / D&D)
-- [x] Gestion inventaire dans la session (ajout/suppression d'objets)
-
-**Statut** : Fonctionnel. Voir "Planifié" pour temps réel SignalR.
-
----
-
-### Notifications
-- [x] Système de notifications in-app
-- [x] Badge compteur non-lus dans la topbar
-- [x] Notification invitation à un monde
-- [x] Notification lancement de session
-- [x] Lien d'action dans chaque notification
-
-**Statut** : Complété (in-app uniquement).
-
----
-
-### Interface et Thèmes
-- [x] Design system CSS avec variables et thèmes
-- [x] Thème par GameType (.theme-dnd5e, .theme-cyberpunk, etc.)
-- [x] Mode sombre par défaut, mode clair disponible
-- [x] Navigation dual-sidebar (principale + contextuelle)
-- [x] Responsive mobile (hamburger, tiroirs)
-- [x] Localisation fr/en (fichiers resx)
-
-**Statut** : Complété.
-
----
-
-## Phase 1 : Enrichissement MVP — LARGEMENT COMPLÉTÉE
+## Phase 1 : Enrichissement MVP — COMPLÉTÉE
 
 ### PNJ (Personnages Non-Joueurs)
-- [x] Création de PNJ générique dans un chapitre (nom, description, comportement, PV)
-- [x] Association PNJ ↔ Chapitre
-- [x] Affichage PNJ dans la session MJ
-- [x] Monstres comme sous-type de PNJ (`DndMonsterTemplate`)
+- [x] Création de PNJ dans un chapitre (nom, description, apparence, âge)
+- [x] Association PNJ ↔ Chapitre, affichage en session MJ
+- [x] Stats D&D 5e du PNJ (type, race, classe, indice de dangerosité, 6 stats, CA, PV, vitesse)
+- [~] Attaques du PNJ avec modificateurs, jets de sauvegarde du PNJ — non implémentés
 
-**Statut** : Complété. Le MJ crée ses PNJ depuis l'onglet PNJ du chapitre et les retrouve en session.
+**Statut** : Complété (hors attaques/JdS avancés du PNJ).
 
 ---
 
 ### Temps Réel (SignalR)
-- [x] Hub SignalR pour les sessions actives (`SessionHub`, `CombatHub`, `NotificationHub`)
-- [x] Synchronisation en temps réel entre MJ et joueurs
-- [x] Notifications push sans rechargement de page
-- [x] Statut de connexion des participants (badge « Connecté »)
+- [x] Hubs `SessionHub`, `CombatHub`, `NotificationHub`
+- [x] Synchronisation temps réel MJ ↔ joueurs, push sans rechargement
+- [x] Statut de connexion des participants
+- [x] Autorisation d'appartenance à la campagne vérifiée avant de rejoindre un groupe
 
-**Statut** : Complété et validé par un test à deux comptes (18/07/2026).
-Autorisation d'appartenance à la campagne vérifiée avant de rejoindre un groupe.
+**Statut** : Complété.
 
 ---
 
 ### Communication Email
-- [ ] Réinitialisation de mot de passe par email (Azure Communication Services)
-- [ ] Validation d'email à l'inscription
-- [ ] Invitation d'un joueur par email directement depuis le monde
+- [x] Réinitialisation de mot de passe par email
+- [x] Validation d'email à l'inscription
+- [x] Invitation d'un joueur par email depuis le monde (`InvitePlayerByEmailAsync`)
 
-**Critère de succès** : Un utilisateur peut récupérer son accès via email.
+**Statut** : Complété.
 
 ---
 
 ### Historique
-- [~] Historique des sessions par campagne — page `/sessions` existante, mais liste limitée
-- [ ] Historique des mondes rejoints par l'utilisateur
-- [ ] **Rechargement de l'historique du chat et des dés à l'ouverture d'une session**
-      (les messages et jets sont bien persistés en base, mais jamais relus : le chat
-      repart vide à chaque connexion)
+- [x] **Rechargement de l'historique du chat et des dés à l'ouverture d'une session**
+      (`GetSessionHistoryAsync` + reconstruction de la timeline avant connexion au hub, MJ et Joueur)
+- [~] Historique des sessions par campagne — page `/sessions` (liste), pas de vue par campagne détaillée
+- [x] Liste des mondes rejoints (section « Mondes rejoints » de `/worlds`)
 
 ---
 
-## Phase 2 : Systèmes de Jeu Avancés — FUTUR
+## Phase 3 : Combat et Dés — COMPLÉTÉE
 
-> Ces fonctionnalités dépendent de la validation du MVP et de la disponibilité.
-
-### D&D 5e Avancé
-- [ ] Sous-classe (archétype)
-- [ ] Compétences et maîtrises
-- [ ] Classe d'armure calculée automatiquement
-- [ ] Points de vie calculés (selon classe + Constitution)
-- [ ] Bonus de maîtrise automatique selon le niveau
-- [ ] Jets de sauvegarde
-
-**Note** : Le niveau et la montée de niveau sont spécifiques à D&D et seront implémentés dans cette phase.
-
----
-
-### Autres Types de Jeu
-- [ ] Skyrim : races, compétences, perks, statistiques Skyrim
-- [ ] Pathfinder : adaptation proche D&D avec différences de règles
-- [ ] Call of Cthulhu : système de santé mentale, compétences spécifiques
-- [ ] Warhammer Fantasy : système de carrières, blessures critiques
-- [ ] Cyberpunk : statistiques net-runner, équipement cybernétique
-
----
-
-### PNJ D&D Avancé
-- [ ] Statistiques complètes D&D (CA, vitesse, sens, langues, CR)
-- [ ] Attaques avec modificateurs
-- [ ] Jets de sauvegarde
-
----
-
-## Phase 3 : Combat et Dés — LARGEMENT COMPLÉTÉE
-
-> Livrée en avance (avril 2026), avant les Phases 2 et 4.
+> Livrée dès avril 2026.
 
 ### Lanceur de Dés
-- [x] Support d4, d6, d8, d10, d12, d20, d100
-- [x] Nombre de dés variable (XdY + modificateur)
-- [x] Affichage et transmission au MJ (diffusion SignalR à toute la table)
-- [~] Historique des lancers — persisté en base, mais pas rechargé à l'ouverture
+- [x] d4, d6, d8, d10, d12, d20, d100, XdY + modificateur
+- [x] Diffusion SignalR à la table
+- [x] Historique des lancers persisté **et rechargé** à l'ouverture
 
 ### Combat Générique
-- [x] Déclenchement par le MJ, sélection des combattants (`CombatSetup`)
-- [x] Initiative manuelle, gestion des tours (vues MJ et joueur)
-- [x] Suivi PV en temps réel
-- [x] Résumé de combat (camp vainqueur + notes)
-
-**Statut** : Complété et validé en test à deux comptes.
+- [x] Déclenchement MJ, sélection des combattants, initiative, gestion des tours, suivi PV, résumé
 
 ### Combat D&D Automatisé
-- [ ] Initiative 1d20 + modificateur Dextérité
-- [ ] Jets d'attaque avec bonus automatiques
-- [ ] Calcul dégâts + résistances/vulnérabilités
-- [ ] Jets de sauvegarde automatiques
+- [x] Initiative auto 1d20 + modificateur de Dextérité (résolue serveur)
+- [x] Jets d'attaque d20 + détection du critique (nat 20 / nat 1)
+- [~] Calcul des dégâts avec résistances/vulnérabilités — dégâts oui, résistances/vulnérabilités non
+- [~] Jets de sauvegarde automatiques en combat — partiels
 
 ---
 
-## Phase 4 : Sorts et Équipements — PARTIELLEMENT COMPLÉTÉE
+## Phase 2 / 4 : Systèmes de Jeu — D&D COMPLÉTÉ
 
-### Sorts
-- [~] Création de sorts génériques (titre, description)
-- [x] Sorts D&D spécialisés (`DndSpell` : niveau, école, composantes, dégâts)
-- [x] Bibliothèque de sorts officielle (seeder D&D 5e)
-- [x] Sorts appris par personnage (`DndCharacterSpell`, sélection dans le wizard)
+### D&D 5e Avancé (personnage)
+- [x] Sous-classe (archétype)
+- [x] Compétences et maîtrises (onglet Compétences, sauvegarde des maîtrises)
+- [x] Classe d'armure, points de vie, bonus de maîtrise (`DndRules` : `ProficiencyBonus`, `UnarmoredArmorClass`, `AverageHitPoints`)
+- [x] Jets de sauvegarde (onglet dédié)
 
-### Équipements
-- [x] Catalogue d'équipements officiel (`DndItem`, seeder)
-- [~] Inventaire (`DndInventoryItem` + gestion en session) — pas de notion de poids
-- [x] Équipements D&D (type, bonus, dégâts, propriétés)
+### Sorts & Équipements
+- [x] Sorts D&D (`DndSpell`), bibliothèque officielle (seeder), sorts appris par personnage
+- [~] Sorts génériques (titre/description) — base présente, peu développée
+- [x] Catalogue d'équipements officiel (seeder), équipements D&D
+- [~] Inventaire — gestion en session OK, **pas de notion de poids**
 
-### Échanges d'Équipements — **NON COMMENCÉ**
-- [ ] MJ → Joueur : proposition d'équipement, acceptation/refus
-- [ ] Joueur → Joueur : échange direct entre joueurs de la même campagne
-- [ ] Notifications de proposition
-- [ ] Liste des propositions en attente
+### Échanges d'Équipements
+- [x] MJ → Joueur : proposition, acceptation/refus (UI en session MJ et Joueur)
+- [x] Joueur → Joueur : échange dans la même campagne
+- [x] Notifications de proposition, liste des propositions en attente
 
-> ⚠️ Seule la méthode hub `ProposeTradeTheory` et le type de notification `TradeProposed`
-> existent : **il n'y a aucune interface utilisateur**. La base est posée, tout le reste est à faire.
+### Autres Types de Jeu (systèmes de règles spécifiques)
+- [ ] Skyrim, Pathfinder, Call of Cthulhu, Warhammer, Cyberpunk : **thème visuel présent, mais pas de bloc de stats/règles dédié** (profil générique utilisé). Seul D&D 5e a un système de règles complet.
 
 ---
 
-## Phase 5 : Engagement et Progression — FUTUR
+## Phase 5 : Engagement et Progression — PARTIELLEMENT COMPLÉTÉE
 
-### Système d'Achievements (Succès) — PARTIELLEMENT COMPLÉTÉ
-- [~] Succès à 3 niveaux : Monde, Campagne, Chapitre — création au niveau Monde opérationnelle
-- [x] Rareté : Commun, Rare, Épique, Légendaire (`AchievementRarity`)
-- [~] Attribution manuelle (MJ) en place ; **attribution automatique par conditions à faire**
-- [~] Type de notification `AchievementUnlocked` défini — déclenchement à vérifier
-- [ ] Affichage dans le profil joueur
+### Système d'Achievements (Succès)
+- [x] Modèle à 3 niveaux : Monde, Campagne, Chapitre (`AchievementLevel`)
+- [x] Rareté : Commun, Rare, Épique, Légendaire
+- [x] Attribution manuelle (MJ)
+- [x] Attribution automatique par conditions (`AchievementEvaluationService` : critiques, fumbles, nb de jets, sessions…)
+- [x] Notification `AchievementUnlocked` déclenchée à l'attribution
+- [x] Affichage dans le profil joueur (section « Mes succès »)
+- [~] UI de création aux niveaux Campagne/Chapitre (le modèle le permet ; création surtout exposée au niveau Monde)
 
 ### Statistiques de Dés
-- [ ] Total de lancers, moyenne, facteur de chance
-- [ ] Analyse par type de dé (d4 à d100)
-- [ ] Analyse d20 : coups critiques / échecs critiques
-- [ ] Tendances temporelles par mois et par campagne
+- [x] Total de lancers, moyenne, analyse d20 (nat 20 / nat 1, taux de critique/échec), par type de dé
+- [x] Affichage dans le profil
+- [ ] Tendances temporelles (par mois, par campagne)
 - [ ] Segmentation par système de jeu
 
-### Statistiques de Participation
+### Statistiques de Participation — **NON COMMENCÉ**
 - [ ] Sessions jouées, heures de jeu (mensuel / annuel / total)
 - [ ] Distribution MJ/Joueur, taille moyenne des groupes
 - [ ] Historique par campagne
 
-### Rapports Automatiques
-- [ ] Rapport mensuel : activité, records, moments forts
-- [ ] Rapport annuel : rétrospective complète
+### Rapports Automatiques — **NON COMMENCÉ**
+- [ ] Rapport mensuel (activité, records, moments forts)
+- [ ] Rapport annuel (rétrospective)
 - [ ] Envoi optionnel par email
 
 ---
 
-## Phase 6 : Expérience Immersive — VISION LONG TERME
-
-> Extension de l'expérience utilisateur, sans planification immédiate.
+## Phase 6 : Expérience Immersive — NON COMMENCÉE
 
 ### Salon Vocal en Session
-- [ ] Intégration audio pendant les sessions actives
-- [ ] Contrôle du MJ (muet/actif par joueur)
-- [ ] Option partage d'écran
+- [ ] Audio pendant les sessions, contrôle MJ (muet/actif), partage d'écran
 
 ### Autres Outils MJ
-- [ ] Générateurs : PNJ aléatoires, lieux, trésors
+- [ ] Générateurs (PNJ aléatoires, lieux, trésors)
 - [ ] Carte de monde interactive
 - [ ] Ambiance sonore (bibliothèque musicale)
 
@@ -287,3 +203,22 @@ Autorisation d'appartenance à la campagne vérifiée avant de rejoindre un grou
 - [ ] Messagerie privée
 - [ ] Partage de contenu (campagnes, personnages)
 
+---
+
+## ➡️ Ce qui reste vraiment à faire (par effort croissant)
+
+**Petit / bounded**
+1. **Poids de l'inventaire** (D&D) — champ + affichage + capacité de charge.
+2. **PNJ D&D : attaques + jets de sauvegarde** (compléter le bloc de stats existant).
+3. **Combat D&D : résistances/vulnérabilités + JdS automatiques** (compléter l'auto existant).
+4. **UI de création de succès aux niveaux Campagne/Chapitre** (le back le permet déjà).
+
+**Moyen**
+5. **Statistiques de participation** (sessions jouées, heures, distribution MJ/Joueur) — nouveau service + page.
+6. **Stats de dés : tendances temporelles + segmentation par système** (étendre `DiceStatsDto`/`StatisticsService`).
+7. **Sorts génériques** (hors D&D) — enrichir la création.
+
+**Gros**
+8. **Rapports automatiques** mensuel/annuel + envoi email.
+9. **Systèmes de règles des autres jeux** (Skyrim, Pathfinder, Cthulhu, Warhammer, Cyberpunk) — chacun = un bloc de stats/règles dédié.
+10. **Phase 6** : vocal, générateurs, carte interactive, ambiance sonore, amis, messagerie, partage.


### PR DESCRIPTION
La roadmap sous-estimait fortement l'avancement. Vérifié dans le code : historique chat/dés, échanges d'équipement, succès auto+notif+profil, invite email, D&D avancé (compétences, JdS, CA/PV/maîtrise), combat D&D auto (initiative 1d20+DEX, jets d'attaque, critiques) sont LIVRÉS. Ajoute une section « ce qui reste vraiment » priorisée par effort.