### PR TITLE
feat(loot): butin de campagne/chapitre + distribution en session

### DIFF
--- a/.github/ROADMAP.md
+++ b/.github/ROADMAP.md
@@ -248,8 +248,9 @@
 - [x] **Partager** un item (marketplace) — onglet Items de `/marketplace` + bouton de partage depuis le Codex.
 - [~] L'ajout à l'inventaire utilise `DndInventoryItem` (seule table d'inventaire existante) : fonctionne pour tout perso, mais l'inventaire n'est affiché que sur la fiche D&D. Un inventaire générique par système reste à faire.
 
-### 4. Loot en campagne / chapitre
-- [ ] Le MJ attache des **items (loot)** à une campagne ou un chapitre.
-- [ ] En session, le MJ **distribue** ce loot aux joueurs quand il estime qu'ils l'ont mérité.
+### 4. Loot en campagne / chapitre (branche `feature/campaign-loot`)
+- [x] Le MJ attache des **items (loot)** à une campagne ou un chapitre — entités `CampaignLoot` (+ `LootDistribution`), `ILootService` (CRUD MJ + distribution), panneau « Butin » sur la fiche de campagne (`CampaignLootPanel`). Loot facultativement copié depuis un item du Codex.
+- [x] En session, le MJ **distribue** ce loot à un personnage joueur : hub `DistributeLoot` → copie dans l'inventaire (`DndInventoryItem`) + événement temps réel `LootReceived` (toast joueur, entrée dans le chat, rafraîchissement de la fiche). Panneau « Butin » dans l'écran MJ de session.
+- [~] Comme pour le Codex, la copie atterrit dans `DndInventoryItem` (affiché sur la fiche D&D). Un inventaire générique par système reste à faire.
 
 > **Note localisation** : le mécanisme fr/en (resx `AppStrings.*.resx` + `@L["Clé"]`) est **déjà en place**. Continuer à externaliser les chaînes en dur au fil de l'eau.

--- a/Cdm/Cdm.ApiService/Endpoints/LootEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/LootEndpoints.cs
@@ -1,0 +1,108 @@
+// -----------------------------------------------------------------------
+// <copyright file="LootEndpoints.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.ApiService.Endpoints;
+
+using System.Security.Claims;
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.Services;
+using Microsoft.AspNetCore.Mvc;
+
+/// <summary>
+/// Endpoints for campaign loot: the GM prepares loot on a campaign/chapter and
+/// distributes it to players' characters during a session.
+/// </summary>
+public static class LootEndpoints
+{
+    /// <summary>Maps the loot endpoints.</summary>
+    public static void MapLootEndpoints(this IEndpointRouteBuilder app)
+    {
+        var campaignGroup = app.MapGroup("/api/campaigns/{campaignId:int}/loot")
+            .WithTags("Loot")
+            .RequireAuthorization();
+
+        campaignGroup.MapGet("/", GetCampaignLootAsync).WithName("GetCampaignLoot");
+        campaignGroup.MapPost("/", CreateLootAsync).WithName("CreateLoot");
+
+        var lootGroup = app.MapGroup("/api/loot")
+            .WithTags("Loot")
+            .RequireAuthorization();
+
+        lootGroup.MapPut("/{lootId:int}", UpdateLootAsync).WithName("UpdateLoot");
+        lootGroup.MapDelete("/{lootId:int}", DeleteLootAsync).WithName("DeleteLoot");
+        lootGroup.MapPost("/{lootId:int}/distribute", DistributeLootAsync).WithName("DistributeLoot");
+    }
+
+    private static async Task<IResult> GetCampaignLootAsync(int campaignId, [FromServices] ILootService loot, ClaimsPrincipal user)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        return Results.Ok(await loot.GetCampaignLootAsync(campaignId, userId.Value));
+    }
+
+    private static async Task<IResult> CreateLootAsync(int campaignId, [FromBody] CreateLootDto dto, [FromServices] ILootService loot, ClaimsPrincipal user)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var created = await loot.CreateAsync(campaignId, dto, userId.Value);
+        return created is null ? Results.BadRequest(new { error = "Création du loot impossible." }) : Results.Ok(created);
+    }
+
+    private static async Task<IResult> UpdateLootAsync(int lootId, [FromBody] CreateLootDto dto, [FromServices] ILootService loot, ClaimsPrincipal user)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var updated = await loot.UpdateAsync(lootId, dto, userId.Value);
+        return updated is null ? Results.NotFound() : Results.Ok(updated);
+    }
+
+    private static async Task<IResult> DeleteLootAsync(int lootId, [FromServices] ILootService loot, ClaimsPrincipal user)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var ok = await loot.DeleteAsync(lootId, userId.Value);
+        return ok ? Results.NoContent() : Results.NotFound();
+    }
+
+    private static async Task<IResult> DistributeLootAsync(
+        int lootId,
+        [FromServices] ILootService loot,
+        ClaimsPrincipal user,
+        [FromQuery] int worldCharacterId,
+        [FromQuery] int? sessionId = null)
+    {
+        var userId = GetUserId(user);
+        if (userId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var (success, error, result) = await loot.DistributeAsync(lootId, worldCharacterId, sessionId, userId.Value);
+        return success ? Results.Ok(result) : Results.BadRequest(new { error });
+    }
+
+    private static int? GetUserId(ClaimsPrincipal user)
+    {
+        var claim = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return int.TryParse(claim, out var id) ? id : null;
+    }
+}

--- a/Cdm/Cdm.ApiService/Hubs/SessionHub.cs
+++ b/Cdm/Cdm.ApiService/Hubs/SessionHub.cs
@@ -25,6 +25,7 @@ public class SessionHub : Hub
     private readonly AppDbContext db;
     private readonly ITradeService tradeService;
     private readonly IAchievementEvaluationService achievementEvaluation;
+    private readonly ILootService lootService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SessionHub"/> class.
@@ -33,12 +34,14 @@ public class SessionHub : Hub
     /// <param name="db">Database context.</param>
     /// <param name="tradeService">Trade service for object-exchange proposals.</param>
     /// <param name="achievementEvaluation">Evaluator that awards automatic achievements.</param>
-    public SessionHub(ILogger<SessionHub> logger, AppDbContext db, ITradeService tradeService, IAchievementEvaluationService achievementEvaluation)
+    /// <param name="lootService">Loot service for in-session loot distribution.</param>
+    public SessionHub(ILogger<SessionHub> logger, AppDbContext db, ITradeService tradeService, IAchievementEvaluationService achievementEvaluation, ILootService lootService)
     {
         this.logger = logger;
         this.db = db;
         this.tradeService = tradeService;
         this.achievementEvaluation = achievementEvaluation;
+        this.lootService = lootService;
     }
 
     /// <summary>
@@ -317,6 +320,36 @@ public class SessionHub : Hub
         }
 
         await this.Clients.Group(groupName).SendAsync("TradeResolved", trade);
+    }
+
+    /// <summary>
+    /// The game master hands a prepared loot item to a player's character during the session.
+    /// The loot is copied into the recipient's inventory and every session member is notified.
+    /// Only the campaign's GM may distribute (enforced by the loot service).
+    /// </summary>
+    /// <param name="sessionId">The session identifier.</param>
+    /// <param name="lootId">The loot identifier.</param>
+    /// <param name="worldCharacterId">The recipient world character identifier.</param>
+    /// <returns>A task representing the async operation.</returns>
+    public async Task DistributeLoot(int sessionId, int lootId, int worldCharacterId)
+    {
+        var userId = this.GetUserId();
+        var groupName = $"session_{sessionId}";
+
+        var (success, error, result) = await this.lootService.DistributeAsync(lootId, worldCharacterId, sessionId, userId);
+        if (!success || result is null)
+        {
+            throw new HubException(error ?? "Impossible de distribuer ce loot.");
+        }
+
+        this.logger.LogInformation(
+            "GM {UserId} distributed loot {LootId} to character {WorldCharacterId} in session {SessionId}",
+            userId,
+            lootId,
+            worldCharacterId,
+            sessionId);
+
+        await this.Clients.Group(groupName).SendAsync("LootReceived", result);
     }
 
     /// <summary>

--- a/Cdm/Cdm.ApiService/Program.cs
+++ b/Cdm/Cdm.ApiService/Program.cs
@@ -180,6 +180,7 @@ builder.Services.AddScoped<ICampaignService, CampaignService>();
 builder.Services.AddScoped<ICharacterService, CharacterService>();
 builder.Services.AddScoped<ICodexService, CodexService>();
 builder.Services.AddScoped<IMarketplaceService, MarketplaceService>();
+builder.Services.AddScoped<ILootService, LootService>();
 builder.Services.AddScoped<IWorldService, WorldService>();
 builder.Services.AddScoped<IChapterService, ChapterService>();
 builder.Services.AddScoped<IEventService, EventService>();
@@ -267,6 +268,7 @@ app.MapStatisticsEndpoints();
 app.MapImageEndpoints();
 app.MapCodexEndpoints();
 app.MapMarketplaceEndpoints();
+app.MapLootEndpoints();
 
 // Map SignalR hubs
 app.MapHub<Cdm.ApiService.Hubs.SessionHub>("/hubs/session");

--- a/Cdm/Cdm.Business.Abstraction/DTOs/CampaignLootDto.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/CampaignLootDto.cs
@@ -1,0 +1,46 @@
+// -----------------------------------------------------------------------
+// <copyright file="CampaignLootDto.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.DTOs;
+
+using Cdm.Common.Enums;
+
+/// <summary>A loot item prepared by the GM for a campaign (optionally a chapter).</summary>
+public class CampaignLootDto
+{
+    /// <summary>Gets or sets the loot identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the campaign this loot belongs to.</summary>
+    public int CampaignId { get; set; }
+
+    /// <summary>Gets or sets the optional chapter scope (null = whole campaign).</summary>
+    public int? ChapterId { get; set; }
+
+    /// <summary>Gets or sets the loot name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the optional description.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Gets or sets the optional image URL.</summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>Gets or sets the game system / theme.</summary>
+    public GameType GameType { get; set; }
+
+    /// <summary>Gets or sets the optional item category.</summary>
+    public string? ItemType { get; set; }
+
+    /// <summary>Gets or sets the optional game-specific data (JSON).</summary>
+    public string? GameSpecificData { get; set; }
+
+    /// <summary>Gets or sets the quantity handed out per distribution.</summary>
+    public int Quantity { get; set; } = 1;
+
+    /// <summary>Gets or sets the creation date.</summary>
+    public DateTime CreatedAt { get; set; }
+}

--- a/Cdm/Cdm.Business.Abstraction/DTOs/CreateLootDto.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/CreateLootDto.cs
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------
+// <copyright file="CreateLootDto.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.DTOs;
+
+using Cdm.Common.Enums;
+
+/// <summary>Payload to create or update a piece of campaign loot.</summary>
+public class CreateLootDto
+{
+    /// <summary>Gets or sets the optional chapter scope (null = whole campaign).</summary>
+    public int? ChapterId { get; set; }
+
+    /// <summary>Gets or sets the loot name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the optional description.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Gets or sets the optional image URL.</summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>Gets or sets the game system / theme.</summary>
+    public GameType GameType { get; set; }
+
+    /// <summary>Gets or sets the optional item category.</summary>
+    public string? ItemType { get; set; }
+
+    /// <summary>Gets or sets the optional game-specific data (JSON).</summary>
+    public string? GameSpecificData { get; set; }
+
+    /// <summary>Gets or sets the quantity handed out per distribution.</summary>
+    public int Quantity { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets an optional codex item id to copy the loot from (owned by the GM).
+    /// When set, its fields seed the loot; explicit fields above still override.
+    /// </summary>
+    public int? SourceCodexItemId { get; set; }
+}

--- a/Cdm/Cdm.Business.Abstraction/DTOs/LootDistributionResultDto.cs
+++ b/Cdm/Cdm.Business.Abstraction/DTOs/LootDistributionResultDto.cs
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------
+// <copyright file="LootDistributionResultDto.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.DTOs;
+
+/// <summary>
+/// Describes a loot hand-out: used both as the distribution result and as the
+/// SignalR "LootReceived" broadcast payload so players can react in real time.
+/// </summary>
+public class LootDistributionResultDto
+{
+    /// <summary>Gets or sets the loot identifier.</summary>
+    public int LootId { get; set; }
+
+    /// <summary>Gets or sets the loot name.</summary>
+    public string LootName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the optional image URL.</summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>Gets or sets the optional item category.</summary>
+    public string? ItemType { get; set; }
+
+    /// <summary>Gets or sets the quantity handed out.</summary>
+    public int Quantity { get; set; }
+
+    /// <summary>Gets or sets the recipient world character identifier.</summary>
+    public int RecipientWorldCharacterId { get; set; }
+
+    /// <summary>Gets or sets the recipient character display name.</summary>
+    public string RecipientName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the recipient user identifier.</summary>
+    public int RecipientUserId { get; set; }
+}

--- a/Cdm/Cdm.Business.Abstraction/Services/ILootService.cs
+++ b/Cdm/Cdm.Business.Abstraction/Services/ILootService.cs
@@ -1,0 +1,37 @@
+// -----------------------------------------------------------------------
+// <copyright file="ILootService.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Abstraction.Services;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Cdm.Business.Abstraction.DTOs;
+
+/// <summary>
+/// Manages campaign loot: the GM prepares items on a campaign/chapter and hands them
+/// out to players' characters during a session (copied into their inventory).
+/// </summary>
+public interface ILootService
+{
+    /// <summary>Creates a loot entry on a campaign (GM only). Optionally seeded from a codex item.</summary>
+    Task<CampaignLootDto?> CreateAsync(int campaignId, CreateLootDto dto, int userId);
+
+    /// <summary>Lists the active loot of a campaign (GM only).</summary>
+    Task<IEnumerable<CampaignLootDto>> GetCampaignLootAsync(int campaignId, int userId);
+
+    /// <summary>Updates a loot entry (GM only).</summary>
+    Task<CampaignLootDto?> UpdateAsync(int lootId, CreateLootDto dto, int userId);
+
+    /// <summary>Soft-deletes a loot entry (GM only).</summary>
+    Task<bool> DeleteAsync(int lootId, int userId);
+
+    /// <summary>
+    /// Hands a loot item to a player's character: copies it into their inventory and records
+    /// the distribution. Only the campaign's GM may distribute. Returns a payload suitable for
+    /// broadcasting to the session.
+    /// </summary>
+    Task<(bool Success, string? Error, LootDistributionResultDto? Result)> DistributeAsync(int lootId, int worldCharacterId, int? sessionId, int userId);
+}

--- a/Cdm/Cdm.Business.Common.Tests/Services/LootServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/LootServiceTests.cs
@@ -1,0 +1,218 @@
+// -----------------------------------------------------------------------
+// <copyright file="LootServiceTests.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Tests.Services;
+
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Common.Services;
+using Cdm.Common.Enums;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="LootService"/> — GM-scoped CRUD + in-session distribution.
+/// </summary>
+public class LootServiceTests
+{
+    private const int GmId = 1;
+    private const int PlayerId = 2;
+    private const int OtherUserId = 3;
+
+    private readonly Mock<ILogger<LootService>> loggerMock = new();
+
+    private static AppDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"LootTests_{Guid.NewGuid()}")
+            .Options);
+
+    /// <summary>Seeds a world + campaign owned by the GM. Returns the campaign id.</summary>
+    private static int SeedCampaign(AppDbContext ctx, GameType type = GameType.DnD5e, int worldId = 100, int campaignId = 200)
+    {
+        ctx.Worlds.Add(new World { Id = worldId, UserId = GmId, Name = "Monde", GameType = type, IsActive = true, CreatedAt = DateTime.UtcNow });
+        ctx.Campaigns.Add(new Campaign { Id = campaignId, Name = "Campagne", WorldId = worldId, CreatedBy = GmId, IsActive = true, IsDeleted = false, CreatedAt = DateTime.UtcNow });
+        ctx.SaveChanges();
+        return campaignId;
+    }
+
+    /// <summary>Seeds a player's world character in the given world. Returns its id.</summary>
+    private static int SeedWorldCharacter(AppDbContext ctx, int worldId, int userId, int charId = 300, int worldCharId = 400)
+    {
+        ctx.Characters.Add(new Character { Id = charId, UserId = userId, Name = "Doe", FirstName = "Aria", IsActive = true, CreatedAt = DateTime.UtcNow });
+        ctx.WorldCharacters.Add(new WorldCharacter { Id = worldCharId, CharacterId = charId, WorldId = worldId, IsActive = true });
+        ctx.SaveChanges();
+        return worldCharId;
+    }
+
+    private LootService NewService(AppDbContext ctx) => new(ctx, this.loggerMock.Object);
+
+    private static CreateLootDto NewLootDto(string name = "Épée +1", int qty = 1) => new()
+    {
+        Name = name,
+        Description = "Une lame enchantée.",
+        ItemType = "Arme",
+        Quantity = qty,
+    };
+
+    // ── CRUD ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateAsync_GmCreatesLoot_GameTypeFromWorld()
+    {
+        using var ctx = NewContext();
+        var campaignId = SeedCampaign(ctx, GameType.CallOfCthulhu);
+        var service = this.NewService(ctx);
+
+        var result = await service.CreateAsync(campaignId, NewLootDto(), GmId);
+
+        Assert.NotNull(result);
+        Assert.Equal("Épée +1", result!.Name);
+        Assert.Equal(GameType.CallOfCthulhu, result.GameType);
+        Assert.Equal(campaignId, result.CampaignId);
+    }
+
+    [Fact]
+    public async Task CreateAsync_NonGmRejected()
+    {
+        using var ctx = NewContext();
+        var campaignId = SeedCampaign(ctx);
+        var service = this.NewService(ctx);
+
+        var result = await service.CreateAsync(campaignId, NewLootDto(), OtherUserId);
+
+        Assert.Null(result);
+        Assert.Empty(ctx.CampaignLoots);
+    }
+
+    [Fact]
+    public async Task CreateAsync_SeedsFromCodexItem()
+    {
+        using var ctx = NewContext();
+        var campaignId = SeedCampaign(ctx);
+        ctx.CodexItems.Add(new CodexItem { Id = 500, UserId = GmId, Name = "Potion", Description = "Soigne 2d4", ItemType = "Potion", GameType = GameType.DnD5e, IsActive = true, CreatedAt = DateTime.UtcNow });
+        ctx.SaveChanges();
+        var service = this.NewService(ctx);
+
+        var dto = new CreateLootDto { Name = string.Empty, SourceCodexItemId = 500 };
+        var result = await service.CreateAsync(campaignId, dto, GmId);
+
+        Assert.NotNull(result);
+        Assert.Equal("Potion", result!.Name);
+        Assert.Equal("Potion", result.ItemType);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsChapterFromAnotherCampaign()
+    {
+        using var ctx = NewContext();
+        var campaignId = SeedCampaign(ctx);
+        ctx.Chapters.Add(new Chapter { Id = 700, CampaignId = 999, ChapterNumber = 1, Title = "Ailleurs", IsActive = true, CreatedAt = DateTime.UtcNow });
+        ctx.SaveChanges();
+        var service = this.NewService(ctx);
+
+        var dto = NewLootDto();
+        dto.ChapterId = 700;
+        var result = await service.CreateAsync(campaignId, dto, GmId);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetCampaignLootAsync_ReturnsActiveForGmOnly()
+    {
+        using var ctx = NewContext();
+        var campaignId = SeedCampaign(ctx);
+        var service = this.NewService(ctx);
+        await service.CreateAsync(campaignId, NewLootDto("A"), GmId);
+        await service.CreateAsync(campaignId, NewLootDto("B"), GmId);
+
+        var forGm = (await service.GetCampaignLootAsync(campaignId, GmId)).ToList();
+        var forOther = (await service.GetCampaignLootAsync(campaignId, OtherUserId)).ToList();
+
+        Assert.Equal(2, forGm.Count);
+        Assert.Empty(forOther);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SoftDeletesAndHides()
+    {
+        using var ctx = NewContext();
+        var campaignId = SeedCampaign(ctx);
+        var service = this.NewService(ctx);
+        var loot = await service.CreateAsync(campaignId, NewLootDto(), GmId);
+
+        var ok = await service.DeleteAsync(loot!.Id, GmId);
+
+        Assert.True(ok);
+        Assert.Empty(await service.GetCampaignLootAsync(campaignId, GmId));
+    }
+
+    // ── Distribution ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DistributeAsync_CopiesToInventoryAndRecords()
+    {
+        using var ctx = NewContext();
+        var campaignId = SeedCampaign(ctx);
+        var worldCharId = SeedWorldCharacter(ctx, worldId: 100, userId: PlayerId);
+        var service = this.NewService(ctx);
+        var loot = await service.CreateAsync(campaignId, NewLootDto("Bouclier", qty: 2), GmId);
+
+        var (success, error, result) = await service.DistributeAsync(loot!.Id, worldCharId, sessionId: 55, GmId);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.NotNull(result);
+        Assert.Equal("Bouclier", result!.LootName);
+        Assert.Equal(PlayerId, result.RecipientUserId);
+        Assert.Equal("Aria", result.RecipientName);
+
+        var inv = Assert.Single(ctx.DndInventoryItems);
+        Assert.Equal(worldCharId, inv.WorldCharacterId);
+        Assert.Equal(2, inv.Quantity);
+
+        var dist = Assert.Single(ctx.LootDistributions);
+        Assert.Equal(55, dist.SessionId);
+        Assert.Equal(GmId, dist.DistributedByUserId);
+    }
+
+    [Fact]
+    public async Task DistributeAsync_NonGmRejected()
+    {
+        using var ctx = NewContext();
+        var campaignId = SeedCampaign(ctx);
+        var worldCharId = SeedWorldCharacter(ctx, worldId: 100, userId: PlayerId);
+        var service = this.NewService(ctx);
+        var loot = await service.CreateAsync(campaignId, NewLootDto(), GmId);
+
+        var (success, _, _) = await service.DistributeAsync(loot!.Id, worldCharId, null, OtherUserId);
+
+        Assert.False(success);
+        Assert.Empty(ctx.DndInventoryItems);
+    }
+
+    [Fact]
+    public async Task DistributeAsync_RejectsCharacterOutsideCampaignWorld()
+    {
+        using var ctx = NewContext();
+        var campaignId = SeedCampaign(ctx, worldId: 100);
+        // Character lives in a different world (101).
+        ctx.Worlds.Add(new World { Id = 101, UserId = OtherUserId, Name = "Autre", GameType = GameType.DnD5e, IsActive = true, CreatedAt = DateTime.UtcNow });
+        ctx.SaveChanges();
+        var worldCharId = SeedWorldCharacter(ctx, worldId: 101, userId: PlayerId);
+        var service = this.NewService(ctx);
+        var loot = await service.CreateAsync(campaignId, NewLootDto(), GmId);
+
+        var (success, error, _) = await service.DistributeAsync(loot!.Id, worldCharId, null, GmId);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+        Assert.Empty(ctx.DndInventoryItems);
+    }
+}

--- a/Cdm/Cdm.Business.Common/Services/LootService.cs
+++ b/Cdm/Cdm.Business.Common/Services/LootService.cs
@@ -1,0 +1,294 @@
+// -----------------------------------------------------------------------
+// <copyright file="LootService.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Business.Common.Services;
+
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Business.Abstraction.Services;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Campaign loot management and in-session distribution. The loot's game type always
+/// follows the campaign's world, so distribution to any character of that world is compatible.
+/// </summary>
+public class LootService(AppDbContext dbContext, ILogger<LootService> logger) : ILootService
+{
+    private readonly AppDbContext dbContext = dbContext;
+    private readonly ILogger<LootService> logger = logger;
+
+    /// <inheritdoc/>
+    public async Task<CampaignLootDto?> CreateAsync(int campaignId, CreateLootDto dto, int userId)
+    {
+        try
+        {
+            var campaign = await this.dbContext.Campaigns
+                .Include(c => c.World)
+                .FirstOrDefaultAsync(c => c.Id == campaignId && !c.IsDeleted);
+            if (campaign == null || campaign.CreatedBy != userId)
+            {
+                return null;
+            }
+
+            if (dto.ChapterId.HasValue)
+            {
+                var chapterOk = await this.dbContext.Chapters
+                    .AnyAsync(ch => ch.Id == dto.ChapterId.Value && ch.CampaignId == campaignId);
+                if (!chapterOk)
+                {
+                    return null;
+                }
+            }
+
+            var loot = new CampaignLoot
+            {
+                CampaignId = campaignId,
+                ChapterId = dto.ChapterId,
+                Name = dto.Name,
+                Description = dto.Description,
+                ImageUrl = dto.ImageUrl,
+                ItemType = dto.ItemType,
+                GameSpecificData = dto.GameSpecificData,
+                Quantity = dto.Quantity < 1 ? 1 : dto.Quantity,
+                GameType = campaign.World.GameType,
+                CreatedBy = userId,
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            };
+
+            // Seed from a codex item owned by the GM (explicit dto fields still win when provided).
+            if (dto.SourceCodexItemId.HasValue)
+            {
+                var source = await this.dbContext.CodexItems
+                    .FirstOrDefaultAsync(c => c.Id == dto.SourceCodexItemId.Value && c.UserId == userId && c.IsActive);
+                if (source != null)
+                {
+                    if (string.IsNullOrWhiteSpace(loot.Name))
+                    {
+                        loot.Name = source.Name;
+                    }
+
+                    loot.Description ??= source.Description;
+                    loot.ImageUrl ??= source.ImageUrl;
+                    loot.ItemType ??= source.ItemType;
+                    loot.GameSpecificData ??= source.GameSpecificData;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(loot.Name))
+            {
+                return null;
+            }
+
+            this.dbContext.CampaignLoots.Add(loot);
+            await this.dbContext.SaveChangesAsync();
+            this.logger.LogInformation("Created loot {LootId} for campaign {CampaignId}", loot.Id, campaignId);
+            return MapToDto(loot);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error creating loot for campaign {CampaignId}", campaignId);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<CampaignLootDto>> GetCampaignLootAsync(int campaignId, int userId)
+    {
+        try
+        {
+            var isGm = await this.dbContext.Campaigns
+                .AnyAsync(c => c.Id == campaignId && !c.IsDeleted && c.CreatedBy == userId);
+            if (!isGm)
+            {
+                return Enumerable.Empty<CampaignLootDto>();
+            }
+
+            var loot = await this.dbContext.CampaignLoots
+                .Where(l => l.CampaignId == campaignId && l.IsActive)
+                .OrderByDescending(l => l.CreatedAt)
+                .ToListAsync();
+
+            return loot.Select(MapToDto);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error listing loot for campaign {CampaignId}", campaignId);
+            return Enumerable.Empty<CampaignLootDto>();
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<CampaignLootDto?> UpdateAsync(int lootId, CreateLootDto dto, int userId)
+    {
+        try
+        {
+            var loot = await this.dbContext.CampaignLoots
+                .Include(l => l.Campaign)
+                .FirstOrDefaultAsync(l => l.Id == lootId && l.IsActive);
+            if (loot == null || loot.Campaign.CreatedBy != userId)
+            {
+                return null;
+            }
+
+            if (dto.ChapterId.HasValue)
+            {
+                var chapterOk = await this.dbContext.Chapters
+                    .AnyAsync(ch => ch.Id == dto.ChapterId.Value && ch.CampaignId == loot.CampaignId);
+                if (!chapterOk)
+                {
+                    return null;
+                }
+            }
+
+            loot.ChapterId = dto.ChapterId;
+            loot.Name = dto.Name;
+            loot.Description = dto.Description;
+            loot.ImageUrl = dto.ImageUrl;
+            loot.ItemType = dto.ItemType;
+            loot.GameSpecificData = dto.GameSpecificData;
+            loot.Quantity = dto.Quantity < 1 ? 1 : dto.Quantity;
+            loot.UpdatedAt = DateTime.UtcNow;
+
+            await this.dbContext.SaveChangesAsync();
+            this.logger.LogInformation("Updated loot {LootId}", lootId);
+            return MapToDto(loot);
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error updating loot {LootId}", lootId);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> DeleteAsync(int lootId, int userId)
+    {
+        try
+        {
+            var loot = await this.dbContext.CampaignLoots
+                .Include(l => l.Campaign)
+                .FirstOrDefaultAsync(l => l.Id == lootId && l.IsActive);
+            if (loot == null || loot.Campaign.CreatedBy != userId)
+            {
+                return false;
+            }
+
+            loot.IsActive = false;
+            loot.UpdatedAt = DateTime.UtcNow;
+            await this.dbContext.SaveChangesAsync();
+            this.logger.LogInformation("Soft-deleted loot {LootId}", lootId);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error deleting loot {LootId}", lootId);
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<(bool Success, string? Error, LootDistributionResultDto? Result)> DistributeAsync(int lootId, int worldCharacterId, int? sessionId, int userId)
+    {
+        try
+        {
+            var loot = await this.dbContext.CampaignLoots
+                .Include(l => l.Campaign)
+                .FirstOrDefaultAsync(l => l.Id == lootId && l.IsActive);
+            if (loot == null)
+            {
+                return (false, "Loot introuvable.", null);
+            }
+
+            if (loot.Campaign.CreatedBy != userId)
+            {
+                return (false, "Seul le MJ de la campagne peut distribuer ce loot.", null);
+            }
+
+            var recipient = await this.dbContext.WorldCharacters
+                .Include(w => w.Character)
+                .FirstOrDefaultAsync(w => w.Id == worldCharacterId && w.IsActive);
+            if (recipient == null)
+            {
+                return (false, "Personnage destinataire introuvable.", null);
+            }
+
+            // The recipient must belong to the campaign's world (guarantees a compatible game type).
+            if (recipient.WorldId != loot.Campaign.WorldId)
+            {
+                return (false, "Ce personnage n'appartient pas au monde de la campagne.", null);
+            }
+
+            // Independent copy into the character's inventory.
+            var inventoryItem = new DndInventoryItem
+            {
+                WorldCharacterId = worldCharacterId,
+                Name = loot.Name,
+                Category = string.IsNullOrWhiteSpace(loot.ItemType) ? "Objet" : loot.ItemType!,
+                Quantity = loot.Quantity,
+                Notes = loot.Description,
+                CreatedAt = DateTime.UtcNow,
+            };
+            this.dbContext.DndInventoryItems.Add(inventoryItem);
+
+            this.dbContext.LootDistributions.Add(new LootDistribution
+            {
+                LootId = lootId,
+                WorldCharacterId = worldCharacterId,
+                SessionId = sessionId,
+                DistributedByUserId = userId,
+                DistributedAt = DateTime.UtcNow,
+            });
+
+            await this.dbContext.SaveChangesAsync();
+
+            var recipientName = !string.IsNullOrWhiteSpace(recipient.Character.FirstName)
+                ? recipient.Character.FirstName!
+                : recipient.Character.Name;
+
+            this.logger.LogInformation(
+                "GM {UserId} distributed loot {LootId} to world character {WorldCharacterId}",
+                userId,
+                lootId,
+                worldCharacterId);
+
+            return (true, null, new LootDistributionResultDto
+            {
+                LootId = loot.Id,
+                LootName = loot.Name,
+                ImageUrl = loot.ImageUrl,
+                ItemType = loot.ItemType,
+                Quantity = loot.Quantity,
+                RecipientWorldCharacterId = worldCharacterId,
+                RecipientName = recipientName,
+                RecipientUserId = recipient.Character.UserId,
+            });
+        }
+        catch (Exception ex)
+        {
+            this.logger.LogError(ex, "Error distributing loot {LootId} to character {WorldCharacterId}", lootId, worldCharacterId);
+            return (false, "Erreur lors de la distribution du loot.", null);
+        }
+    }
+
+    private static CampaignLootDto MapToDto(CampaignLoot loot) => new()
+    {
+        Id = loot.Id,
+        CampaignId = loot.CampaignId,
+        ChapterId = loot.ChapterId,
+        Name = loot.Name,
+        Description = loot.Description,
+        ImageUrl = loot.ImageUrl,
+        GameType = loot.GameType,
+        ItemType = loot.ItemType,
+        GameSpecificData = loot.GameSpecificData,
+        Quantity = loot.Quantity,
+        CreatedAt = loot.CreatedAt,
+    };
+}

--- a/Cdm/Cdm.Data.Common/AppDbContext.cs
+++ b/Cdm/Cdm.Data.Common/AppDbContext.cs
@@ -141,6 +141,12 @@ public class AppDbContext : DbContext
     /// <summary>Codex items (user-owned generic item templates).</summary>
     public DbSet<CodexItem> CodexItems { get; set; } = null!;
 
+    /// <summary>Loot the GM prepared for a campaign/chapter, to hand out in session.</summary>
+    public DbSet<CampaignLoot> CampaignLoots { get; set; } = null!;
+
+    /// <summary>Records of loot handed out to players' characters.</summary>
+    public DbSet<LootDistribution> LootDistributions { get; set; } = null!;
+
     /// <summary>D&amp;D 5e spells known/prepared by world characters.</summary>
     public DbSet<DndCharacterSpell> DndCharacterSpells { get; set; } = null!;
 

--- a/Cdm/Cdm.Data.Common/Models/CampaignLoot.cs
+++ b/Cdm/Cdm.Data.Common/Models/CampaignLoot.cs
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// <copyright file="CampaignLoot.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Data.Common.Models;
+
+using Cdm.Common.Enums;
+
+/// <summary>
+/// A loot item the Game Master prepared for a campaign (optionally scoped to a chapter),
+/// ready to be handed out to players during a session. Item data is a self-contained snapshot
+/// (same shape as <see cref="CodexItem"/>) so editing the source codex later does not change it.
+/// </summary>
+public class CampaignLoot
+{
+    /// <summary>Gets or sets the loot identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the campaign this loot belongs to.</summary>
+    public int CampaignId { get; set; }
+
+    /// <summary>Gets or sets the optional chapter this loot is scoped to (null = whole campaign).</summary>
+    public int? ChapterId { get; set; }
+
+    /// <summary>Gets or sets the loot name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the optional description.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Gets or sets the optional image URL.</summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>Gets or sets the game system / theme of the item.</summary>
+    public GameType GameType { get; set; }
+
+    /// <summary>Gets or sets the optional item category (e.g. "Arme", "Potion").</summary>
+    public string? ItemType { get; set; }
+
+    /// <summary>Gets or sets the optional game-specific data (JSON).</summary>
+    public string? GameSpecificData { get; set; }
+
+    /// <summary>Gets or sets the quantity handed out per distribution.</summary>
+    public int Quantity { get; set; } = 1;
+
+    /// <summary>Gets or sets the user ID of the GM who created this loot.</summary>
+    public int CreatedBy { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the loot is active (soft delete).</summary>
+    public bool IsActive { get; set; } = true;
+
+    /// <summary>Gets or sets the creation date.</summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>Gets or sets the last update date.</summary>
+    public DateTime? UpdatedAt { get; set; }
+
+    /// <summary>Gets or sets the campaign navigation property.</summary>
+    public virtual Campaign Campaign { get; set; } = null!;
+
+    /// <summary>Gets or sets the chapter navigation property (optional).</summary>
+    public virtual Chapter? Chapter { get; set; }
+
+    /// <summary>Gets or sets the distributions of this loot to players.</summary>
+    public virtual ICollection<LootDistribution> Distributions { get; set; } = new List<LootDistribution>();
+}

--- a/Cdm/Cdm.Data.Common/Models/LootDistribution.cs
+++ b/Cdm/Cdm.Data.Common/Models/LootDistribution.cs
@@ -1,0 +1,38 @@
+// -----------------------------------------------------------------------
+// <copyright file="LootDistribution.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Data.Common.Models;
+
+/// <summary>
+/// Records that a piece of <see cref="CampaignLoot"/> was handed out to a player's character
+/// (usually during a session). One row per recipient, so the same loot can be given to several players.
+/// </summary>
+public class LootDistribution
+{
+    /// <summary>Gets or sets the distribution identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the loot that was distributed.</summary>
+    public int LootId { get; set; }
+
+    /// <summary>Gets or sets the recipient world character.</summary>
+    public int WorldCharacterId { get; set; }
+
+    /// <summary>Gets or sets the session during which the loot was distributed (optional).</summary>
+    public int? SessionId { get; set; }
+
+    /// <summary>Gets or sets the user ID of the GM who distributed the loot.</summary>
+    public int DistributedByUserId { get; set; }
+
+    /// <summary>Gets or sets when the loot was distributed.</summary>
+    public DateTime DistributedAt { get; set; }
+
+    /// <summary>Gets or sets the loot navigation property.</summary>
+    public virtual CampaignLoot Loot { get; set; } = null!;
+
+    /// <summary>Gets or sets the recipient world character navigation property.</summary>
+    public virtual WorldCharacter WorldCharacter { get; set; } = null!;
+}

--- a/Cdm/Cdm.Migrations/Migrations/20260721080000_AddCampaignLoot.cs
+++ b/Cdm/Cdm.Migrations/Migrations/20260721080000_AddCampaignLoot.cs
@@ -1,0 +1,82 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Cdm.Migrations;
+
+#nullable disable
+
+namespace Cdm.Migrations.Migrations
+{
+    /// <summary>
+    /// Ajoute les tables [CampaignLoots] (loot préparé par le MJ pour une campagne/chapitre)
+    /// et [LootDistributions] (traçabilité de la distribution aux personnages joueurs).
+    /// Migration idempotente (IF OBJECT_ID ... IS NULL). Les FK vers WorldCharacters/Chapters
+    /// sont en NO ACTION pour éviter les chemins de cascade multiples SQL Server.
+    /// </summary>
+    [DbContext(typeof(MigrationsContext))]
+    [Migration("20260721080000_AddCampaignLoot")]
+    public partial class AddCampaignLoot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF OBJECT_ID(N'[CampaignLoots]', N'U') IS NULL
+                BEGIN
+                    CREATE TABLE [CampaignLoots] (
+                        [Id] int NOT NULL IDENTITY,
+                        [CampaignId] int NOT NULL,
+                        [ChapterId] int NULL,
+                        [Name] nvarchar(200) NOT NULL DEFAULT N'',
+                        [Description] nvarchar(max) NULL,
+                        [ImageUrl] nvarchar(1000) NULL,
+                        [GameType] int NOT NULL DEFAULT 0,
+                        [ItemType] nvarchar(50) NULL,
+                        [GameSpecificData] nvarchar(max) NULL,
+                        [Quantity] int NOT NULL DEFAULT 1,
+                        [CreatedBy] int NOT NULL,
+                        [IsActive] bit NOT NULL DEFAULT 1,
+                        [CreatedAt] datetime2 NOT NULL DEFAULT (GETUTCDATE()),
+                        [UpdatedAt] datetime2 NULL,
+                        CONSTRAINT [PK_CampaignLoots] PRIMARY KEY ([Id]),
+                        CONSTRAINT [FK_CampaignLoots_Campaigns_CampaignId] FOREIGN KEY ([CampaignId])
+                            REFERENCES [Campaigns] ([Id]) ON DELETE CASCADE,
+                        CONSTRAINT [FK_CampaignLoots_Chapters_ChapterId] FOREIGN KEY ([ChapterId])
+                            REFERENCES [Chapters] ([Id]) ON DELETE NO ACTION
+                    );
+
+                    CREATE INDEX [IX_CampaignLoots_CampaignId] ON [CampaignLoots] ([CampaignId]);
+                    CREATE INDEX [IX_CampaignLoots_ChapterId] ON [CampaignLoots] ([ChapterId]);
+                END
+            ");
+
+            migrationBuilder.Sql(@"
+                IF OBJECT_ID(N'[LootDistributions]', N'U') IS NULL
+                BEGIN
+                    CREATE TABLE [LootDistributions] (
+                        [Id] int NOT NULL IDENTITY,
+                        [LootId] int NOT NULL,
+                        [WorldCharacterId] int NOT NULL,
+                        [SessionId] int NULL,
+                        [DistributedByUserId] int NOT NULL,
+                        [DistributedAt] datetime2 NOT NULL DEFAULT (GETUTCDATE()),
+                        CONSTRAINT [PK_LootDistributions] PRIMARY KEY ([Id]),
+                        CONSTRAINT [FK_LootDistributions_CampaignLoots_LootId] FOREIGN KEY ([LootId])
+                            REFERENCES [CampaignLoots] ([Id]) ON DELETE CASCADE,
+                        CONSTRAINT [FK_LootDistributions_WorldCharacters_WorldCharacterId] FOREIGN KEY ([WorldCharacterId])
+                            REFERENCES [WorldCharacters] ([Id]) ON DELETE NO ACTION
+                    );
+
+                    CREATE INDEX [IX_LootDistributions_LootId] ON [LootDistributions] ([LootId]);
+                    CREATE INDEX [IX_LootDistributions_WorldCharacterId] ON [LootDistributions] ([WorldCharacterId]);
+                END
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"IF OBJECT_ID(N'[LootDistributions]', N'U') IS NOT NULL DROP TABLE [LootDistributions];");
+            migrationBuilder.Sql(@"IF OBJECT_ID(N'[CampaignLoots]', N'U') IS NOT NULL DROP TABLE [CampaignLoots];");
+        }
+    }
+}

--- a/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignDetail.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignDetail.razor
@@ -385,6 +385,11 @@ else
                     </ActionContent>
                 </AppEmptyState>
             }
+
+            @if (IsGm)
+            {
+                <CampaignLootPanel CampaignId="Campaign.Id" Chapters="Chapters" />
+            }
         }
 
         <!-- Formulaire de création de chapitre -->

--- a/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignLootPanel.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignLootPanel.razor
@@ -1,0 +1,214 @@
+@using Cdm.Business.Abstraction.DTOs
+@using Cdm.Common.Enums
+@inject Cdm.Web.Services.ApiClients.LootApiClient LootClient
+
+@* GM-only panel to prepare the loot handed out to players during sessions. *@
+<div class="cdm-card" style="margin-top: var(--spacing-lg);">
+    <AppSectionTitle Title="Butin (loot)" Icon="bi-gem">
+        <Actions>
+            <button class="btn btn-ghost btn-sm" @onclick="() => ShowForm = !ShowForm">
+                <i class="bi bi-plus"></i> Ajouter
+            </button>
+        </Actions>
+    </AppSectionTitle>
+
+    <p style="color: var(--color-text-muted); font-size: var(--font-size-sm); margin-top: -4px;">
+        Préparez des objets à distribuer aux joueurs en session, pour l'ensemble de la campagne ou un chapitre précis.
+    </p>
+
+    @if (ShowForm)
+    {
+        <div class="cdm-card" style="background: var(--color-surface-alt); margin-bottom: var(--spacing-md);">
+            <div style="display: grid; grid-template-columns: 2fr 1fr; gap: var(--spacing-sm);">
+                <div class="form-group" style="margin-bottom: 0;">
+                    <label class="form-label">Nom</label>
+                    <input class="form-control" @bind="Draft.Name" placeholder="Épée longue, Potion de soin..." />
+                </div>
+                <div class="form-group" style="margin-bottom: 0;">
+                    <label class="form-label">Catégorie</label>
+                    <input class="form-control" @bind="Draft.ItemType" placeholder="Arme, Potion..." />
+                </div>
+            </div>
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-sm); margin-top: var(--spacing-sm);">
+                <div class="form-group" style="margin-bottom: 0;">
+                    <label class="form-label">Quantité</label>
+                    <input type="number" min="1" class="form-control" @bind="Draft.Quantity" />
+                </div>
+                <div class="form-group" style="margin-bottom: 0;">
+                    <label class="form-label">Portée</label>
+                    <select class="form-control" @bind="Draft.ChapterId">
+                        <option value="">Toute la campagne</option>
+                        @foreach (var ch in Chapters.OrderBy(c => c.ChapterNumber))
+                        {
+                            <option value="@ch.Id">Chapitre @ch.ChapterNumber — @ch.Title</option>
+                        }
+                    </select>
+                </div>
+            </div>
+            <div class="form-group" style="margin-top: var(--spacing-sm);">
+                <label class="form-label">Description</label>
+                <textarea class="form-control" rows="2" @bind="Draft.Description" placeholder="Effet, apparence..."></textarea>
+            </div>
+            @if (!string.IsNullOrEmpty(FormError))
+            {
+                <p style="color: var(--color-error, #e88); font-size: var(--font-size-sm);">@FormError</p>
+            }
+            <div class="form-actions" style="margin-top: var(--spacing-sm);">
+                <button type="button" class="btn btn-ghost btn-sm" @onclick="CancelForm">Annuler</button>
+                <button type="button" class="btn btn-primary btn-sm" @onclick="SaveLoot" disabled="@IsSaving">
+                    @if (IsSaving) { <AppLoadingSpinner Inline="true" Size="sm" /> }
+                    @(EditingId.HasValue ? "Enregistrer" : "Ajouter le butin")
+                </button>
+            </div>
+        </div>
+    }
+
+    @if (IsLoading)
+    {
+        <AppLoadingSpinner Inline="true" Size="sm" />
+    }
+    else if (Loot.Count == 0)
+    {
+        <p style="color: var(--color-text-muted); font-style: italic; font-size: var(--font-size-sm);">Aucun butin préparé.</p>
+    }
+    else
+    {
+        <div style="display: flex; flex-direction: column; gap: var(--spacing-xs);">
+            @foreach (var loot in Loot)
+            {
+                <div class="cdm-card" style="display: flex; justify-content: space-between; align-items: flex-start; gap: var(--spacing-sm); padding: var(--spacing-sm);">
+                    <div style="min-width: 0;">
+                        <strong>@loot.Name</strong>
+                        @if (loot.Quantity > 1)
+                        {
+                            <span class="status-badge" style="background: var(--color-surface-alt);">×@loot.Quantity</span>
+                        }
+                        @if (!string.IsNullOrEmpty(loot.ItemType))
+                        {
+                            <span class="status-badge" style="background: var(--color-surface-alt);">@loot.ItemType</span>
+                        }
+                        <span class="status-badge" style="background: var(--color-bg-tertiary);">
+                            <i class="bi bi-@(loot.ChapterId.HasValue ? "bookmark" : "map")"></i>
+                            @ScopeLabel(loot.ChapterId)
+                        </span>
+                        @if (!string.IsNullOrEmpty(loot.Description))
+                        {
+                            <p class="card-description" style="margin: 4px 0 0;">@loot.Description</p>
+                        }
+                    </div>
+                    <div style="display: flex; gap: 4px; flex-shrink: 0;">
+                        <button class="btn btn-ghost btn-icon" title="Modifier" @onclick="() => EditLoot(loot)">
+                            <i class="bi bi-pencil"></i>
+                        </button>
+                        <button class="btn btn-ghost btn-icon danger" title="Supprimer" @onclick="() => DeleteLoot(loot.Id)">
+                            <i class="bi bi-trash3"></i>
+                        </button>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public int CampaignId { get; set; }
+    [Parameter] public List<ChapterDto> Chapters { get; set; } = new();
+
+    private List<CampaignLootDto> Loot = new();
+    private bool IsLoading = true;
+    private bool ShowForm;
+    private bool IsSaving;
+    private int? EditingId;
+    private string? FormError;
+    private LootDraft Draft = new();
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private async Task Reload()
+    {
+        IsLoading = true;
+        Loot = await LootClient.GetCampaignLootAsync(CampaignId);
+        IsLoading = false;
+    }
+
+    private string ScopeLabel(int? chapterId)
+    {
+        if (!chapterId.HasValue) return "Campagne";
+        var ch = Chapters.FirstOrDefault(c => c.Id == chapterId.Value);
+        return ch != null ? $"Ch. {ch.ChapterNumber}" : "Chapitre";
+    }
+
+    private void CancelForm()
+    {
+        ShowForm = false;
+        EditingId = null;
+        FormError = null;
+        Draft = new LootDraft();
+    }
+
+    private void EditLoot(CampaignLootDto loot)
+    {
+        EditingId = loot.Id;
+        Draft = new LootDraft
+        {
+            Name = loot.Name,
+            ItemType = loot.ItemType,
+            Description = loot.Description,
+            Quantity = loot.Quantity,
+            ChapterId = loot.ChapterId?.ToString() ?? string.Empty,
+        };
+        FormError = null;
+        ShowForm = true;
+    }
+
+    private async Task SaveLoot()
+    {
+        if (string.IsNullOrWhiteSpace(Draft.Name))
+        {
+            FormError = "Le nom est requis.";
+            return;
+        }
+
+        IsSaving = true;
+        FormError = null;
+        var dto = new CreateLootDto
+        {
+            Name = Draft.Name.Trim(),
+            ItemType = string.IsNullOrWhiteSpace(Draft.ItemType) ? null : Draft.ItemType.Trim(),
+            Description = string.IsNullOrWhiteSpace(Draft.Description) ? null : Draft.Description.Trim(),
+            Quantity = Draft.Quantity < 1 ? 1 : Draft.Quantity,
+            ChapterId = int.TryParse(Draft.ChapterId, out var cid) ? cid : null,
+        };
+
+        var result = EditingId.HasValue
+            ? await LootClient.UpdateAsync(EditingId.Value, dto)
+            : await LootClient.CreateAsync(CampaignId, dto);
+
+        IsSaving = false;
+        if (result == null)
+        {
+            FormError = "Enregistrement impossible.";
+            return;
+        }
+
+        CancelForm();
+        await Reload();
+    }
+
+    private async Task DeleteLoot(int id)
+    {
+        if (await LootClient.DeleteAsync(id))
+        {
+            Loot.RemoveAll(l => l.Id == id);
+        }
+    }
+
+    private sealed class LootDraft
+    {
+        public string Name { get; set; } = string.Empty;
+        public string? ItemType { get; set; }
+        public string? Description { get; set; }
+        public int Quantity { get; set; } = 1;
+        public string ChapterId { get; set; } = string.Empty;
+    }
+}

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor
@@ -423,6 +423,43 @@ else if (Session != null)
                         </button>
                     </div>
                 </div>
+
+                <!-- Distribution de butin (loot) -->
+                <div class="gm-chat-section">
+                    <div class="gm-chat-header">
+                        <i class="bi bi-gem"></i>
+                        <span>Butin</span>
+                    </div>
+                    <div style="padding: var(--spacing-sm); display: flex; flex-direction: column; gap: var(--spacing-xs);">
+                        @if (CampaignLoot.Count == 0)
+                        {
+                            <p style="color: var(--color-text-muted); font-size: var(--font-size-xs); font-style: italic; text-align: center;">
+                                Aucun butin préparé. Ajoutez-en depuis la fiche de campagne.
+                            </p>
+                        }
+                        else
+                        {
+                            <select class="form-control" style="font-size: var(--font-size-xs);" @bind="DistributeLootId" disabled="@(!IsHubConnected)">
+                                <option value="0">— Objet à donner —</option>
+                                @foreach (var loot in CampaignLoot)
+                                {
+                                    <option value="@loot.Id">@loot.Name@(loot.Quantity > 1 ? $" ×{loot.Quantity}" : "") — @LootScopeLabel(loot.ChapterId)</option>
+                                }
+                            </select>
+                            <select class="form-control" style="font-size: var(--font-size-xs);" @bind="DistributeTargetWcId" disabled="@(!IsHubConnected)">
+                                <option value="0">— Personnage destinataire —</option>
+                                @foreach (var target in LootTargets())
+                                {
+                                    <option value="@target.WorldCharacterId">@target.Name</option>
+                                }
+                            </select>
+                            <button class="btn btn-primary btn-sm" @onclick="DistributeLoot"
+                                    disabled="@(!IsHubConnected || IsDistributingLoot || DistributeLootId <= 0 || DistributeTargetWcId <= 0)">
+                                <i class="bi bi-gift"></i> Distribuer
+                            </button>
+                        }
+                    </div>
+                </div>
             </aside>
         </div>
     </div>

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionGm.razor.cs
@@ -24,6 +24,7 @@ public partial class SessionGm : IAsyncDisposable
     [Inject] private WorldApiClient WorldClient { get; set; } = default!;
     [Inject] private NpcApiClient NpcClient { get; set; } = default!;
     [Inject] private CombatApiClient CombatClient { get; set; } = default!;
+    [Inject] private LootApiClient LootClient { get; set; } = default!;
     [Inject] private NavigationContextService NavContext { get; set; } = default!;
     [Inject] private AuthenticationStateProvider AuthStateProvider { get; set; } = default!;
     [Inject] private NavigationManager Nav { get; set; } = default!;
@@ -62,6 +63,12 @@ public partial class SessionGm : IAsyncDisposable
     private string TradeRequest = "";
     private bool IsProposingTrade;
 
+    // Loot distribution
+    private List<CampaignLootDto> CampaignLoot { get; set; } = new();
+    private int DistributeLootId;
+    private int DistributeTargetWcId;
+    private bool IsDistributingLoot;
+
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
@@ -95,6 +102,7 @@ public partial class SessionGm : IAsyncDisposable
 
         Chapters = await ChapterClient.GetChaptersByCampaignAsync(Session.CampaignId);
         WorldCharacters = await WorldClient.GetWorldCharactersTypedAsync(Session.WorldId);
+        CampaignLoot = await LootClient.GetCampaignLootAsync(Session.CampaignId);
 
         if (Session.CurrentChapterId.HasValue)
         {
@@ -170,6 +178,13 @@ public partial class SessionGm : IAsyncDisposable
         _hub.On<SessionTradeDto>("TradeResolved", trade =>
         {
             PendingTrades.RemoveAll(t => t.Id == trade.Id);
+            InvokeAsync(StateHasChanged);
+        });
+
+        _hub.On<LootDistributionResultDto>("LootReceived", loot =>
+        {
+            var qty = loot.Quantity > 1 ? $" ×{loot.Quantity}" : string.Empty;
+            ChatEntries.Add(new ChatEntry("text", "🎁 Butin", $"{loot.RecipientName} reçoit {loot.LootName}{qty}.", null, null, DateTime.UtcNow));
             InvokeAsync(StateHasChanged);
         });
 
@@ -332,6 +347,49 @@ public partial class SessionGm : IAsyncDisposable
             Logger.LogWarning(ex, "Annulation de l'échange impossible (session {SessionId})", SessionId);
             Toast.ShowError("Annulation non envoyée.", "Échange");
         }
+    }
+
+    /// <summary>Selectable loot recipients: every session participant's character.</summary>
+    private List<(int WorldCharacterId, string Name)> LootTargets()
+    {
+        var targets = new List<(int, string)>();
+        if (Session == null) return targets;
+
+        foreach (var p in Session.Participants)
+        {
+            if (p.WorldCharacterId > 0)
+            {
+                targets.Add((p.WorldCharacterId, string.IsNullOrWhiteSpace(p.CharacterName) ? p.UserName : p.CharacterName));
+            }
+        }
+        return targets;
+    }
+
+    private string LootScopeLabel(int? chapterId)
+    {
+        if (!chapterId.HasValue) return "Campagne";
+        var ch = Chapters.FirstOrDefault(c => c.Id == chapterId.Value);
+        return ch != null ? $"Ch. {ch.ChapterNumber}" : "Chapitre";
+    }
+
+    private async Task DistributeLoot()
+    {
+        if (_hub == null || !IsHubConnected || IsDistributingLoot) return;
+        if (DistributeLootId <= 0 || DistributeTargetWcId <= 0) return;
+
+        IsDistributingLoot = true;
+        try
+        {
+            await _hub.InvokeAsync("DistributeLoot", SessionId, DistributeLootId, DistributeTargetWcId);
+            DistributeLootId = 0;
+            DistributeTargetWcId = 0;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Distribution de butin impossible (session {SessionId})", SessionId);
+            Toast.ShowError("Butin non distribué. Vérifiez votre connexion.", "Butin");
+        }
+        IsDistributingLoot = false;
     }
 
     private async Task SelectChapter(ChapterDto chapter)

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor.cs
@@ -230,6 +230,25 @@ public partial class SessionPlayer : IAsyncDisposable
             InvokeAsync(StateHasChanged);
         });
 
+        _hub.On<LootDistributionResultDto>("LootReceived", loot =>
+        {
+            var qty = loot.Quantity > 1 ? $" ×{loot.Quantity}" : string.Empty;
+            ChatEntries.Add(new ChatEntry("text", "🎁 Butin", $"{loot.RecipientName} reçoit {loot.LootName}{qty}.", null, null, DateTime.UtcNow));
+
+            if (loot.RecipientUserId == CurrentUserId)
+            {
+                Toast.ShowSuccess($"Vous recevez : {loot.LootName}{qty}.", "Butin obtenu !");
+                // The item was added to the inventory server-side; refresh the sheet so it appears.
+                _ = InvokeAsync(async () =>
+                {
+                    await LoadDndSheetAsync();
+                    StateHasChanged();
+                });
+            }
+
+            InvokeAsync(StateHasChanged);
+        });
+
         _hub.On<object>("SessionEnded", _ =>
         {
             InvokeAsync(() =>

--- a/Cdm/Cdm.Web/Program.cs
+++ b/Cdm/Cdm.Web/Program.cs
@@ -225,6 +225,18 @@ builder.Services.AddScoped<MarketplaceApiClient>(sp =>
 
 builder.Services.AddHttpClient("MarketplaceApiClient", ConfigureApiClient);
 
+// Register LootApiClient with scoped lifetime
+builder.Services.AddScoped<LootApiClient>(sp =>
+{
+    var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
+    var httpClient = httpClientFactory.CreateClient("LootApiClient");
+    var localStorage = sp.GetRequiredService<ILocalStorageService>();
+    var logger = sp.GetRequiredService<ILogger<LootApiClient>>();
+    return new LootApiClient(httpClient, logger, localStorage);
+});
+
+builder.Services.AddHttpClient("LootApiClient", ConfigureApiClient);
+
 // Register NotificationApiClient with scoped lifetime
 builder.Services.AddScoped<NotificationApiClient>(sp =>
 {

--- a/Cdm/Cdm.Web/Services/ApiClients/LootApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ApiClients/LootApiClient.cs
@@ -1,0 +1,116 @@
+using Cdm.Business.Abstraction.DTOs;
+using Cdm.Web.Services.Storage;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace Cdm.Web.Services.ApiClients;
+
+/// <summary>
+/// HTTP client for campaign loot endpoints (GM preparation + out-of-session distribution).
+/// In-session distribution goes through the SignalR hub, not this client.
+/// </summary>
+public class LootApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<LootApiClient> _logger;
+    private readonly ILocalStorageService _localStorage;
+
+    public LootApiClient(HttpClient httpClient, ILogger<LootApiClient> logger, ILocalStorageService localStorage)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _localStorage = localStorage;
+    }
+
+    private async Task AddAuthHeaderAsync()
+    {
+        var token = await _localStorage.GetItemAsync("auth_token");
+        if (!string.IsNullOrEmpty(token))
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    public async Task<List<CampaignLootDto>> GetCampaignLootAsync(int campaignId)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await _httpClient.GetAsync($"api/campaigns/{campaignId}/loot");
+            if (!response.IsSuccessStatusCode) return new();
+            return await response.Content.ReadFromJsonAsync<List<CampaignLootDto>>() ?? new();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching loot for campaign {CampaignId}", campaignId);
+            return new();
+        }
+    }
+
+    public async Task<CampaignLootDto?> CreateAsync(int campaignId, CreateLootDto dto)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await _httpClient.PostAsJsonAsync($"api/campaigns/{campaignId}/loot", dto);
+            return response.IsSuccessStatusCode ? await response.Content.ReadFromJsonAsync<CampaignLootDto>() : null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating loot for campaign {CampaignId}", campaignId);
+            return null;
+        }
+    }
+
+    public async Task<CampaignLootDto?> UpdateAsync(int lootId, CreateLootDto dto)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await _httpClient.PutAsJsonAsync($"api/loot/{lootId}", dto);
+            return response.IsSuccessStatusCode ? await response.Content.ReadFromJsonAsync<CampaignLootDto>() : null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating loot {LootId}", lootId);
+            return null;
+        }
+    }
+
+    public async Task<bool> DeleteAsync(int lootId)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var response = await _httpClient.DeleteAsync($"api/loot/{lootId}");
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting loot {LootId}", lootId);
+            return false;
+        }
+    }
+
+    public async Task<(bool Success, string? Error)> DistributeAsync(int lootId, int worldCharacterId, int? sessionId = null)
+    {
+        try
+        {
+            await AddAuthHeaderAsync();
+            var url = $"api/loot/{lootId}/distribute?worldCharacterId={worldCharacterId}";
+            if (sessionId.HasValue) url += $"&sessionId={sessionId.Value}";
+            var response = await _httpClient.PostAsync(url, null);
+            if (response.IsSuccessStatusCode) return (true, null);
+            var problem = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+            return (false, problem?.Error ?? "Distribution impossible.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error distributing loot {LootId}", lootId);
+            return (false, "Distribution impossible.");
+        }
+    }
+
+    private sealed class ErrorResponse
+    {
+        public string? Error { get; set; }
+    }
+}


### PR DESCRIPTION
- Entités CampaignLoot + LootDistribution (+ migration idempotente, FK NO ACTION vers WorldCharacters/Chapters pour éviter les cascades multiples).
- ILootService : CRUD MJ (loot scopé campagne ou chapitre, optionnellement copié depuis un item du Codex) + DistributeAsync (copie dans l'inventaire du perso + traçabilité). GameType du loot aligné sur le monde de la campagne.
- Endpoints /api/campaigns/{id}/loot (list/create) + /api/loot/{id} (update/delete)
  + /api/loot/{id}/distribute. Hub SessionHub.DistributeLoot → event LootReceived.
- Web : LootApiClient, CampaignLootPanel (prépa MJ sur la fiche de campagne), panneau « Butin » dans l'écran MJ de session (distribution temps réel), réception joueur (toast + chat + refresh de la fiche).
- 9 tests LootService (CRUD scopé MJ + distribution + garde-fous). 161 tests verts.