### PR TITLE
feat(marketplace): partage/import complet des mondes, campagnes et pe…

### DIFF
--- a/.github/ROADMAP.md
+++ b/.github/ROADMAP.md
@@ -236,15 +236,16 @@
 
 > À faire au **déploiement** : appliquer le bicep + poser les app settings `ImageStorage__Provider=AzureBlob`, `ImageStorage__BlobServiceUri`, `ImageStorage__ContainerName` (sinon reste en local).
 
-### 2. Marketplace / Partage
-- [ ] Les utilisateurs partagent : **monde**, **campagne**, **personnages génériques** (pas les copies liées à un monde), **items**.
-- [ ] **DataGrid** avec **onglets par type d'élément** + **filtres** (type de jeu, etc.).
-- [ ] Intégration contextuelle : ajouter une campagne partagée → propose les **mondes du même type** de l'utilisateur ; ajouter un item → propose les **personnages du même type**. Bouton **grisé** si l'utilisateur n'a pas de monde/personnage cible.
+### 2. Marketplace / Partage (branche `feature/marketplace-full`)
+- [x] Les utilisateurs partagent : **monde**, **campagne**, **personnages génériques** (base only), **items** — `IMarketplaceService` (share/browse/import) + `MarketplaceEndpoints` + `MarketplaceApiClient`. Toggles de partage sur les listes Mondes / Campagnes / Personnages.
+- [x] Page `/marketplace` avec **onglets par type d'élément** (Items, Mondes, Campagnes, Personnages) + **filtres** (type de jeu) + recherche.
+- [x] Intégration contextuelle : importer une campagne partagée → sélecteur des **mondes du même type** de l'utilisateur ; bouton **grisé** (« Aucun monde compatible ») s'il n'a pas de monde cible. Import = **copie indépendante** (monde, campagne + chapitres, perso de base).
+- [ ] (Optionnel) Item → suggérer les **personnages du même type** à l'import direct (aujourd'hui l'ajout à un perso se fait depuis le Codex).
 
 ### 3. Codex d'items (branche `feature/codex`)
 - [x] Système de création d'items **de tous les thèmes** (`CodexItem` : GameType + JSON + image), rangés dans un **codex** personnel — page `/codex` (CRUD + filtres par univers).
 - [x] Depuis le codex : **ajouter à un personnage** (copie indépendante dans l'inventaire d'un perso du même type ; sélecteur des persos compatibles).
-- [ ] **Partager** un item (marketplace) — `IsShared` posé, UI de partage à faire avec la marketplace.
+- [x] **Partager** un item (marketplace) — onglet Items de `/marketplace` + bouton de partage depuis le Codex.
 - [~] L'ajout à l'inventaire utilise `DndInventoryItem` (seule table d'inventaire existante) : fonctionne pour tout perso, mais l'inventaire n'est affiché que sur la fiche D&D. Un inventaire générique par système reste à faire.
 
 ### 4. Loot en campagne / chapitre

--- a/Cdm/Cdm.ApiService/Endpoints/MarketplaceEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/MarketplaceEndpoints.cs
@@ -1,0 +1,177 @@
+// -----------------------------------------------------------------------
+// <copyright file="MarketplaceEndpoints.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.ApiService.Endpoints;
+
+using System.Security.Claims;
+using Cdm.Business.Abstraction.Services;
+using Cdm.Common.Enums;
+using Microsoft.AspNetCore.Mvc;
+
+/// <summary>
+/// Endpoints for sharing / browsing / importing worlds, campaigns and base characters on the marketplace.
+/// (Codex item marketplace lives in <see cref="CodexEndpoints"/>.)
+/// </summary>
+public static class MarketplaceEndpoints
+{
+    /// <summary>Maps the marketplace endpoints for worlds, campaigns and characters.</summary>
+    public static void MapMarketplaceEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/marketplace")
+            .WithTags("Marketplace")
+            .RequireAuthorization();
+
+        // Browse.
+        group.MapGet("/worlds", GetSharedWorldsAsync).WithName("GetSharedWorlds");
+        group.MapGet("/campaigns", GetSharedCampaignsAsync).WithName("GetSharedCampaigns");
+        group.MapGet("/characters", GetSharedCharactersAsync).WithName("GetSharedCharacters");
+
+        // Import.
+        group.MapPost("/worlds/{id:int}/import", ImportWorldAsync).WithName("ImportSharedWorld");
+        group.MapPost("/campaigns/{id:int}/import", ImportCampaignAsync).WithName("ImportSharedCampaign");
+        group.MapPost("/characters/{id:int}/import", ImportCharacterAsync).WithName("ImportSharedCharacter");
+
+        // Share toggles.
+        group.MapPut("/worlds/{id:int}/share", SetWorldSharedAsync).WithName("ShareWorld");
+        group.MapPut("/campaigns/{id:int}/share", SetCampaignSharedAsync).WithName("ShareCampaign");
+        group.MapPut("/characters/{id:int}/share", SetCharacterSharedAsync).WithName("ShareCharacter");
+    }
+
+    private static async Task<IResult> GetSharedWorldsAsync(
+        [FromServices] IMarketplaceService market,
+        ClaimsPrincipal user,
+        [FromQuery] GameType? gameType = null,
+        [FromQuery] string? search = null)
+    {
+        if (GetUserId(user) is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        return Results.Ok(await market.GetSharedWorldsAsync(gameType, search));
+    }
+
+    private static async Task<IResult> GetSharedCampaignsAsync(
+        [FromServices] IMarketplaceService market,
+        ClaimsPrincipal user,
+        [FromQuery] GameType? gameType = null,
+        [FromQuery] string? search = null)
+    {
+        if (GetUserId(user) is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        return Results.Ok(await market.GetSharedCampaignsAsync(gameType, search));
+    }
+
+    private static async Task<IResult> GetSharedCharactersAsync(
+        [FromServices] IMarketplaceService market,
+        ClaimsPrincipal user,
+        [FromQuery] string? search = null)
+    {
+        if (GetUserId(user) is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        return Results.Ok(await market.GetSharedCharactersAsync(search));
+    }
+
+    private static async Task<IResult> ImportWorldAsync(int id, [FromServices] IMarketplaceService market, ClaimsPrincipal user)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var (ok, error) = await market.ImportWorldAsync(id, userId.Value);
+        return ok ? Results.Ok() : Results.BadRequest(new { error });
+    }
+
+    private static async Task<IResult> ImportCampaignAsync(
+        int id,
+        [FromServices] IMarketplaceService market,
+        ClaimsPrincipal user,
+        [FromQuery] int targetWorldId)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var (ok, error) = await market.ImportCampaignAsync(id, targetWorldId, userId.Value);
+        return ok ? Results.Ok() : Results.BadRequest(new { error });
+    }
+
+    private static async Task<IResult> ImportCharacterAsync(int id, [FromServices] IMarketplaceService market, ClaimsPrincipal user)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var (ok, error) = await market.ImportCharacterAsync(id, userId.Value);
+        return ok ? Results.Ok() : Results.BadRequest(new { error });
+    }
+
+    private static async Task<IResult> SetWorldSharedAsync(
+        int id,
+        [FromServices] IMarketplaceService market,
+        ClaimsPrincipal user,
+        [FromQuery] bool shared = true)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var ok = await market.SetWorldSharedAsync(id, userId.Value, shared);
+        return ok ? Results.NoContent() : Results.NotFound();
+    }
+
+    private static async Task<IResult> SetCampaignSharedAsync(
+        int id,
+        [FromServices] IMarketplaceService market,
+        ClaimsPrincipal user,
+        [FromQuery] bool shared = true)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var ok = await market.SetCampaignSharedAsync(id, userId.Value, shared);
+        return ok ? Results.NoContent() : Results.NotFound();
+    }
+
+    private static async Task<IResult> SetCharacterSharedAsync(
+        int id,
+        [FromServices] IMarketplaceService market,
+        ClaimsPrincipal user,
+        [FromQuery] bool shared = true)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var ok = await market.SetCharacterSharedAsync(id, userId.Value, shared);
+        return ok ? Results.NoContent() : Results.NotFound();
+    }
+
+    private static int? GetUserId(ClaimsPrincipal user)
+    {
+        var claim = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return int.TryParse(claim, out var id) ? id : null;
+    }
+}

--- a/Cdm/Cdm.ApiService/Program.cs
+++ b/Cdm/Cdm.ApiService/Program.cs
@@ -179,6 +179,7 @@ else
 builder.Services.AddScoped<ICampaignService, CampaignService>();
 builder.Services.AddScoped<ICharacterService, CharacterService>();
 builder.Services.AddScoped<ICodexService, CodexService>();
+builder.Services.AddScoped<IMarketplaceService, MarketplaceService>();
 builder.Services.AddScoped<IWorldService, WorldService>();
 builder.Services.AddScoped<IChapterService, ChapterService>();
 builder.Services.AddScoped<IEventService, EventService>();
@@ -265,6 +266,7 @@ app.MapDndEndpoints();
 app.MapStatisticsEndpoints();
 app.MapImageEndpoints();
 app.MapCodexEndpoints();
+app.MapMarketplaceEndpoints();
 
 // Map SignalR hubs
 app.MapHub<Cdm.ApiService.Hubs.SessionHub>("/hubs/session");

--- a/Cdm/Cdm.Business.Abstraction/DTOs/CampaignDto.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/CampaignDto.cs
@@ -77,4 +77,9 @@ public class CampaignDto
     /// Gets or sets whether the campaign is active (deprecated - use Status)
     /// </summary>
     public bool IsActive { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the campaign is shared on the marketplace.
+    /// </summary>
+    public bool IsShared { get; set; }
 }

--- a/Cdm/Cdm.Business.Abstraction/DTOs/CharacterDto.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/CharacterDto.cs
@@ -70,4 +70,9 @@ public class CharacterDto
     /// Gets or sets the source character ID for world copies (null for base characters).
     /// </summary>
     public int? SourceCharacterId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this base character is shared on the marketplace.
+    /// </summary>
+    public bool IsShared { get; set; }
 }

--- a/Cdm/Cdm.Business.Abstraction/DTOs/MarketplaceEntryDto.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/MarketplaceEntryDto.cs
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+// <copyright file="MarketplaceEntryDto.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.DTOs;
+
+using Cdm.Common.Enums;
+
+/// <summary>
+/// A unified marketplace entry (world, campaign or base character shared by a user).
+/// </summary>
+public class MarketplaceEntryDto
+{
+    /// <summary>Gets or sets the source entity identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the display name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the optional description.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Gets or sets the optional image URL.</summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>Gets or sets the game system / theme.</summary>
+    public GameType GameType { get; set; }
+
+    /// <summary>Gets or sets the owner's display name.</summary>
+    public string? SharedByName { get; set; }
+}

--- a/Cdm/Cdm.Business.Abstraction/DTOs/WorldDto.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/WorldDto.cs
@@ -44,6 +44,11 @@ public class WorldDto
     public bool IsActive { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the world is shared on the marketplace.
+    /// </summary>
+    public bool IsShared { get; set; }
+
+    /// <summary>
     /// Gets or sets the creation date.
     /// </summary>
     public DateTime CreatedAt { get; set; }

--- a/Cdm/Cdm.Business.Abstraction/Services/IMarketplaceService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/IMarketplaceService.cs
@@ -1,0 +1,40 @@
+// -----------------------------------------------------------------------
+// <copyright file="IMarketplaceService.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.Services;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Common.Enums;
+
+/// <summary>
+/// Marketplace: sharing, browsing and importing worlds, campaigns and base characters.
+/// (Codex items are handled by <see cref="ICodexService"/>.)
+/// </summary>
+public interface IMarketplaceService
+{
+    Task<bool> SetWorldSharedAsync(int worldId, int userId, bool isShared);
+
+    Task<bool> SetCampaignSharedAsync(int campaignId, int userId, bool isShared);
+
+    Task<bool> SetCharacterSharedAsync(int characterId, int userId, bool isShared);
+
+    Task<IEnumerable<MarketplaceEntryDto>> GetSharedWorldsAsync(GameType? gameType = null, string? search = null);
+
+    Task<IEnumerable<MarketplaceEntryDto>> GetSharedCampaignsAsync(GameType? gameType = null, string? search = null);
+
+    Task<IEnumerable<MarketplaceEntryDto>> GetSharedCharactersAsync(string? search = null);
+
+    /// <summary>Imports a shared world as a new world owned by the user.</summary>
+    Task<(bool Success, string? Error)> ImportWorldAsync(int worldId, int userId);
+
+    /// <summary>Imports a shared campaign (and its chapters) into one of the user's worlds of the same game type.</summary>
+    Task<(bool Success, string? Error)> ImportCampaignAsync(int campaignId, int targetWorldId, int userId);
+
+    /// <summary>Imports a shared base character as a new base character owned by the user.</summary>
+    Task<(bool Success, string? Error)> ImportCharacterAsync(int characterId, int userId);
+}

--- a/Cdm/Cdm.Business.Common.Tests/Services/MarketplaceServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/MarketplaceServiceTests.cs
@@ -1,0 +1,285 @@
+// -----------------------------------------------------------------------
+// <copyright file="MarketplaceServiceTests.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Tests.Services;
+
+using Cdm.Business.Common.Services;
+using Cdm.Common.Enums;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="MarketplaceService"/> — sharing, browsing and importing.
+/// </summary>
+public class MarketplaceServiceTests
+{
+    private const int OwnerId = 1;
+    private const int OtherUserId = 2;
+
+    private readonly Mock<ILogger<MarketplaceService>> loggerMock = new();
+
+    private static AppDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"MarketTests_{Guid.NewGuid()}")
+            .Options);
+
+    private static void SeedUser(AppDbContext ctx, int id, string nickname)
+    {
+        ctx.Users.Add(new User { Id = id, Nickname = nickname, Email = $"u{id}@x.io", PasswordHash = "x" });
+        ctx.SaveChanges();
+    }
+
+    private static World SeedWorld(AppDbContext ctx, int id, int userId, GameType type = GameType.DnD5e, bool shared = false, bool active = true, string name = "Monde")
+    {
+        var w = new World { Id = id, UserId = userId, Name = name, GameType = type, IsShared = shared, IsActive = active, CreatedAt = DateTime.UtcNow };
+        ctx.Worlds.Add(w);
+        ctx.SaveChanges();
+        return w;
+    }
+
+    private static Campaign SeedCampaign(AppDbContext ctx, int id, int worldId, int createdBy, bool shared = false, string name = "Campagne")
+    {
+        var c = new Campaign { Id = id, Name = name, WorldId = worldId, CreatedBy = createdBy, IsShared = shared, IsActive = true, IsDeleted = false, CreatedAt = DateTime.UtcNow };
+        ctx.Campaigns.Add(c);
+        ctx.SaveChanges();
+        return c;
+    }
+
+    private static Character SeedCharacter(AppDbContext ctx, int id, int userId, bool baseChar = true, bool shared = false, string name = "Perso")
+    {
+        var ch = new Character { Id = id, UserId = userId, Name = name, FirstName = "Aria", IsBaseCharacter = baseChar, IsShared = shared, IsActive = true, CreatedAt = DateTime.UtcNow };
+        ctx.Characters.Add(ch);
+        ctx.SaveChanges();
+        return ch;
+    }
+
+    private MarketplaceService NewService(AppDbContext ctx) => new(ctx, this.loggerMock.Object);
+
+    // ── Sharing toggles ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SetWorldSharedAsync_OwnerCanShare()
+    {
+        using var ctx = NewContext();
+        SeedWorld(ctx, 10, OwnerId);
+        var service = this.NewService(ctx);
+
+        var ok = await service.SetWorldSharedAsync(10, OwnerId, true);
+
+        Assert.True(ok);
+        Assert.True((await ctx.Worlds.FindAsync(10))!.IsShared);
+    }
+
+    [Fact]
+    public async Task SetWorldSharedAsync_NonOwnerRejected()
+    {
+        using var ctx = NewContext();
+        SeedWorld(ctx, 10, OwnerId);
+        var service = this.NewService(ctx);
+
+        var ok = await service.SetWorldSharedAsync(10, OtherUserId, true);
+
+        Assert.False(ok);
+        Assert.False((await ctx.Worlds.FindAsync(10))!.IsShared);
+    }
+
+    [Fact]
+    public async Task SetCharacterSharedAsync_RejectsNonBaseCharacter()
+    {
+        using var ctx = NewContext();
+        SeedCharacter(ctx, 10, OwnerId, baseChar: false);
+        var service = this.NewService(ctx);
+
+        var ok = await service.SetCharacterSharedAsync(10, OwnerId, true);
+
+        Assert.False(ok);
+    }
+
+    // ── Browse ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetSharedWorldsAsync_ReturnsOnlySharedActiveWithOwnerName()
+    {
+        using var ctx = NewContext();
+        SeedUser(ctx, OwnerId, "Tommy");
+        SeedWorld(ctx, 10, OwnerId, shared: true, name: "Shared");
+        SeedWorld(ctx, 11, OwnerId, shared: false, name: "Private");
+        SeedWorld(ctx, 12, OwnerId, shared: true, active: false, name: "Deleted");
+        var service = this.NewService(ctx);
+
+        var result = (await service.GetSharedWorldsAsync()).ToList();
+
+        var entry = Assert.Single(result);
+        Assert.Equal("Shared", entry.Name);
+        Assert.Equal("Tommy", entry.SharedByName);
+    }
+
+    [Fact]
+    public async Task GetSharedWorldsAsync_FiltersByGameType()
+    {
+        using var ctx = NewContext();
+        SeedUser(ctx, OwnerId, "Tommy");
+        SeedWorld(ctx, 10, OwnerId, type: GameType.DnD5e, shared: true);
+        SeedWorld(ctx, 11, OwnerId, type: GameType.CallOfCthulhu, shared: true);
+        var service = this.NewService(ctx);
+
+        var result = (await service.GetSharedWorldsAsync(GameType.CallOfCthulhu)).ToList();
+
+        var entry = Assert.Single(result);
+        Assert.Equal(GameType.CallOfCthulhu, entry.GameType);
+    }
+
+    [Fact]
+    public async Task GetSharedCampaignsAsync_UsesWorldGameType()
+    {
+        using var ctx = NewContext();
+        SeedUser(ctx, OwnerId, "Tommy");
+        SeedWorld(ctx, 10, OwnerId, type: GameType.Pathfinder);
+        SeedCampaign(ctx, 20, worldId: 10, createdBy: OwnerId, shared: true);
+        var service = this.NewService(ctx);
+
+        var result = (await service.GetSharedCampaignsAsync()).ToList();
+
+        var entry = Assert.Single(result);
+        Assert.Equal(GameType.Pathfinder, entry.GameType);
+        Assert.Equal("Tommy", entry.SharedByName);
+    }
+
+    [Fact]
+    public async Task GetSharedCharactersAsync_ReturnsOnlySharedBaseCharacters()
+    {
+        using var ctx = NewContext();
+        SeedUser(ctx, OwnerId, "Tommy");
+        SeedCharacter(ctx, 30, OwnerId, baseChar: true, shared: true, name: "Base");
+        SeedCharacter(ctx, 31, OwnerId, baseChar: false, shared: true, name: "Copy");
+        SeedCharacter(ctx, 32, OwnerId, baseChar: true, shared: false, name: "Private");
+        var service = this.NewService(ctx);
+
+        var result = (await service.GetSharedCharactersAsync()).ToList();
+
+        var entry = Assert.Single(result);
+        Assert.Equal(GameType.Generic, entry.GameType);
+        Assert.Equal("Aria", entry.Name);
+    }
+
+    // ── Import ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ImportWorldAsync_CreatesIndependentCopyOwnedByUser()
+    {
+        using var ctx = NewContext();
+        SeedWorld(ctx, 10, OwnerId, type: GameType.DnD5e, shared: true, name: "Faerûn");
+        var service = this.NewService(ctx);
+
+        var (success, error) = await service.ImportWorldAsync(10, OtherUserId);
+
+        Assert.True(success);
+        Assert.Null(error);
+        var copy = await ctx.Worlds.SingleAsync(w => w.UserId == OtherUserId);
+        Assert.Equal("Faerûn", copy.Name);
+        Assert.False(copy.IsShared);
+        Assert.NotEqual(10, copy.Id);
+    }
+
+    [Fact]
+    public async Task ImportWorldAsync_RejectsUnsharedWorld()
+    {
+        using var ctx = NewContext();
+        SeedWorld(ctx, 10, OwnerId, shared: false);
+        var service = this.NewService(ctx);
+
+        var (success, _) = await service.ImportWorldAsync(10, OtherUserId);
+
+        Assert.False(success);
+    }
+
+    [Fact]
+    public async Task ImportCampaignAsync_RejectsIncompatibleWorldType()
+    {
+        using var ctx = NewContext();
+        SeedWorld(ctx, 10, OwnerId, type: GameType.DnD5e);
+        SeedCampaign(ctx, 20, worldId: 10, createdBy: OwnerId, shared: true);
+        var target = SeedWorld(ctx, 11, OtherUserId, type: GameType.CallOfCthulhu);
+        var service = this.NewService(ctx);
+
+        var (success, error) = await service.ImportCampaignAsync(20, target.Id, OtherUserId);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public async Task ImportCampaignAsync_CopiesCampaignAndChapters()
+    {
+        using var ctx = NewContext();
+        SeedWorld(ctx, 10, OwnerId, type: GameType.DnD5e);
+        SeedCampaign(ctx, 20, worldId: 10, createdBy: OwnerId, shared: true, name: "La Malédiction");
+        ctx.Chapters.Add(new Chapter { Id = 100, CampaignId = 20, ChapterNumber = 1, Title = "Prologue", Content = "…", IsActive = true, CreatedAt = DateTime.UtcNow });
+        ctx.Chapters.Add(new Chapter { Id = 101, CampaignId = 20, ChapterNumber = 2, Title = "Le donjon", Content = "…", IsActive = true, CreatedAt = DateTime.UtcNow });
+        ctx.SaveChanges();
+        var target = SeedWorld(ctx, 11, OtherUserId, type: GameType.DnD5e);
+        var service = this.NewService(ctx);
+
+        var (success, error) = await service.ImportCampaignAsync(20, target.Id, OtherUserId);
+
+        Assert.True(success);
+        Assert.Null(error);
+        var copy = await ctx.Campaigns.SingleAsync(c => c.CreatedBy == OtherUserId);
+        Assert.Equal("La Malédiction", copy.Name);
+        Assert.Equal(target.Id, copy.WorldId);
+        Assert.False(copy.IsShared);
+        var chapters = await ctx.Chapters.Where(ch => ch.CampaignId == copy.Id).ToListAsync();
+        Assert.Equal(2, chapters.Count);
+        Assert.Contains(chapters, ch => ch.Title == "Prologue");
+    }
+
+    [Fact]
+    public async Task ImportCampaignAsync_RejectsWorldNotOwnedByUser()
+    {
+        using var ctx = NewContext();
+        SeedWorld(ctx, 10, OwnerId, type: GameType.DnD5e);
+        SeedCampaign(ctx, 20, worldId: 10, createdBy: OwnerId, shared: true);
+        SeedWorld(ctx, 11, OwnerId, type: GameType.DnD5e); // target owned by someone else
+        var service = this.NewService(ctx);
+
+        var (success, _) = await service.ImportCampaignAsync(20, 11, OtherUserId);
+
+        Assert.False(success);
+    }
+
+    [Fact]
+    public async Task ImportCharacterAsync_CopiesBaseCharacter()
+    {
+        using var ctx = NewContext();
+        SeedCharacter(ctx, 30, OwnerId, baseChar: true, shared: true, name: "Legolas");
+        var service = this.NewService(ctx);
+
+        var (success, error) = await service.ImportCharacterAsync(30, OtherUserId);
+
+        Assert.True(success);
+        Assert.Null(error);
+        var copy = await ctx.Characters.SingleAsync(c => c.UserId == OtherUserId);
+        Assert.Equal("Legolas", copy.Name);
+        Assert.True(copy.IsBaseCharacter);
+        Assert.False(copy.IsShared);
+    }
+
+    [Fact]
+    public async Task ImportCharacterAsync_RejectsUnsharedCharacter()
+    {
+        using var ctx = NewContext();
+        SeedCharacter(ctx, 30, OwnerId, baseChar: true, shared: false);
+        var service = this.NewService(ctx);
+
+        var (success, _) = await service.ImportCharacterAsync(30, OtherUserId);
+
+        Assert.False(success);
+    }
+}

--- a/Cdm/Cdm.Business.Common/Services/CampaignService.cs
+++ b/Cdm/Cdm.Business.Common/Services/CampaignService.cs
@@ -378,7 +378,8 @@ public class CampaignService(
             CreatedBy = campaign.CreatedBy,
             CreatedAt = campaign.CreatedAt,
             UpdatedAt = campaign.UpdatedAt,
-            IsActive = campaign.IsActive
+            IsActive = campaign.IsActive,
+            IsShared = campaign.IsShared
         };
     }
 

--- a/Cdm/Cdm.Business.Common/Services/CharacterService.cs
+++ b/Cdm/Cdm.Business.Common/Services/CharacterService.cs
@@ -588,6 +588,7 @@ public class CharacterService(
             AvatarUrl = character.AvatarUrl,
             IsLocked = character.IsLocked,
             IsBaseCharacter = character.IsBaseCharacter,
+            IsShared = character.IsShared,
             SourceCharacterId = character.SourceCharacterId,
             CreatedAt = character.CreatedAt,
             UpdatedAt = character.UpdatedAt

--- a/Cdm/Cdm.Business.Common/Services/MarketplaceService.cs
+++ b/Cdm/Cdm.Business.Common/Services/MarketplaceService.cs
@@ -1,0 +1,301 @@
+// -----------------------------------------------------------------------
+// <copyright file="MarketplaceService.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Services;
+
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.Services;
+using Cdm.Common.Enums;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Marketplace sharing/browsing/importing for worlds, campaigns and base characters.
+/// Imports always create independent copies owned by the importing user.
+/// </summary>
+public class MarketplaceService(AppDbContext dbContext, ILogger<MarketplaceService> logger) : IMarketplaceService
+{
+    private readonly AppDbContext dbContext = dbContext;
+    private readonly ILogger<MarketplaceService> logger = logger;
+
+    // ── Sharing toggles ──────────────────────────────────────────────────
+
+    public async Task<bool> SetWorldSharedAsync(int worldId, int userId, bool isShared)
+    {
+        var world = await this.dbContext.Worlds.FirstOrDefaultAsync(w => w.Id == worldId && w.UserId == userId && w.IsActive);
+        if (world == null)
+        {
+            return false;
+        }
+
+        world.IsShared = isShared;
+        world.UpdatedAt = DateTime.UtcNow;
+        await this.dbContext.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> SetCampaignSharedAsync(int campaignId, int userId, bool isShared)
+    {
+        var campaign = await this.dbContext.Campaigns.FirstOrDefaultAsync(c => c.Id == campaignId && c.CreatedBy == userId && c.IsActive && !c.IsDeleted);
+        if (campaign == null)
+        {
+            return false;
+        }
+
+        campaign.IsShared = isShared;
+        campaign.UpdatedAt = DateTime.UtcNow;
+        await this.dbContext.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> SetCharacterSharedAsync(int characterId, int userId, bool isShared)
+    {
+        var character = await this.dbContext.Characters.FirstOrDefaultAsync(c => c.Id == characterId && c.UserId == userId && c.IsActive && c.IsBaseCharacter);
+        if (character == null)
+        {
+            return false;
+        }
+
+        character.IsShared = isShared;
+        character.UpdatedAt = DateTime.UtcNow;
+        await this.dbContext.SaveChangesAsync();
+        return true;
+    }
+
+    // ── Browse ───────────────────────────────────────────────────────────
+
+    public async Task<IEnumerable<MarketplaceEntryDto>> GetSharedWorldsAsync(GameType? gameType = null, string? search = null)
+    {
+        try
+        {
+            var term = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+            var query = from w in this.dbContext.Worlds
+                        join u in this.dbContext.Users on w.UserId equals u.Id
+                        where w.IsActive && w.IsShared
+                            && (gameType == null || w.GameType == gameType)
+                            && (term == null || w.Name.Contains(term))
+                        orderby w.CreatedAt descending
+                        select new MarketplaceEntryDto
+                        {
+                            Id = w.Id,
+                            Name = w.Name,
+                            Description = w.Description,
+                            GameType = w.GameType,
+                            SharedByName = u.Nickname,
+                        };
+            return await query.ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error listing shared worlds");
+            return Enumerable.Empty<MarketplaceEntryDto>();
+        }
+    }
+
+    public async Task<IEnumerable<MarketplaceEntryDto>> GetSharedCampaignsAsync(GameType? gameType = null, string? search = null)
+    {
+        try
+        {
+            var term = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+            var query = from c in this.dbContext.Campaigns
+                        join wld in this.dbContext.Worlds on c.WorldId equals wld.Id
+                        join u in this.dbContext.Users on c.CreatedBy equals u.Id
+                        where c.IsActive && !c.IsDeleted && c.IsShared
+                            && (gameType == null || wld.GameType == gameType)
+                            && (term == null || c.Name.Contains(term))
+                        orderby c.CreatedAt descending
+                        select new MarketplaceEntryDto
+                        {
+                            Id = c.Id,
+                            Name = c.Name,
+                            Description = c.Description,
+                            ImageUrl = c.CoverImageUrl,
+                            GameType = wld.GameType,
+                            SharedByName = u.Nickname,
+                        };
+            return await query.ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error listing shared campaigns");
+            return Enumerable.Empty<MarketplaceEntryDto>();
+        }
+    }
+
+    public async Task<IEnumerable<MarketplaceEntryDto>> GetSharedCharactersAsync(string? search = null)
+    {
+        try
+        {
+            var term = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+            var query = from ch in this.dbContext.Characters
+                        join u in this.dbContext.Users on ch.UserId equals u.Id
+                        where ch.IsActive && ch.IsShared && ch.IsBaseCharacter
+                            && (term == null || ch.Name.Contains(term) || (ch.FirstName != null && ch.FirstName.Contains(term)))
+                        orderby ch.CreatedAt descending
+                        select new MarketplaceEntryDto
+                        {
+                            Id = ch.Id,
+                            Name = ch.FirstName ?? ch.Name,
+                            Description = ch.Description,
+                            ImageUrl = ch.AvatarUrl,
+                            GameType = GameType.Generic,
+                            SharedByName = u.Nickname,
+                        };
+            return await query.ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error listing shared characters");
+            return Enumerable.Empty<MarketplaceEntryDto>();
+        }
+    }
+
+    // ── Import (independent copies) ──────────────────────────────────────
+
+    public async Task<(bool Success, string? Error)> ImportWorldAsync(int worldId, int userId)
+    {
+        try
+        {
+            var src = await this.dbContext.Worlds.FirstOrDefaultAsync(w => w.Id == worldId && w.IsActive && w.IsShared);
+            if (src == null)
+            {
+                return (false, "Monde introuvable ou non partagé.");
+            }
+
+            var copy = new World
+            {
+                UserId = userId,
+                Name = src.Name,
+                Description = src.Description,
+                GameType = src.GameType,
+                IsActive = true,
+                IsShared = false,
+                CreatedAt = DateTime.UtcNow,
+            };
+            this.dbContext.Worlds.Add(copy);
+            await this.dbContext.SaveChangesAsync();
+            this.logger.LogInformation("User {UserId} imported world {WorldId} as {NewId}", userId, worldId, copy.Id);
+            return (true, null);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error importing world {WorldId}", worldId);
+            return (false, "Erreur lors de l'import du monde.");
+        }
+    }
+
+    public async Task<(bool Success, string? Error)> ImportCampaignAsync(int campaignId, int targetWorldId, int userId)
+    {
+        try
+        {
+            var src = await this.dbContext.Campaigns
+                .Include(c => c.World)
+                .FirstOrDefaultAsync(c => c.Id == campaignId && c.IsActive && !c.IsDeleted && c.IsShared);
+            if (src == null)
+            {
+                return (false, "Campagne introuvable ou non partagée.");
+            }
+
+            var targetWorld = await this.dbContext.Worlds
+                .FirstOrDefaultAsync(w => w.Id == targetWorldId && w.IsActive && w.UserId == userId);
+            if (targetWorld == null)
+            {
+                return (false, "Monde cible introuvable ou ne vous appartient pas.");
+            }
+
+            if (targetWorld.GameType != src.World.GameType)
+            {
+                return (false, "Le type de jeu du monde cible ne correspond pas à celui de la campagne.");
+            }
+
+            var copy = new Campaign
+            {
+                Name = src.Name,
+                Description = src.Description,
+                WorldId = targetWorldId,
+                CreatedBy = userId,
+                Visibility = Visibility.Private,
+                MaxPlayers = src.MaxPlayers,
+                CoverImageUrl = src.CoverImageUrl,
+                IsActive = true,
+                IsShared = false,
+                CreatedAt = DateTime.UtcNow,
+            };
+            this.dbContext.Campaigns.Add(copy);
+            await this.dbContext.SaveChangesAsync();
+
+            // Deep-copy the chapters (content of the campaign).
+            var chapters = await this.dbContext.Chapters
+                .Where(ch => ch.CampaignId == src.Id && ch.IsActive)
+                .OrderBy(ch => ch.ChapterNumber)
+                .ToListAsync();
+
+            foreach (var ch in chapters)
+            {
+                this.dbContext.Chapters.Add(new Chapter
+                {
+                    CampaignId = copy.Id,
+                    ChapterNumber = ch.ChapterNumber,
+                    Title = ch.Title,
+                    Content = ch.Content,
+                    IsActive = true,
+                    CreatedAt = DateTime.UtcNow,
+                });
+            }
+
+            if (chapters.Count > 0)
+            {
+                await this.dbContext.SaveChangesAsync();
+            }
+
+            this.logger.LogInformation("User {UserId} imported campaign {CampaignId} into world {WorldId} ({ChapterCount} chapters)", userId, campaignId, targetWorldId, chapters.Count);
+            return (true, null);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error importing campaign {CampaignId}", campaignId);
+            return (false, "Erreur lors de l'import de la campagne.");
+        }
+    }
+
+    public async Task<(bool Success, string? Error)> ImportCharacterAsync(int characterId, int userId)
+    {
+        try
+        {
+            var src = await this.dbContext.Characters
+                .FirstOrDefaultAsync(c => c.Id == characterId && c.IsActive && c.IsShared && c.IsBaseCharacter);
+            if (src == null)
+            {
+                return (false, "Personnage introuvable ou non partagé.");
+            }
+
+            var copy = new Character
+            {
+                UserId = userId,
+                Name = src.Name,
+                FirstName = src.FirstName,
+                Description = src.Description,
+                Age = src.Age,
+                AvatarUrl = src.AvatarUrl,
+                IsActive = true,
+                IsBaseCharacter = true,
+                IsShared = false,
+                CreatedAt = DateTime.UtcNow,
+            };
+            this.dbContext.Characters.Add(copy);
+            await this.dbContext.SaveChangesAsync();
+            this.logger.LogInformation("User {UserId} imported character {CharacterId} as {NewId}", userId, characterId, copy.Id);
+            return (true, null);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error importing character {CharacterId}", characterId);
+            return (false, "Erreur lors de l'import du personnage.");
+        }
+    }
+}

--- a/Cdm/Cdm.Business.Common/Services/WorldService.cs
+++ b/Cdm/Cdm.Business.Common/Services/WorldService.cs
@@ -365,6 +365,7 @@ public class WorldService(
             Description = world.Description,
             GameType = world.GameType,
             IsActive = world.IsActive,
+            IsShared = world.IsShared,
             CreatedAt = world.CreatedAt,
             UpdatedAt = world.UpdatedAt,
             CampaignCount = world.Campaigns?.Count(c => c.IsActive && !c.IsDeleted) ?? 0,

--- a/Cdm/Cdm.Data.Common/Models/Campaign.cs
+++ b/Cdm/Cdm.Data.Common/Models/Campaign.cs
@@ -109,6 +109,9 @@ public class Campaign
     [Required]
     public bool IsDeleted { get; set; } = false;
 
+    /// <summary>Gets or sets a value indicating whether the campaign is shared on the marketplace.</summary>
+    public bool IsShared { get; set; } = false;
+
     /// <summary>
     /// Gets or sets the chapters in this campaign.
     /// </summary>

--- a/Cdm/Cdm.Data.Common/Models/Character.cs
+++ b/Cdm/Cdm.Data.Common/Models/Character.cs
@@ -57,6 +57,9 @@ public class Character
     /// </summary>
     public bool IsBaseCharacter { get; set; } = false;
 
+    /// <summary>Gets or sets a value indicating whether this base character is shared on the marketplace.</summary>
+    public bool IsShared { get; set; } = false;
+
     /// <summary>
     /// Gets or sets the source character ID (for world copies).
     /// Null for base characters. Points to the original Character that was duplicated.

--- a/Cdm/Cdm.Data.Common/Models/World.cs
+++ b/Cdm/Cdm.Data.Common/Models/World.cs
@@ -43,6 +43,9 @@ public class World
     /// </summary>
     public bool IsActive { get; set; } = true;
 
+    /// <summary>Gets or sets a value indicating whether the world is shared on the marketplace.</summary>
+    public bool IsShared { get; set; } = false;
+
     /// <summary>
     /// Gets or sets the invite token for joining the world (generated on demand).
     /// </summary>

--- a/Cdm/Cdm.Migrations/Migrations/20260721070000_AddMarketplaceSharing.cs
+++ b/Cdm/Cdm.Migrations/Migrations/20260721070000_AddMarketplaceSharing.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Cdm.Migrations;
+
+#nullable disable
+
+namespace Cdm.Migrations.Migrations
+{
+    /// <summary>
+    /// Ajoute la colonne [IsShared] (marketplace) sur [Worlds], [Campaigns] et [Characters].
+    /// Migration idempotente (IF COL_LENGTH ... IS NULL).
+    /// </summary>
+    [DbContext(typeof(MigrationsContext))]
+    [Migration("20260721070000_AddMarketplaceSharing")]
+    public partial class AddMarketplaceSharing : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH(N'[Worlds]', N'IsShared') IS NULL
+                    ALTER TABLE [Worlds] ADD [IsShared] bit NOT NULL DEFAULT 0;
+            ");
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH(N'[Campaigns]', N'IsShared') IS NULL
+                    ALTER TABLE [Campaigns] ADD [IsShared] bit NOT NULL DEFAULT 0;
+            ");
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH(N'[Characters]', N'IsShared') IS NULL
+                    ALTER TABLE [Characters] ADD [IsShared] bit NOT NULL DEFAULT 0;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"IF COL_LENGTH(N'[Worlds]', N'IsShared') IS NOT NULL ALTER TABLE [Worlds] DROP COLUMN [IsShared];");
+            migrationBuilder.Sql(@"IF COL_LENGTH(N'[Campaigns]', N'IsShared') IS NOT NULL ALTER TABLE [Campaigns] DROP COLUMN [IsShared];");
+            migrationBuilder.Sql(@"IF COL_LENGTH(N'[Characters]', N'IsShared') IS NOT NULL ALTER TABLE [Characters] DROP COLUMN [IsShared];");
+        }
+    }
+}

--- a/Cdm/Cdm.Web/Components/Pages/Campaigns/Campaigns.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Campaigns/Campaigns.razor
@@ -41,6 +41,11 @@ else
                     <div class="card-header-row">
                         <AppGameBadge GameType="@campaign.GameType" />
                         <div class="card-actions">
+                            <button class="btn btn-ghost btn-icon @(campaign.IsShared ? "danger" : "")"
+                                    @onclick="() => ToggleShare(campaign)"
+                                    title="@(campaign.IsShared ? L["Marketplace_Unshare"] : L["Marketplace_Share"])">
+                                <i class="bi @(campaign.IsShared ? "bi-share-fill" : "bi-share")"></i>
+                            </button>
                             <a href="/campaigns/@campaign.Id" class="btn btn-ghost btn-icon" title="@L["Common_Details"]">
                                 <i class="bi bi-arrow-right"></i>
                             </a>

--- a/Cdm/Cdm.Web/Components/Pages/Campaigns/Campaigns.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Campaigns/Campaigns.razor.cs
@@ -11,6 +11,7 @@ namespace Cdm.Web.Components.Pages.Campaigns;
 public partial class Campaigns
 {
     [Inject] private CampaignApiClient CampaignClient { get; set; } = default!;
+    [Inject] private MarketplaceApiClient MarketClient { get; set; } = default!;
     [Inject] private IStringLocalizer<AppStrings> L { get; set; } = default!;
 
     private List<CampaignDto> CampaignList { get; set; } = new();
@@ -23,6 +24,16 @@ public partial class Campaigns
         IsLoading = true;
         CampaignList = await CampaignClient.GetMyCampaignsAsync();
         IsLoading = false;
+    }
+
+    private async Task ToggleShare(CampaignDto campaign)
+    {
+        var newValue = !campaign.IsShared;
+        var ok = await MarketClient.SetCampaignSharedAsync(campaign.Id, newValue);
+        if (ok)
+        {
+            campaign.IsShared = newValue;
+        }
     }
 
     private void ConfirmDelete(CampaignDto campaign)

--- a/Cdm/Cdm.Web/Components/Pages/Characters/Characters.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/Characters.razor
@@ -49,6 +49,14 @@ else
                         }
                     </div>
                     <div class="card-actions">
+                        @if (character.IsBaseCharacter)
+                        {
+                            <button class="btn btn-ghost btn-icon @(character.IsShared ? "danger" : "")"
+                                    @onclick="() => ToggleShare(character)"
+                                    title="@(character.IsShared ? L["Marketplace_Unshare"] : L["Marketplace_Share"])">
+                                <i class="bi @(character.IsShared ? "bi-share-fill" : "bi-share")"></i>
+                            </button>
+                        }
                         <a href="/characters/@character.Id/edit" class="btn btn-ghost btn-icon" title="@L["Common_Edit"]">
                             <i class="bi bi-pencil"></i>
                         </a>

--- a/Cdm/Cdm.Web/Components/Pages/Characters/Characters.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/Characters.razor.cs
@@ -10,6 +10,7 @@ namespace Cdm.Web.Components.Pages.Characters;
 public partial class Characters
 {
     [Inject] private ICharacterApiClient CharacterClient { get; set; } = default!;
+    [Inject] private MarketplaceApiClient MarketClient { get; set; } = default!;
     [Inject] private IStringLocalizer<AppStrings> L { get; set; } = default!;
 
     private List<CharacterDto> CharacterList { get; set; } = new();
@@ -37,6 +38,16 @@ public partial class Characters
         var success = await CharacterClient.DeleteCharacterAsync(CharacterToDelete.Id);
         if (success) CharacterList.Remove(CharacterToDelete);
         CharacterToDelete = null;
+    }
+
+    private async Task ToggleShare(CharacterDto character)
+    {
+        var newValue = !character.IsShared;
+        var ok = await MarketClient.SetCharacterSharedAsync(character.Id, newValue);
+        if (ok)
+        {
+            character.IsShared = newValue;
+        }
     }
 
     private static string GetInitials(CharacterDto character)

--- a/Cdm/Cdm.Web/Components/Pages/Marketplace/Marketplace.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Marketplace/Marketplace.razor
@@ -3,6 +3,8 @@
 @using Cdm.Business.Abstraction.DTOs
 @using Cdm.Common.Enums
 @inject Cdm.Web.Services.ApiClients.CodexApiClient CodexClient
+@inject Cdm.Web.Services.ApiClients.MarketplaceApiClient MarketClient
+@inject Cdm.Web.Services.ApiClients.WorldApiClient WorldClient
 
 <PageTitle>Marketplace — Chronique des Mondes</PageTitle>
 
@@ -10,10 +12,10 @@
 
 @* Onglets par type d'élément *@
 <div style="display: flex; gap: var(--spacing-xs); border-bottom: 1px solid var(--color-border); margin-bottom: var(--spacing-lg);">
-    <button class="mkt-tab active"><i class="bi bi-journal-bookmark"></i> Items</button>
-    <button class="mkt-tab" disabled title="Bientôt"><i class="bi bi-globe2"></i> Mondes <span class="mkt-soon">bientôt</span></button>
-    <button class="mkt-tab" disabled title="Bientôt"><i class="bi bi-map"></i> Campagnes <span class="mkt-soon">bientôt</span></button>
-    <button class="mkt-tab" disabled title="Bientôt"><i class="bi bi-people"></i> Personnages <span class="mkt-soon">bientôt</span></button>
+    <button class="mkt-tab @(ActiveTab == Tab.Items ? "active" : "")" @onclick="() => SwitchTab(Tab.Items)"><i class="bi bi-journal-bookmark"></i> Items</button>
+    <button class="mkt-tab @(ActiveTab == Tab.Worlds ? "active" : "")" @onclick="() => SwitchTab(Tab.Worlds)"><i class="bi bi-globe2"></i> Mondes</button>
+    <button class="mkt-tab @(ActiveTab == Tab.Campaigns ? "active" : "")" @onclick="() => SwitchTab(Tab.Campaigns)"><i class="bi bi-map"></i> Campagnes</button>
+    <button class="mkt-tab @(ActiveTab == Tab.Characters ? "active" : "")" @onclick="() => SwitchTab(Tab.Characters)"><i class="bi bi-people"></i> Personnages</button>
 </div>
 
 <style>
@@ -22,23 +24,29 @@
                gap: var(--spacing-xs); white-space: nowrap; margin-bottom: -1px; }
     .mkt-tab.active { color: var(--theme-ink, var(--color-primary)); border-bottom-color: var(--theme-primary, var(--color-primary)); font-weight: 600; }
     .mkt-tab:disabled { opacity: 0.5; cursor: not-allowed; }
-    .mkt-soon { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.08em; background: var(--color-bg-tertiary);
-                padding: 1px 5px; border-radius: var(--radius-sm); }
 </style>
 
 @* Filtres *@
 <div style="display: flex; flex-wrap: wrap; gap: var(--spacing-sm); align-items: center; margin-bottom: var(--spacing-lg);">
-    <div style="display: flex; flex-wrap: wrap; gap: var(--spacing-xs);">
-        <button class="btn btn-sm @(FilterType == null ? "btn-primary" : "btn-ghost")" @onclick="() => SetFilter(null)">Tous</button>
-        @foreach (var gt in GameTypes)
-        {
-            <button class="btn btn-sm @(FilterType == gt.Value ? "btn-primary" : "btn-ghost")" @onclick="() => SetFilter(gt.Value)">@gt.Label</button>
-        }
-    </div>
+    @if (ActiveTab != Tab.Characters)
+    {
+        <div style="display: flex; flex-wrap: wrap; gap: var(--spacing-xs);">
+            <button class="btn btn-sm @(FilterType == null ? "btn-primary" : "btn-ghost")" @onclick="() => SetFilter(null)">Tous</button>
+            @foreach (var gt in GameTypes)
+            {
+                <button class="btn btn-sm @(FilterType == gt.Value ? "btn-primary" : "btn-ghost")" @onclick="() => SetFilter(gt.Value)">@gt.Label</button>
+            }
+        </div>
+    }
     <div class="form-group" style="margin: 0; min-width: 200px;">
-        <input type="text" class="form-control" placeholder="Rechercher un item…" @bind="SearchTerm" @bind:event="oninput" @onkeyup="OnSearchKey" />
+        <input type="text" class="form-control" placeholder="@SearchPlaceholder" @bind="SearchTerm" @bind:event="oninput" @onkeyup="OnSearchKey" />
     </div>
 </div>
+
+@if (!string.IsNullOrEmpty(ErrorMessage))
+{
+    <div class="alert alert-danger" style="margin-bottom: var(--spacing-md);">@ErrorMessage</div>
+}
 
 @if (IsLoading)
 {
@@ -46,70 +54,156 @@
         @for (int i = 0; i < 3; i++) { <AppSkeletonCard /> }
     </div>
 }
-else if (Items.Count == 0)
+else if (ActiveTab == Tab.Items)
 {
-    <AppEmptyState Icon="bi-shop"
-                   Title="Rien à afficher"
-                   Message="Aucun item partagé ne correspond. Partagez les vôtres depuis votre Codex !" />
-}
-else
-{
-    <div class="cards-grid">
-        @foreach (var item in Items)
-        {
-            <AppThemeWrapper GameType="@item.GameType">
-                <div class="cdm-card">
-                    <div class="card-header-row">
-                        <AppGameBadge GameType="@item.GameType" />
-                        @if (!string.IsNullOrEmpty(item.SharedByName))
-                        {
-                            <span class="status-badge" style="background: var(--color-bg-tertiary);">
-                                <i class="bi bi-person"></i> @item.SharedByName
-                            </span>
-                        }
-                    </div>
-
-                    <div style="display: flex; gap: var(--spacing-md); align-items: flex-start;">
-                        @if (!string.IsNullOrEmpty(item.ImageUrl))
-                        {
-                            <img src="@item.ImageUrl" alt="@item.Name"
-                                 style="width: 56px; height: 56px; object-fit: cover; border-radius: var(--radius-md); border: 1px solid var(--theme-card-border, var(--color-border)); flex-shrink: 0;" />
-                        }
-                        <div style="min-width: 0;">
-                            <h3 class="card-title">@item.Name</h3>
-                            @if (!string.IsNullOrEmpty(item.ItemType))
+    @if (Items.Count == 0)
+    {
+        <AppEmptyState Icon="bi-shop" Title="Rien à afficher"
+                       Message="Aucun item partagé ne correspond. Partagez les vôtres depuis votre Codex !" />
+    }
+    else
+    {
+        <div class="cards-grid">
+            @foreach (var item in Items)
+            {
+                <AppThemeWrapper GameType="@item.GameType">
+                    <div class="cdm-card">
+                        <div class="card-header-row">
+                            <AppGameBadge GameType="@item.GameType" />
+                            @if (!string.IsNullOrEmpty(item.SharedByName))
                             {
-                                <span class="status-badge" style="background: var(--color-bg-tertiary);">@item.ItemType</span>
+                                <span class="status-badge" style="background: var(--color-bg-tertiary);"><i class="bi bi-person"></i> @item.SharedByName</span>
+                            }
+                        </div>
+                        <div style="display: flex; gap: var(--spacing-md); align-items: flex-start;">
+                            @if (!string.IsNullOrEmpty(item.ImageUrl))
+                            {
+                                <img src="@item.ImageUrl" alt="@item.Name" class="mkt-thumb" />
+                            }
+                            <div style="min-width: 0;">
+                                <h3 class="card-title">@item.Name</h3>
+                                @if (!string.IsNullOrEmpty(item.ItemType))
+                                {
+                                    <span class="status-badge" style="background: var(--color-bg-tertiary);">@item.ItemType</span>
+                                }
+                            </div>
+                        </div>
+                        @if (!string.IsNullOrEmpty(item.Description))
+                        {
+                            <p class="card-description">@item.Description</p>
+                        }
+                        <div style="margin-top: var(--spacing-md);">
+                            @if (ImportedIds.Contains(item.Id))
+                            {
+                                <span style="font-size: var(--font-size-sm); color: var(--color-success);"><i class="bi bi-check-circle"></i> Ajouté à votre codex</span>
+                            }
+                            else
+                            {
+                                <button class="btn btn-primary btn-sm" @onclick="() => ImportItem(item.Id)" disabled="@(ImportingId == item.Id)">
+                                    <i class="bi bi-plus"></i> Ajouter à mon codex
+                                </button>
                             }
                         </div>
                     </div>
-
-                    @if (!string.IsNullOrEmpty(item.Description))
-                    {
-                        <p class="card-description">@item.Description</p>
-                    }
-
-                    <div style="margin-top: var(--spacing-md);">
-                        @if (ImportedIds.Contains(item.Id))
+                </AppThemeWrapper>
+            }
+        </div>
+    }
+}
+else
+{
+    @if (Entries.Count == 0)
+    {
+        <AppEmptyState Icon="bi-shop" Title="Rien à afficher" Message="@EmptyMessage" />
+    }
+    else
+    {
+        <div class="cards-grid">
+            @foreach (var entry in Entries)
+            {
+                <AppThemeWrapper GameType="@entry.GameType">
+                    <div class="cdm-card">
+                        <div class="card-header-row">
+                            @if (ActiveTab != Tab.Characters)
+                            {
+                                <AppGameBadge GameType="@entry.GameType" />
+                            }
+                            else
+                            {
+                                <span class="status-badge" style="background: var(--color-bg-tertiary);"><i class="bi bi-person-badge"></i> Personnage</span>
+                            }
+                            @if (!string.IsNullOrEmpty(entry.SharedByName))
+                            {
+                                <span class="status-badge" style="background: var(--color-bg-tertiary);"><i class="bi bi-person"></i> @entry.SharedByName</span>
+                            }
+                        </div>
+                        <div style="display: flex; gap: var(--spacing-md); align-items: flex-start;">
+                            @if (!string.IsNullOrEmpty(entry.ImageUrl))
+                            {
+                                <img src="@entry.ImageUrl" alt="@entry.Name" class="mkt-thumb" />
+                            }
+                            <div style="min-width: 0;">
+                                <h3 class="card-title">@entry.Name</h3>
+                            </div>
+                        </div>
+                        @if (!string.IsNullOrEmpty(entry.Description))
                         {
-                            <span style="font-size: var(--font-size-sm); color: var(--color-success);">
-                                <i class="bi bi-check-circle"></i> Ajouté à votre codex
-                            </span>
+                            <p class="card-description">@entry.Description</p>
                         }
-                        else
-                        {
-                            <button class="btn btn-primary btn-sm" @onclick="() => Import(item)" disabled="@(ImportingId == item.Id)">
-                                <i class="bi bi-plus"></i> Ajouter à mon codex
-                            </button>
-                        }
+
+                        <div style="margin-top: var(--spacing-md);">
+                            @if (ImportedIds.Contains(entry.Id))
+                            {
+                                <span style="font-size: var(--font-size-sm); color: var(--color-success);"><i class="bi bi-check-circle"></i> Importé</span>
+                            }
+                            else if (ActiveTab == Tab.Campaigns)
+                            {
+                                var compatible = MyWorlds.Where(w => w.GameType == entry.GameType).ToList();
+                                @if (compatible.Count == 0)
+                                {
+                                    <button class="btn btn-secondary btn-sm" disabled title="Aucun monde compatible de type @entry.GameType">
+                                        <i class="bi bi-slash-circle"></i> Aucun monde compatible
+                                    </button>
+                                }
+                                else
+                                {
+                                    <div style="display: flex; gap: var(--spacing-xs); flex-wrap: wrap; align-items: center;">
+                                        <select class="form-control" style="width: auto; min-width: 140px;"
+                                                value="@GetTargetWorld(entry.Id, compatible)"
+                                                @onchange="e => SetTargetWorld(entry.Id, e.Value?.ToString())">
+                                            @foreach (var w in compatible)
+                                            {
+                                                <option value="@w.Id">@w.Name</option>
+                                            }
+                                        </select>
+                                        <button class="btn btn-primary btn-sm" @onclick="() => ImportCampaign(entry.Id, compatible)" disabled="@(ImportingId == entry.Id)">
+                                            <i class="bi bi-download"></i> Importer
+                                        </button>
+                                    </div>
+                                }
+                            }
+                            else
+                            {
+                                <button class="btn btn-primary btn-sm" @onclick="() => ImportEntry(entry.Id)" disabled="@(ImportingId == entry.Id)">
+                                    <i class="bi bi-download"></i> Importer
+                                </button>
+                            }
+                        </div>
                     </div>
-                </div>
-            </AppThemeWrapper>
-        }
-    </div>
+                </AppThemeWrapper>
+            }
+        </div>
+    }
 }
 
+<style>
+    .mkt-thumb { width: 56px; height: 56px; object-fit: cover; border-radius: var(--radius-md);
+                 border: 1px solid var(--theme-card-border, var(--color-border)); flex-shrink: 0; }
+</style>
+
 @code {
+    private enum Tab { Items, Worlds, Campaigns, Characters }
+
     private static readonly (GameType Value, string Label)[] GameTypes = new[]
     {
         (GameType.Generic, "Générique"),
@@ -122,19 +216,71 @@ else
         (GameType.Custom, "Personnalisé"),
     };
 
+    private Tab ActiveTab = Tab.Items;
     private List<CodexItemDto> Items = new();
+    private List<MarketplaceEntryDto> Entries = new();
+    private List<WorldDto> MyWorlds = new();
+    private readonly Dictionary<int, int> TargetWorlds = new();
     private bool IsLoading = true;
     private GameType? FilterType;
     private string SearchTerm = string.Empty;
     private int? ImportingId;
     private readonly HashSet<int> ImportedIds = new();
+    private string? ErrorMessage;
 
-    protected override async Task OnInitializedAsync() => await Reload();
+    private string SearchPlaceholder => ActiveTab switch
+    {
+        Tab.Worlds => "Rechercher un monde…",
+        Tab.Campaigns => "Rechercher une campagne…",
+        Tab.Characters => "Rechercher un personnage…",
+        _ => "Rechercher un item…",
+    };
+
+    private string EmptyMessage => ActiveTab switch
+    {
+        Tab.Worlds => "Aucun monde partagé ne correspond.",
+        Tab.Campaigns => "Aucune campagne partagée ne correspond.",
+        Tab.Characters => "Aucun personnage partagé ne correspond.",
+        _ => "Aucun item partagé ne correspond.",
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        MyWorlds = await WorldClient.GetMyWorldsAsync();
+        await Reload();
+    }
+
+    private async Task SwitchTab(Tab tab)
+    {
+        if (ActiveTab == tab) return;
+        ActiveTab = tab;
+        FilterType = null;
+        SearchTerm = string.Empty;
+        ImportedIds.Clear();
+        ErrorMessage = null;
+        await Reload();
+    }
 
     private async Task Reload()
     {
         IsLoading = true;
-        Items = await CodexClient.GetMarketplaceItemsAsync(FilterType, string.IsNullOrWhiteSpace(SearchTerm) ? null : SearchTerm);
+        ErrorMessage = null;
+        var search = string.IsNullOrWhiteSpace(SearchTerm) ? null : SearchTerm;
+        switch (ActiveTab)
+        {
+            case Tab.Items:
+                Items = await CodexClient.GetMarketplaceItemsAsync(FilterType, search);
+                break;
+            case Tab.Worlds:
+                Entries = await MarketClient.GetSharedWorldsAsync(FilterType, search);
+                break;
+            case Tab.Campaigns:
+                Entries = await MarketClient.GetSharedCampaignsAsync(FilterType, search);
+                break;
+            case Tab.Characters:
+                Entries = await MarketClient.GetSharedCharactersAsync(search);
+                break;
+        }
         IsLoading = false;
     }
 
@@ -152,15 +298,81 @@ else
         }
     }
 
-    private async Task Import(CodexItemDto item)
+    private int GetTargetWorld(int campaignId, List<WorldDto> compatible)
+        => TargetWorlds.TryGetValue(campaignId, out var id) ? id : compatible[0].Id;
+
+    private void SetTargetWorld(int campaignId, string? value)
     {
-        ImportingId = item.Id;
+        if (int.TryParse(value, out var id))
+        {
+            TargetWorlds[campaignId] = id;
+        }
+    }
+
+    private async Task ImportItem(int id)
+    {
+        ImportingId = id;
         try
         {
-            var imported = await CodexClient.ImportItemAsync(item.Id);
+            var imported = await CodexClient.ImportItemAsync(id);
             if (imported != null)
             {
-                ImportedIds.Add(item.Id);
+                ImportedIds.Add(id);
+            }
+            else
+            {
+                ErrorMessage = "Import impossible.";
+            }
+        }
+        finally
+        {
+            ImportingId = null;
+        }
+    }
+
+    private async Task ImportEntry(int id)
+    {
+        ImportingId = id;
+        ErrorMessage = null;
+        try
+        {
+            var (success, error) = ActiveTab == Tab.Worlds
+                ? await MarketClient.ImportWorldAsync(id)
+                : await MarketClient.ImportCharacterAsync(id);
+            if (success)
+            {
+                ImportedIds.Add(id);
+                if (ActiveTab == Tab.Worlds)
+                {
+                    MyWorlds = await WorldClient.GetMyWorldsAsync();
+                }
+            }
+            else
+            {
+                ErrorMessage = error;
+            }
+        }
+        finally
+        {
+            ImportingId = null;
+        }
+    }
+
+    private async Task ImportCampaign(int id, List<WorldDto> compatible)
+    {
+        ImportingId = id;
+        ErrorMessage = null;
+        try
+        {
+            var targetWorldId = GetTargetWorld(id, compatible);
+            var (success, error) = await MarketClient.ImportCampaignAsync(id, targetWorldId);
+            if (success)
+            {
+                ImportedIds.Add(id);
+            }
+            else
+            {
+                ErrorMessage = error;
             }
         }
         finally

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/Worlds.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/Worlds.razor
@@ -53,6 +53,12 @@ else
                     <div class="card-header-row">
                         <AppGameBadge GameType="@world.GameType" />
                         <div class="card-actions">
+                            <button class="btn btn-ghost btn-icon @(world.IsShared ? "danger" : "")"
+                                    @onclick:stopPropagation="true"
+                                    @onclick="() => ToggleShare(world)"
+                                    title="@(world.IsShared ? L["Marketplace_Unshare"] : L["Marketplace_Share"])">
+                                <i class="bi @(world.IsShared ? "bi-share-fill" : "bi-share")"></i>
+                            </button>
                             <button class="btn btn-ghost btn-icon danger"
                                     @onclick:stopPropagation="true"
                                     @onclick="() => ConfirmDelete(world)"

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/Worlds.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/Worlds.razor.cs
@@ -10,6 +10,7 @@ namespace Cdm.Web.Components.Pages.Worlds;
 public partial class Worlds
 {
     [Inject] private WorldApiClient WorldClient { get; set; } = default!;
+    [Inject] private MarketplaceApiClient MarketClient { get; set; } = default!;
     [Inject] private NavigationManager Nav { get; set; } = default!;
     [Inject] private IStringLocalizer<AppStrings> L { get; set; } = default!;
 
@@ -51,6 +52,16 @@ public partial class Worlds
     }
 
     private void NavigateToWorld(int worldId) => Nav.NavigateTo($"/worlds/{worldId}");
+
+    private async Task ToggleShare(WorldDto world)
+    {
+        var newValue = !world.IsShared;
+        var ok = await MarketClient.SetWorldSharedAsync(world.Id, newValue);
+        if (ok)
+        {
+            world.IsShared = newValue;
+        }
+    }
 
     private void ConfirmDelete(WorldDto world)
     {

--- a/Cdm/Cdm.Web/Program.cs
+++ b/Cdm/Cdm.Web/Program.cs
@@ -213,6 +213,18 @@ builder.Services.AddScoped<CodexApiClient>(sp =>
 
 builder.Services.AddHttpClient("CodexApiClient", ConfigureApiClient);
 
+// Register MarketplaceApiClient with scoped lifetime
+builder.Services.AddScoped<MarketplaceApiClient>(sp =>
+{
+    var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
+    var httpClient = httpClientFactory.CreateClient("MarketplaceApiClient");
+    var localStorage = sp.GetRequiredService<ILocalStorageService>();
+    var logger = sp.GetRequiredService<ILogger<MarketplaceApiClient>>();
+    return new MarketplaceApiClient(httpClient, logger, localStorage);
+});
+
+builder.Services.AddHttpClient("MarketplaceApiClient", ConfigureApiClient);
+
 // Register NotificationApiClient with scoped lifetime
 builder.Services.AddScoped<NotificationApiClient>(sp =>
 {

--- a/Cdm/Cdm.Web/Resources/AppStrings.en.resx
+++ b/Cdm/Cdm.Web/Resources/AppStrings.en.resx
@@ -301,6 +301,8 @@
   <data name="Error_Profile_UpdateFailed" xml:space="preserve"><value>Failed to update profile. Please try again.</value></data>
   <data name="Error_Profile_AvatarUploadFailed" xml:space="preserve"><value>Failed to upload avatar. Check format (PNG/JPG, max 5 MB).</value></data>
   <data name="Characters_BadgeBase" xml:space="preserve"><value>Base character</value></data>
+  <data name="Marketplace_Share" xml:space="preserve"><value>Share on the marketplace</value></data>
+  <data name="Marketplace_Unshare" xml:space="preserve"><value>Stop sharing</value></data>
   <data name="Characters_BadgeWorldCopy" xml:space="preserve"><value>World copy</value></data>
   <data name="Common_YearsOld" xml:space="preserve"><value>{0} yrs</value></data>
   <data name="Common_Completed" xml:space="preserve"><value>Completed</value></data>

--- a/Cdm/Cdm.Web/Resources/AppStrings.fr.resx
+++ b/Cdm/Cdm.Web/Resources/AppStrings.fr.resx
@@ -301,6 +301,8 @@
   <data name="Error_Profile_UpdateFailed" xml:space="preserve"><value>Erreur lors de la mise à jour du profil. Veuillez réessayer.</value></data>
   <data name="Error_Profile_AvatarUploadFailed" xml:space="preserve"><value>Erreur lors de l'envoi de l'avatar. Vérifiez le format (PNG/JPG, max 5 Mo).</value></data>
   <data name="Characters_BadgeBase" xml:space="preserve"><value>Personnage de base</value></data>
+  <data name="Marketplace_Share" xml:space="preserve"><value>Partager sur la marketplace</value></data>
+  <data name="Marketplace_Unshare" xml:space="preserve"><value>Ne plus partager</value></data>
   <data name="Characters_BadgeWorldCopy" xml:space="preserve"><value>Copie de monde</value></data>
   <data name="Common_YearsOld" xml:space="preserve"><value>{0} ans</value></data>
   <data name="Common_Completed" xml:space="preserve"><value>Terminé</value></data>

--- a/Cdm/Cdm.Web/Resources/AppStrings.resx
+++ b/Cdm/Cdm.Web/Resources/AppStrings.resx
@@ -255,6 +255,8 @@
   <data name="Visibility_Private" xml:space="preserve"><value>Privé</value></data>
   <data name="Visibility_Public" xml:space="preserve"><value>Public</value></data>
   <data name="Characters_BadgeBase" xml:space="preserve"><value>Personnage de base</value></data>
+  <data name="Marketplace_Share" xml:space="preserve"><value>Partager sur la marketplace</value></data>
+  <data name="Marketplace_Unshare" xml:space="preserve"><value>Ne plus partager</value></data>
   <data name="Characters_BadgeWorldCopy" xml:space="preserve"><value>Copie de monde</value></data>
   <data name="Common_YearsOld" xml:space="preserve"><value>{0} ans</value></data>
   <data name="Common_Completed" xml:space="preserve"><value>Terminé</value></data>

--- a/Cdm/Cdm.Web/Services/ApiClients/MarketplaceApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ApiClients/MarketplaceApiClient.cs
@@ -1,0 +1,121 @@
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Common.Enums;
+using Cdm.Web.Services.Storage;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace Cdm.Web.Services.ApiClients;
+
+/// <summary>
+/// HTTP client for the marketplace endpoints (shared worlds, campaigns and base characters).
+/// </summary>
+public class MarketplaceApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<MarketplaceApiClient> _logger;
+    private readonly ILocalStorageService _localStorage;
+
+    public MarketplaceApiClient(HttpClient httpClient, ILogger<MarketplaceApiClient> logger, ILocalStorageService localStorage)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _localStorage = localStorage;
+    }
+
+    private async Task AddAuthHeaderAsync()
+    {
+        var token = await _localStorage.GetItemAsync("auth_token");
+        if (!string.IsNullOrEmpty(token))
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    // ── Browse ───────────────────────────────────────────────────────────
+
+    public Task<List<MarketplaceEntryDto>> GetSharedWorldsAsync(GameType? gameType = null, string? search = null)
+        => GetSharedAsync("worlds", gameType, search);
+
+    public Task<List<MarketplaceEntryDto>> GetSharedCampaignsAsync(GameType? gameType = null, string? search = null)
+        => GetSharedAsync("campaigns", gameType, search);
+
+    public Task<List<MarketplaceEntryDto>> GetSharedCharactersAsync(string? search = null)
+        => GetSharedAsync("characters", null, search);
+
+    private async Task<List<MarketplaceEntryDto>> GetSharedAsync(string kind, GameType? gameType, string? search)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var query = new List<string>();
+            if (gameType.HasValue) query.Add($"gameType={(int)gameType.Value}");
+            if (!string.IsNullOrWhiteSpace(search)) query.Add($"search={Uri.EscapeDataString(search)}");
+            var url = $"api/marketplace/{kind}" + (query.Count > 0 ? "?" + string.Join("&", query) : string.Empty);
+            var response = await _httpClient.GetAsync(url);
+            if (!response.IsSuccessStatusCode) return new();
+            return await response.Content.ReadFromJsonAsync<List<MarketplaceEntryDto>>() ?? new();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching shared {Kind}", kind);
+            return new();
+        }
+    }
+
+    // ── Import ───────────────────────────────────────────────────────────
+
+    public Task<(bool Success, string? Error)> ImportWorldAsync(int id)
+        => ImportAsync($"api/marketplace/worlds/{id}/import");
+
+    public Task<(bool Success, string? Error)> ImportCampaignAsync(int id, int targetWorldId)
+        => ImportAsync($"api/marketplace/campaigns/{id}/import?targetWorldId={targetWorldId}");
+
+    public Task<(bool Success, string? Error)> ImportCharacterAsync(int id)
+        => ImportAsync($"api/marketplace/characters/{id}/import");
+
+    private async Task<(bool Success, string? Error)> ImportAsync(string url)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await _httpClient.PostAsync(url, null);
+            if (response.IsSuccessStatusCode) return (true, null);
+            var problem = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+            return (false, problem?.Error ?? "Import impossible.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error importing from {Url}", url);
+            return (false, "Import impossible.");
+        }
+    }
+
+    // ── Share toggles ────────────────────────────────────────────────────
+
+    public Task<bool> SetWorldSharedAsync(int id, bool shared)
+        => SetSharedAsync($"api/marketplace/worlds/{id}/share", shared);
+
+    public Task<bool> SetCampaignSharedAsync(int id, bool shared)
+        => SetSharedAsync($"api/marketplace/campaigns/{id}/share", shared);
+
+    public Task<bool> SetCharacterSharedAsync(int id, bool shared)
+        => SetSharedAsync($"api/marketplace/characters/{id}/share", shared);
+
+    private async Task<bool> SetSharedAsync(string url, bool shared)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await _httpClient.PutAsync($"{url}?shared={shared.ToString().ToLowerInvariant()}", null);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sharing via {Url}", url);
+            return false;
+        }
+    }
+
+    private sealed class ErrorResponse
+    {
+        public string? Error { get; set; }
+    }
+}

--- a/Cdm/Cdm.Web/Shared/DTOs/Models/CharacterModels.cs
+++ b/Cdm/Cdm.Web/Shared/DTOs/Models/CharacterModels.cs
@@ -66,6 +66,11 @@ public class CharacterDto
     /// Gets or sets the source character ID for world copies (null for base characters).
     /// </summary>
     public int? SourceCharacterId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this base character is shared on the marketplace.
+    /// </summary>
+    public bool IsShared { get; set; }
 }
 /// </summary>
 public class CreateCharacterDto


### PR DESCRIPTION
…rsonnages

- Ajoute IsShared sur World/Campaign/Character (+ migration idempotente).
- IMarketplaceService : share/browse/import (worlds, campaigns, base characters). Import = copie indépendante ; campagne deep-copie les chapitres dans un monde cible du même type (grisé si aucun monde compatible).
- MarketplaceEndpoints (/api/marketplace/{worlds,campaigns,characters}) + MarketplaceApiClient ; enregistrements DI ApiService/Web.
- Page /marketplace : 4 onglets actifs (Items, Mondes, Campagnes, Personnages)
  + filtres type de jeu + recherche + sélecteur de monde cible pour l'import.
- Toggles de partage sur les listes Mondes / Campagnes / Personnages (base).
- IsShared exposé dans les DTOs read + mappings ; clés resx Marketplace_Share/Unshare.
- 14 tests MarketplaceService (share, browse, import + garde-fous).