### PR TITLE
fix(prod): repare l'upload d'avatar et la confirmation d'email

### DIFF
--- a/Cdm/Cdm.Business.Common.Tests/Services/AuthServiceConfirmEmailTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/AuthServiceConfirmEmailTests.cs
@@ -1,0 +1,138 @@
+// <copyright file="AuthServiceConfirmEmailTests.cs" company="Chronique Des Mondes">
+// Copyright (c) Chronique Des Mondes. All rights reserved.
+// </copyright>
+
+namespace Cdm.Business.Common.Tests.Services;
+
+using Cdm.Business.Common.Services;
+using Cdm.Common.Services;
+using Cdm.Data.Common;
+using Cdm.Data.Common.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="AuthService.ConfirmEmailAsync"/>, notamment son idempotence :
+/// la page de confirmation rappelle l'API quand l'état d'authentification change, et les
+/// scanners de messagerie ouvrent le lien avant le destinataire. Sans idempotence,
+/// l'utilisateur voit « lien expiré » alors que son adresse vient d'être confirmée.
+/// </summary>
+public class AuthServiceConfirmEmailTests
+{
+    private static AuthService NewService(AppDbContext context) => new(
+        context,
+        new Mock<IPasswordService>().Object,
+        new Mock<IJwtService>().Object,
+        new Mock<ILogger<AuthService>>().Object);
+
+    private static async Task<(AppDbContext Context, string Token)> SeedAsync(
+        string dbName,
+        DateTime expiresAt,
+        DateTime? usedAt = null,
+        bool emailConfirmed = false)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+
+        var context = new AppDbContext(options);
+
+        var user = new User
+        {
+            Email = "joueur@example.com",
+            Nickname = "Joueur",
+            PasswordHash = "hash",
+            IsActive = true,
+            EmailConfirmed = emailConfirmed,
+        };
+        context.Users.Add(user);
+        await context.SaveChangesAsync();
+
+        var token = $"token-{dbName}";
+        context.EmailConfirmationTokens.Add(new EmailConfirmationToken
+        {
+            Token = token,
+            UserId = user.Id,
+            ExpiresAt = expiresAt,
+            CreatedAt = DateTime.UtcNow,
+            UsedAt = usedAt,
+        });
+        await context.SaveChangesAsync();
+
+        return (context, token);
+    }
+
+    [Fact]
+    public async Task ConfirmEmailAsync_ValidToken_ConfirmsUser()
+    {
+        var (context, token) = await SeedAsync(nameof(ConfirmEmailAsync_ValidToken_ConfirmsUser), DateTime.UtcNow.AddHours(24));
+        using (context)
+        {
+            var result = await NewService(context).ConfirmEmailAsync(token);
+
+            Assert.True(result.IsSuccess);
+            Assert.True(await context.Users.AnyAsync(u => u.EmailConfirmed));
+        }
+    }
+
+    [Fact]
+    public async Task ConfirmEmailAsync_CalledTwice_SecondCallStillSucceeds()
+    {
+        var (context, token) = await SeedAsync(nameof(ConfirmEmailAsync_CalledTwice_SecondCallStillSucceeds), DateTime.UtcNow.AddHours(24));
+        using (context)
+        {
+            var service = NewService(context);
+
+            var first = await service.ConfirmEmailAsync(token);
+            var second = await service.ConfirmEmailAsync(token);
+
+            Assert.True(first.IsSuccess);
+            Assert.True(second.IsSuccess);
+        }
+    }
+
+    [Fact]
+    public async Task ConfirmEmailAsync_ExpiredToken_Fails()
+    {
+        var (context, token) = await SeedAsync(nameof(ConfirmEmailAsync_ExpiredToken_Fails), DateTime.UtcNow.AddHours(-1));
+        using (context)
+        {
+            var result = await NewService(context).ConfirmEmailAsync(token);
+
+            Assert.False(result.IsSuccess);
+            Assert.False(await context.Users.AnyAsync(u => u.EmailConfirmed));
+        }
+    }
+
+    [Fact]
+    public async Task ConfirmEmailAsync_UsedTokenButUserNotConfirmed_Fails()
+    {
+        // Jeton invalidé par l'émission d'un nouveau lien : il ne doit pas confirmer le compte.
+        var (context, token) = await SeedAsync(
+            nameof(ConfirmEmailAsync_UsedTokenButUserNotConfirmed_Fails),
+            DateTime.UtcNow.AddHours(24),
+            usedAt: DateTime.UtcNow.AddMinutes(-5));
+
+        using (context)
+        {
+            var result = await NewService(context).ConfirmEmailAsync(token);
+
+            Assert.False(result.IsSuccess);
+            Assert.False(await context.Users.AnyAsync(u => u.EmailConfirmed));
+        }
+    }
+
+    [Fact]
+    public async Task ConfirmEmailAsync_UnknownToken_Fails()
+    {
+        var (context, _) = await SeedAsync(nameof(ConfirmEmailAsync_UnknownToken_Fails), DateTime.UtcNow.AddHours(24));
+        using (context)
+        {
+            var result = await NewService(context).ConfirmEmailAsync("jeton-inconnu");
+
+            Assert.False(result.IsSuccess);
+        }
+    }
+}

--- a/Cdm/Cdm.Business.Common.Tests/Services/CombatServiceTests.cs
+++ b/Cdm/Cdm.Business.Common.Tests/Services/CombatServiceTests.cs
@@ -287,7 +287,24 @@ public class CombatServiceTests
 
         Assert.NotNull(result);
         var updated = await context.CombatParticipants.FindAsync(502);
-        // Without crit: base (1+4)=5 doubled = 10 → 90. With a natural 20 crit: dice doubled first.
-        Assert.True(updated!.CurrentHp <= 90, $"Expected doubled damage; HP was {updated.CurrentHp}.");
+
+        // Le jet d'attaque reste aléatoire : un 1 naturel rate quoi qu'il arrive, même avec
+        // un bonus de +50 contre une CA de 1 (5 % des exécutions). On se branche donc sur ce
+        // que le service a effectivement enregistré (DiceResult null = attaque manquée) plutôt
+        // que de supposer un coup au but — sinon le test échoue une fois sur vingt.
+        var action = await context.CombatActions
+            .OrderByDescending(a => a.Id)
+            .FirstAsync(a => a.CombatId == combatId && a.ActionType == "attack");
+
+        if (action.DiceResult is null)
+        {
+            Assert.Equal(100, updated!.CurrentHp);
+        }
+        else
+        {
+            // Sans critique : base (1+4)=5 doublée = 10. Avec un 20 naturel : dés doublés d'abord.
+            Assert.True(action.DiceResult >= 10, $"Expected doubled damage; dealt {action.DiceResult}.");
+            Assert.Equal(100 - action.DiceResult.Value, updated!.CurrentHp);
+        }
     }
 }

--- a/Cdm/Cdm.Business.Common/Services/AuthService.cs
+++ b/Cdm/Cdm.Business.Common/Services/AuthService.cs
@@ -406,13 +406,31 @@ public class AuthService : IAuthService
                 .Include(t => t.User)
                 .FirstOrDefaultAsync(t => t.Token == token);
 
-            if (confirmation == null || !confirmation.IsValid)
+            if (confirmation == null || confirmation.ExpiresAt <= DateTime.UtcNow)
             {
                 this.logger.LogWarning("Email confirmation token invalid or expired");
                 return ServiceResult<bool>.Failure("Ce lien de confirmation est invalide ou a expiré");
             }
 
             var user = confirmation.User;
+
+            // Idempotence : un jeton déjà consommé mais toujours dans sa fenêtre de validité
+            // renvoie un succès si l'adresse est bien confirmée. Sans ça, tout deuxième appel
+            // sur le même lien affiche « expiré » alors que la confirmation a réussi — ce qui
+            // arrive systématiquement (la page rappelle l'API quand l'état d'authentification
+            // change) et aussi quand un scanner de messagerie ouvre le lien avant le
+            // destinataire, ou sur un simple double-clic.
+            if (confirmation.UsedAt != null)
+            {
+                if (user.EmailConfirmed)
+                {
+                    this.logger.LogInformation("Email confirmation replayed for user {UserId}", user.Id);
+                    return ServiceResult<bool>.Success(true);
+                }
+
+                this.logger.LogWarning("Email confirmation token already used for user {UserId}", user.Id);
+                return ServiceResult<bool>.Failure("Ce lien de confirmation est invalide ou a expiré");
+            }
 
             if (!user.EmailConfirmed)
             {

--- a/Cdm/Cdm.Infrastructure.ExternalServices/ServiceCollectionExtensions.cs
+++ b/Cdm/Cdm.Infrastructure.ExternalServices/ServiceCollectionExtensions.cs
@@ -32,8 +32,20 @@ public static class ServiceCollectionExtensions
             var containerName = configuration["ImageStorage:ContainerName"] ?? "images";
 
             // Managed identity in production (no connection string / account key).
+            // On écarte les credentials de développeur : sur un App Service Linux ils sont
+            // absents, mais DefaultAzureCredential les sonde quand même (chacun avec son
+            // propre délai) avant d'abandonner — plusieurs secondes ajoutées à la première
+            // écriture. Même réglage que les sources de configuration dans Program.cs.
+            var credentialOptions = new DefaultAzureCredentialOptions
+            {
+                ExcludeVisualStudioCredential = true,
+                ExcludeAzurePowerShellCredential = true,
+                ExcludeAzureDeveloperCliCredential = true,
+                ExcludeInteractiveBrowserCredential = true,
+            };
+
             services.AddSingleton(_ =>
-                new BlobServiceClient(new Uri(blobServiceUri), new DefaultAzureCredential())
+                new BlobServiceClient(new Uri(blobServiceUri), new DefaultAzureCredential(credentialOptions))
                     .GetBlobContainerClient(containerName));
             services.AddScoped<IImageStorage, AzureBlobImageStorage>();
         }

--- a/Cdm/Cdm.Web/Services/ProfileApiClient.cs
+++ b/Cdm/Cdm.Web/Services/ProfileApiClient.cs
@@ -12,6 +12,9 @@ using Microsoft.AspNetCore.Components.Forms;
 /// </summary>
 public class ProfileApiClient
 {
+    /// <summary>Taille maximale d'un avatar — alignée sur ImageValidation.MaxFileSizeBytes côté API.</summary>
+    private const long MaxAvatarBytes = 5 * 1024 * 1024;
+
     private readonly HttpClient httpClient;
     private readonly ILocalStorageService localStorage;
     private readonly ILogger<ProfileApiClient> logger;
@@ -85,24 +88,38 @@ public class ProfileApiClient
     {
         try
         {
+            // On lit d'abord le fichier en mémoire (même approche que AppImageUpload). Passer
+            // directement le flux du navigateur à StreamContent ferait tenir la requête HTTP
+            // ouverte pendant tout le transfert par le circuit SignalR : côté API on a mesuré
+            // 14 s pour 2 Mo, et le moindre hoquet du circuit avortait l'appel — l'image
+            // finissait dans le blob mais l'utilisateur voyait une erreur.
+            using var buffer = new MemoryStream();
+            await using (var stream = file.OpenReadStream(MaxAvatarBytes))
+            {
+                await stream.CopyToAsync(buffer);
+            }
+
             await this.AddAuthHeaderAsync();
             using var content = new MultipartFormDataContent();
-            var fileContent = new StreamContent(file.OpenReadStream(maxAllowedSize: 2 * 1024 * 1024));
+            var fileContent = new ByteArrayContent(buffer.ToArray());
             fileContent.Headers.ContentType = new MediaTypeHeaderValue(file.ContentType);
             content.Add(fileContent, "avatar", file.Name);
 
             var response = await this.httpClient.PostAsync("api/users/profile/avatar", content);
-            
+
             if (response.IsSuccessStatusCode)
             {
                 var result = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
                 return result?["avatarUrl"];
             }
 
+            this.logger.LogWarning("Avatar upload rejected by the API ({Status})", response.StatusCode);
             return null;
         }
-        catch (HttpRequestException ex)
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or IOException)
         {
+            // IOException : lecture du fichier interrompue / trop volumineux.
+            // TaskCanceledException : délai HttpClient dépassé.
             this.logger.LogError(ex, "Error uploading avatar");
             return null;
         }


### PR DESCRIPTION
Upload de la photo de profil : ProfileApiClient passait le flux du navigateur directement a StreamContent, donc la requete HTTP vers l'API restait ouverte pendant tout le transfert par le circuit SignalR. Mesure en prod : 14 s pour 2 Mo, le client abandonne (499) alors que le blob etait bien ecrit — l'image arrivait mais l'utilisateur voyait une erreur. On bufferise d'abord en memoire (comme AppImageUpload le fait deja), la limite passe de 2 a 5 Mo pour s'aligner sur ImageValidation, et les exceptions de lecture/timeout sont attrapees au lieu de remonter brutes.

Confirmation d'email : le lien est a usage unique et la page rappelle l'API quand l'etat d'authentification change (deux appels a 340 ms d'intervalle constates en prod : 200 puis 400). L'utilisateur voyait « lien expire » alors que son adresse venait d'etre confirmee. ConfirmEmailAsync devient idempotent : un jeton deja consomme mais encore dans sa fenetre de validite renvoie un succes si l'adresse est confirmee. Couvre aussi les scanners de messagerie et le double-clic.

Credential Azure du stockage blob : DefaultAzureCredential etait construit sans options, donc sondait Visual Studio / CLI / PowerShell, absents du conteneur Linux. Meme reglage cible que dans Program.cs.

Au passage : CombatServiceTests.ResolveAttackAsync_VulnerableTarget echouait une fois sur vingt (un 1 naturel rate meme avec +50 contre CA 1). Le test se branche desormais sur le resultat enregistre par le service au lieu de supposer un coup au but.

169 tests verts.