### PR TITLE
chore(ci): protège main/dev — seule dev merge sur main, pas de suppre…

### DIFF
--- a/.github/ROADMAP.md
+++ b/.github/ROADMAP.md
@@ -222,3 +222,31 @@
 8. **Rapports automatiques** mensuel/annuel + envoi email.
 9. **Systèmes de règles des autres jeux** (Skyrim, Pathfinder, Cthulhu, Warhammer, Cyberpunk) — chacun = un bloc de stats/règles dédié.
 10. **Phase 6** : vocal, générateurs, carte interactive, ambiance sonore, amis, messagerie, partage.
+
+---
+
+## Phase 7 : Vision produit (demandée le 21/07/2026)
+
+### 1. Images & médias (branche `feature/images-blob`)
+- [x] **Stockage Azure Blob** — abstraction `IImageStorage` (local en dev/CI, **Azure Blob** en prod via config), compte de stockage + conteneur + rôle MI dans bicep. Validation par magic-bytes + 5 Mo.
+- [x] **Plomberie d'upload générique** — `POST /api/images/{category}` + `ImageApiClient` + composant réutilisable `AppImageUpload` (à déposer dans n'importe quel formulaire).
+- [x] **En session, le MJ « pousse » une image à tous les joueurs** — `SessionHub.ShowImage/HideImage` (vérif MJ) + overlay plein écran non fermable côté joueur. Couvre l'affichage **carte / lieu** du MJ en session.
+- [x] Avatar de profil / de personnage — déjà présents (upload local ; migrables sur `IImageStorage` si besoin d'unifier).
+- [ ] **Image attachée à un item** — dépend de la création d'items (voir Codex ci-dessous) ; le composant d'upload est prêt à y être branché.
+
+> À faire au **déploiement** : appliquer le bicep + poser les app settings `ImageStorage__Provider=AzureBlob`, `ImageStorage__BlobServiceUri`, `ImageStorage__ContainerName` (sinon reste en local).
+
+### 2. Marketplace / Partage
+- [ ] Les utilisateurs partagent : **monde**, **campagne**, **personnages génériques** (pas les copies liées à un monde), **items**.
+- [ ] **DataGrid** avec **onglets par type d'élément** + **filtres** (type de jeu, etc.).
+- [ ] Intégration contextuelle : ajouter une campagne partagée → propose les **mondes du même type** de l'utilisateur ; ajouter un item → propose les **personnages du même type**. Bouton **grisé** si l'utilisateur n'a pas de monde/personnage cible.
+
+### 3. Codex d'items
+- [ ] Système de création d'items **de tous les thèmes**, rangés dans un **codex** personnel.
+- [ ] Depuis le codex : **partager** un item, ou l'**ajouter à un personnage** (y compris créé plus tard).
+
+### 4. Loot en campagne / chapitre
+- [ ] Le MJ attache des **items (loot)** à une campagne ou un chapitre.
+- [ ] En session, le MJ **distribue** ce loot aux joueurs quand il estime qu'ils l'ont mérité.
+
+> **Note localisation** : le mécanisme fr/en (resx `AppStrings.*.resx` + `@L["Clé"]`) est **déjà en place**. Continuer à externaliser les chaînes en dur au fil de l'eau.

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,40 @@
+# Protection des branches `main` et `dev`
+
+Objectif :
+- **Seule `dev` peut être mergée sur `main`** (aucune autre branche).
+- **`main` et `dev` ne peuvent pas être supprimées** (ni force-push).
+
+GitHub ne sait pas restreindre nativement la *branche source* d'une PR. On combine donc :
+1. un **workflow** (`.github/workflows/protect-main.yml`) qui fait échouer toute PR vers `main` ne provenant pas de `dev` ;
+2. deux **rulesets** (`main.json`, `dev.json`) qui exigent la PR + le check, et interdisent suppression/force-push.
+
+## Appliquer via l'interface GitHub (recommandé)
+
+Pour **chaque** fichier (`main.json` puis `dev.json`) :
+1. Repo → **Settings** → **Rules** → **Rulesets** → **New ruleset** → **Import a ruleset**.
+2. Sélectionner le fichier JSON → **Create**.
+
+> ⚠️ Le check requis est nommé **« Seule dev peut viser main »**. Il n'apparaît dans la liste des status checks qu'**après la première exécution** du workflow (donc après avoir ouvert une première PR vers `main`). Si l'import ne le retrouve pas, ouvre d'abord une PR de test `dev → main`, puis ajoute le check requis dans le ruleset `Protéger main`.
+
+## Appliquer via `gh` CLI (alternative)
+
+```bash
+gh auth login   # une seule fois
+
+gh api -X POST repos/Tomtoxi44/Chronique_Des_Mondes/rulesets \
+  --input .github/rulesets/main.json
+
+gh api -X POST repos/Tomtoxi44/Chronique_Des_Mondes/rulesets \
+  --input .github/rulesets/dev.json
+```
+
+## Vérifier
+
+- Une PR `feature/x → main` doit être **bloquée** (check « Seule dev peut viser main » en échec).
+- Une PR `dev → main` passe le check.
+- Tenter de supprimer `main` ou `dev` doit être **refusé**.
+
+## Notes
+
+- `bypass_actors` est **vide** : les règles s'appliquent aussi aux administrateurs (blocage strict demandé). Pour t'autoriser un contournement d'urgence, ajoute ton rôle dans *Bypass list* du ruleset.
+- `required_approving_review_count: 0` : pas de review obligatoire (tu merges tes propres PR), seulement PR + check.

--- a/.github/rulesets/dev.json
+++ b/.github/rulesets/dev.json
@@ -1,0 +1,17 @@
+{
+  "name": "Protéger dev",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["refs/heads/dev"]
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ],
+  "bypass_actors": []
+}

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,38 @@
+{
+  "name": "Protéger main",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["refs/heads/main"]
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "Seule dev peut viser main" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -1,0 +1,26 @@
+name: Protection de main
+
+# Empêche qu'une PR provenant d'une autre branche que `dev` soit mergée sur `main`.
+# GitHub ne sait pas restreindre nativement la branche SOURCE d'une PR : on l'enforce
+# donc par ce check, à rendre OBLIGATOIRE via le ruleset de `main`.
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  seule-dev-vers-main:
+    name: Seule dev peut viser main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Vérifier la branche source
+        run: |
+          echo "PR de '${{ github.head_ref }}' vers 'main'."
+          if [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "::error::Seule la branche 'dev' peut être mergée sur 'main' (source reçue : '${{ github.head_ref }}')."
+            exit 1
+          fi
+          echo "OK : la PR provient bien de 'dev'."


### PR DESCRIPTION
…ssion

Workflow protect-main.yml (échoue toute PR vers main hors dev) + rulesets importables (main : PR + check + anti-suppression/force-push ; dev : anti-suppression/force-push) + README d'application (UI + gh).