### PR TITLE
fix(web): debloque l'affichage des images et annonce les limites

### DIFF
--- a/Cdm/Cdm.ApiService/Endpoints/ImageEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/ImageEndpoints.cs
@@ -20,7 +20,7 @@ public static class ImageEndpoints
     }
 
     private static readonly HashSet<string> AllowedCategories =
-        new(StringComparer.OrdinalIgnoreCase) { "session", "maps", "items", "misc" };
+        new(StringComparer.OrdinalIgnoreCase) { "session", "maps", "items", "misc", "portraits" };
 
     /// <summary>Maps the image endpoints.</summary>
     public static void MapImageEndpoints(this IEndpointRouteBuilder app)
@@ -59,10 +59,14 @@ public static class ImageEndpoints
             return Results.BadRequest(new { error = "Aucun fichier fourni." });
         }
 
+        // Les limites dependent de la categorie (portraits brides, illustrations libres).
+        // Ce pre-controle evite de lire tout le corps pour rien ; ImageValidation refait
+        // le controle sur les octets, dimensions comprises.
+        var policy = ImagePolicy.For(category);
         var file = request.Form.Files[0];
-        if (file.Length == 0 || file.Length > ImageValidation.MaxFileSizeBytes)
+        if (file.Length == 0 || file.Length > policy.MaxFileSizeBytes)
         {
-            return Results.BadRequest(new { error = "Fichier vide ou trop lourd (maximum 5 Mo)." });
+            return Results.BadRequest(new { error = file.Length == 0 ? "Fichier vide." : policy.TooHeavyMessage() });
         }
 
         try

--- a/Cdm/Cdm.ApiService/Endpoints/ProfileEndpoints.cs
+++ b/Cdm/Cdm.ApiService/Endpoints/ProfileEndpoints.cs
@@ -136,10 +136,12 @@ public static class ProfileEndpoints
             return Results.BadRequest(new { error = "No file provided" });
         }
 
+        // Une photo de profil suit les limites « portrait » (poids et dimensions bridés).
+        var policy = ImagePolicy.For("avatars");
         var file = request.Form.Files[0];
-        if (file.Length == 0 || file.Length > ImageValidation.MaxFileSizeBytes)
+        if (file.Length == 0 || file.Length > policy.MaxFileSizeBytes)
         {
-            return Results.BadRequest(new { error = "Fichier vide ou trop lourd (maximum 5 Mo)." });
+            return Results.BadRequest(new { error = file.Length == 0 ? "Fichier vide." : policy.TooHeavyMessage() });
         }
 
         // Store through the configured image storage (Azure Blob in prod, local in dev) so the

--- a/Cdm/Cdm.Common.Tests/Services/ImagePolicyTests.cs
+++ b/Cdm/Cdm.Common.Tests/Services/ImagePolicyTests.cs
@@ -1,0 +1,114 @@
+// -----------------------------------------------------------------------
+// <copyright file="ImagePolicyTests.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Common.Tests.Services;
+
+using Cdm.Common.Services;
+using Xunit;
+
+/// <summary>
+/// Tests des limites par usage : les portraits (photo de profil, personnage, PNJ) sont
+/// bridés en poids et en dimensions, les illustrations de campagne ou de chapitre non.
+/// </summary>
+public class ImagePolicyTests
+{
+    /// <summary>PNG minimal dont l'en-tête IHDR annonce les dimensions demandées.</summary>
+    private static byte[] PngOf(int width, int height)
+    {
+        var bytes = new byte[24];
+        byte[] signature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        signature.CopyTo(bytes, 0);
+        WriteBigEndian(bytes, 16, width);
+        WriteBigEndian(bytes, 20, height);
+        return bytes;
+    }
+
+    private static void WriteBigEndian(byte[] bytes, int offset, int value)
+    {
+        bytes[offset] = (byte)(value >> 24);
+        bytes[offset + 1] = (byte)(value >> 16);
+        bytes[offset + 2] = (byte)(value >> 8);
+        bytes[offset + 3] = (byte)value;
+    }
+
+    [Theory]
+    [InlineData("avatars")]
+    [InlineData("portraits")]
+    public void For_PortraitCategories_UsesTighterLimits(string category)
+    {
+        var policy = ImagePolicy.For(category);
+
+        Assert.Equal(ImagePolicy.Portrait, policy);
+        Assert.Equal(2 * 1024 * 1024, policy.MaxFileSizeBytes);
+        Assert.Equal(2048, policy.MaxDimension);
+    }
+
+    [Theory]
+    [InlineData("maps")]
+    [InlineData("session")]
+    [InlineData("misc")]
+    [InlineData(null)]
+    public void For_OtherCategories_LeavesDimensionsFree(string? category)
+    {
+        var policy = ImagePolicy.For(category);
+
+        Assert.Equal(5 * 1024 * 1024, policy.MaxFileSizeBytes);
+        Assert.Equal(0, policy.MaxDimension);
+    }
+
+    [Fact]
+    public void TryReadDimensions_Png_ReadsHeader()
+    {
+        Assert.True(ImageValidation.TryReadDimensions(PngOf(1920, 1080), "image/png", out var w, out var h));
+        Assert.Equal(1920, w);
+        Assert.Equal(1080, h);
+    }
+
+    [Fact]
+    public void TryValidate_PortraitTooLarge_IsRejectedWithItsSize()
+    {
+        var ok = ImageValidation.TryValidate(PngOf(4000, 3000), ImagePolicy.Portrait, out _, out _, out var error);
+
+        Assert.False(ok);
+        Assert.Contains("4000", error);
+        Assert.Contains("2048", error);
+    }
+
+    [Fact]
+    public void TryValidate_SameImageAsFreeIllustration_IsAccepted()
+    {
+        // Une carte de 4000 px reste légitime : seule la catégorie portrait est bridée.
+        var ok = ImageValidation.TryValidate(PngOf(4000, 3000), ImagePolicy.Default, out _, out _, out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryValidate_PortraitWithinLimits_IsAccepted()
+    {
+        Assert.True(ImageValidation.TryValidate(PngOf(512, 512), ImagePolicy.Portrait, out _, out _, out var error));
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void Describe_MentionsBothLimitsForPortraits()
+    {
+        var description = ImagePolicy.Portrait.Describe();
+
+        Assert.Contains("2 Mo", description);
+        Assert.Contains("2048", description);
+    }
+
+    [Fact]
+    public void Describe_OmitsDimensionsWhenFree()
+    {
+        var description = ImagePolicy.Default.Describe();
+
+        Assert.Contains("5 Mo", description);
+        Assert.DoesNotContain("px", description);
+    }
+}

--- a/Cdm/Cdm.Common/Services/ImagePolicy.cs
+++ b/Cdm/Cdm.Common/Services/ImagePolicy.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------
+// <copyright file="ImagePolicy.cs" company="ANGIBAUD Tommy">
+// Copyright (c) ANGIBAUD Tommy. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Cdm.Common.Services;
+
+/// <summary>
+/// Limites appliquées à une image selon son usage. Source unique partagée par l'API
+/// (qui les fait respecter) et par le front (qui les annonce à l'utilisateur avant
+/// l'envoi) — sans ça les deux côtés dérivent et l'utilisateur découvre la règle en
+/// se prenant une erreur.
+/// </summary>
+/// <param name="MaxFileSizeBytes">Poids maximal accepté, en octets.</param>
+/// <param name="MaxDimension">Côté maximal en pixels (largeur et hauteur), ou 0 si libre.</param>
+public sealed record ImagePolicy(int MaxFileSizeBytes, int MaxDimension)
+{
+    /// <summary>
+    /// Portraits (photo de profil, avatar de personnage, portrait de PNJ) : affichés en
+    /// petites vignettes un peu partout, donc bridés — inutile de faire transiter puis
+    /// redimensionner une photo de 12 Mpx pour une pastille de 72 px.
+    /// </summary>
+    public static readonly ImagePolicy Portrait = new(2 * 1024 * 1024, 2048);
+
+    /// <summary>
+    /// Illustrations libres (cartes, plans, lieux, visuels de campagne ou de chapitre) :
+    /// on veut pouvoir zoomer dedans, seule la taille du fichier est bornée.
+    /// </summary>
+    public static readonly ImagePolicy Default = new(5 * 1024 * 1024, 0);
+
+    /// <summary>Catégories de stockage soumises aux limites de portrait.</summary>
+    private static readonly HashSet<string> PortraitCategories =
+        new(StringComparer.OrdinalIgnoreCase) { "avatars", "portraits" };
+
+    /// <summary>Renvoie la politique applicable à une catégorie de stockage.</summary>
+    public static ImagePolicy For(string? category) =>
+        category is not null && PortraitCategories.Contains(category) ? Portrait : Default;
+
+    /// <summary>Poids maximal exprimé en mégaoctets, pour les messages.</summary>
+    public int MaxFileSizeMb => this.MaxFileSizeBytes / (1024 * 1024);
+
+    /// <summary>
+    /// Description lisible des limites, à afficher sous un champ d'envoi
+    /// (« JPEG, PNG ou WebP · 2 Mo max · 2048 × 2048 px max »).
+    /// </summary>
+    public string Describe() => this.MaxDimension > 0
+        ? $"JPEG, PNG ou WebP · {this.MaxFileSizeMb} Mo max · {this.MaxDimension} × {this.MaxDimension} px max"
+        : $"JPEG, PNG ou WebP · {this.MaxFileSizeMb} Mo max";
+
+    /// <summary>Message d'erreur quand le fichier est trop lourd.</summary>
+    public string TooHeavyMessage() => $"Image trop lourde (maximum {this.MaxFileSizeMb} Mo).";
+
+    /// <summary>Message d'erreur quand l'image dépasse les dimensions autorisées.</summary>
+    public string TooLargeMessage(int width, int height) =>
+        $"Image trop grande ({width} × {height} px) : maximum {this.MaxDimension} × {this.MaxDimension} px.";
+}

--- a/Cdm/Cdm.Infrastructure.ExternalServices/Cdm.Infrastructure.ExternalServices.csproj
+++ b/Cdm/Cdm.Infrastructure.ExternalServices/Cdm.Infrastructure.ExternalServices.csproj
@@ -15,4 +15,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- ImagePolicy : limites partagees avec le front (Cdm.Web reference aussi Cdm.Common). -->
+    <ProjectReference Include="..\Cdm.Common\Cdm.Common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Cdm/Cdm.Infrastructure.ExternalServices/Services/AzureBlobImageStorage.cs
+++ b/Cdm/Cdm.Infrastructure.ExternalServices/Services/AzureBlobImageStorage.cs
@@ -29,7 +29,8 @@ public class AzureBlobImageStorage(BlobContainerClient container, ILogger<AzureB
     /// <inheritdoc/>
     public async Task<ImageUploadResult> UploadAsync(byte[] imageBytes, string category, string entityKey, CancellationToken cancellationToken = default)
     {
-        if (!ImageValidation.TryValidate(imageBytes, out var mimeType, out var extension, out var error))
+        // Les limites dépendent de l'usage : un portrait est bridé, une carte non.
+        if (!ImageValidation.TryValidate(imageBytes, ImagePolicy.For(category), out var mimeType, out var extension, out var error))
         {
             return ImageUploadResult.Fail(error!);
         }

--- a/Cdm/Cdm.Infrastructure.ExternalServices/Services/ImageValidation.cs
+++ b/Cdm/Cdm.Infrastructure.ExternalServices/Services/ImageValidation.cs
@@ -29,6 +29,19 @@ public static class ImageValidation
     /// <param name="error">A user-facing error message (null on success).</param>
     /// <returns><c>true</c> if the image is valid.</returns>
     public static bool TryValidate(byte[]? bytes, out string mimeType, out string extension, out string? error)
+        => TryValidate(bytes, ImagePolicy.Default, out mimeType, out extension, out error);
+
+    /// <summary>
+    /// Validates raw image bytes against a usage-specific policy (portraits are capped more
+    /// tightly than free illustrations — see <see cref="ImagePolicy"/>).
+    /// </summary>
+    /// <param name="bytes">The raw image bytes.</param>
+    /// <param name="policy">The limits to enforce.</param>
+    /// <param name="mimeType">The detected MIME type (empty on failure).</param>
+    /// <param name="extension">The matching file extension including the dot (empty on failure).</param>
+    /// <param name="error">A user-facing error message (null on success).</param>
+    /// <returns><c>true</c> if the image is valid.</returns>
+    public static bool TryValidate(byte[]? bytes, ImagePolicy policy, out string mimeType, out string extension, out string? error)
     {
         mimeType = string.Empty;
         extension = string.Empty;
@@ -40,9 +53,9 @@ public static class ImageValidation
             return false;
         }
 
-        if (bytes.Length > MaxFileSizeBytes)
+        if (bytes.Length > policy.MaxFileSizeBytes)
         {
-            error = "Image trop lourde (maximum 5 Mo).";
+            error = policy.TooHeavyMessage();
             return false;
         }
 
@@ -53,10 +66,129 @@ public static class ImageValidation
             return false;
         }
 
+        // Dimensions : on lit l'en-tête plutôt que de décoder l'image (pas de dépendance
+        // graphique côté serveur). Si le format ne se laisse pas lire, on laisse passer —
+        // le poids reste borné de toute façon.
+        if (policy.MaxDimension > 0
+            && TryReadDimensions(bytes, mime, out var width, out var height)
+            && (width > policy.MaxDimension || height > policy.MaxDimension))
+        {
+            error = policy.TooLargeMessage(width, height);
+            return false;
+        }
+
         mimeType = mime;
         extension = ExtensionFor(mime);
         return true;
     }
+
+    /// <summary>
+    /// Reads an image's pixel dimensions from its header. Supports the three accepted
+    /// formats; returns <c>false</c> when the header is truncated or unrecognized.
+    /// </summary>
+    public static bool TryReadDimensions(byte[] bytes, string mimeType, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+
+        switch (mimeType)
+        {
+            case "image/png":
+                // IHDR : largeur et hauteur en big-endian aux octets 16..23.
+                if (bytes.Length < 24)
+                {
+                    return false;
+                }
+
+                width = ReadBigEndianInt32(bytes, 16);
+                height = ReadBigEndianInt32(bytes, 20);
+                return width > 0 && height > 0;
+
+            case "image/jpeg":
+                return TryReadJpegDimensions(bytes, out width, out height);
+
+            case "image/webp":
+                return TryReadWebpDimensions(bytes, out width, out height);
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryReadJpegDimensions(byte[] bytes, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+
+        // On parcourt les segments jusqu'au marqueur SOFn, qui porte les dimensions.
+        var i = 2;
+        while (i + 9 < bytes.Length)
+        {
+            if (bytes[i] != 0xFF)
+            {
+                i++;
+                continue;
+            }
+
+            var marker = bytes[i + 1];
+            var segmentLength = (bytes[i + 2] << 8) | bytes[i + 3];
+
+            // SOF0..SOF15, en excluant DHT (C4), JPG (C8) et DAC (CC) qui partagent la plage.
+            if (marker >= 0xC0 && marker <= 0xCF && marker != 0xC4 && marker != 0xC8 && marker != 0xCC)
+            {
+                height = (bytes[i + 5] << 8) | bytes[i + 6];
+                width = (bytes[i + 7] << 8) | bytes[i + 8];
+                return width > 0 && height > 0;
+            }
+
+            if (segmentLength <= 0)
+            {
+                return false;
+            }
+
+            i += 2 + segmentLength;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadWebpDimensions(byte[] bytes, out int width, out int height)
+    {
+        width = 0;
+        height = 0;
+
+        if (bytes.Length < 30)
+        {
+            return false;
+        }
+
+        // Le format du bloc dépend de la variante : VP8 (lossy), VP8L (lossless), VP8X (étendu).
+        var variant = System.Text.Encoding.ASCII.GetString(bytes, 12, 4);
+        switch (variant)
+        {
+            case "VP8 ":
+                width = ((bytes[27] << 8) | bytes[26]) & 0x3FFF;
+                height = ((bytes[29] << 8) | bytes[28]) & 0x3FFF;
+                return width > 0 && height > 0;
+
+            case "VP8L":
+                var bits = bytes[21] | (bytes[22] << 8) | (bytes[23] << 16) | (bytes[24] << 24);
+                width = (bits & 0x3FFF) + 1;
+                height = ((bits >> 14) & 0x3FFF) + 1;
+                return true;
+
+            case "VP8X":
+                width = (bytes[24] | (bytes[25] << 8) | (bytes[26] << 16)) + 1;
+                height = (bytes[27] | (bytes[28] << 8) | (bytes[29] << 16)) + 1;
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static int ReadBigEndianInt32(byte[] bytes, int offset) =>
+        (bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3];
 
     /// <summary>Detects the MIME type of an image from its magic bytes, or null if unrecognized.</summary>
     public static string? DetectMimeType(byte[] bytes)

--- a/Cdm/Cdm.Infrastructure.ExternalServices/Services/LocalImageStorage.cs
+++ b/Cdm/Cdm.Infrastructure.ExternalServices/Services/LocalImageStorage.cs
@@ -27,7 +27,8 @@ public class LocalImageStorage(ILogger<LocalImageStorage> logger) : IImageStorag
     /// <inheritdoc/>
     public async Task<ImageUploadResult> UploadAsync(byte[] imageBytes, string category, string entityKey, CancellationToken cancellationToken = default)
     {
-        if (!ImageValidation.TryValidate(imageBytes, out _, out var extension, out var error))
+        // Les limites dépendent de l'usage : un portrait est bridé, une carte non.
+        if (!ImageValidation.TryValidate(imageBytes, ImagePolicy.For(category), out _, out var extension, out var error))
         {
             return ImageUploadResult.Fail(error!);
         }

--- a/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignDetail.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignDetail.razor
@@ -162,7 +162,7 @@ else
                                     </div>
                                     <div class="form-group" style="margin-top: var(--spacing-sm);">
                                         <label class="form-label">Portrait</label>
-                                        <AppImageUpload Category="misc" CurrentUrl="@NewDndNpc.ImageUrl"
+                                        <AppImageUpload Category="portraits" CurrentUrl="@NewDndNpc.ImageUrl"
                                                         Label="Ajouter un portrait" OnUploaded="@((string url) => NewDndNpc.ImageUrl = url)" />
                                     </div>
 
@@ -252,7 +252,7 @@ else
                                     </div>
                                     <div class="form-group">
                                         <label class="form-label">Portrait</label>
-                                        <AppImageUpload Category="misc" CurrentUrl="@NewNpc.ImageUrl"
+                                        <AppImageUpload Category="portraits" CurrentUrl="@NewNpc.ImageUrl"
                                                         Label="Ajouter un portrait" OnUploaded="@((string url) => NewNpc.ImageUrl = url)" />
                                     </div>
                                     <div class="form-actions" style="margin-top: var(--spacing-sm);">

--- a/Cdm/Cdm.Web/Components/Pages/Characters/CharacterCreate.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/CharacterCreate.razor
@@ -50,7 +50,7 @@
 
             <div class="form-group">
                 <label class="form-label">@L["Characters_AvatarUrl"]</label>
-                <AppImageUpload Category="misc" CurrentUrl="@Model.AvatarUrl"
+                <AppImageUpload Category="portraits" CurrentUrl="@Model.AvatarUrl"
                                 Label="Ajouter une photo" OnUploaded="OnAvatarUploaded" />
                 <ValidationMessage For="() => Model.AvatarUrl" class="form-error" />
             </div>

--- a/Cdm/Cdm.Web/Components/Pages/Characters/CharacterEdit.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/CharacterEdit.razor
@@ -67,7 +67,7 @@ else
 
                 <div class="form-group">
                     <label class="form-label">@L["Characters_AvatarUrl"]</label>
-                    <AppImageUpload Category="misc" CurrentUrl="@Model.AvatarUrl"
+                    <AppImageUpload Category="portraits" CurrentUrl="@Model.AvatarUrl"
                                     Label="Ajouter une photo" OnUploaded="OnAvatarUploaded" />
                 </div>
             </div>

--- a/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor
@@ -51,6 +51,10 @@ else
                 <p style="font-size: var(--font-size-xs); color: var(--color-error); margin-top: var(--spacing-xs);">@AvatarError</p>
             }
 
+            <p style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin-top: var(--spacing-xs);">
+                @AvatarPolicy.Describe()
+            </p>
+
             <h3 class="card-title" style="margin-top: var(--spacing-sm);">@(UserProfile?.Nickname ?? UserName)</h3>
             <p style="color: var(--color-text-muted); font-size: var(--font-size-sm);">@UserProfile?.Email</p>
             @if (UserProfile?.CreatedAt != null)

--- a/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Profile/Profile.razor.cs
@@ -1,6 +1,7 @@
 using Cdm.Business.Abstraction.DTOs;
 using Cdm.Business.Abstraction.DTOs.Models;
 using Cdm.Business.Abstraction.DTOs.ViewModels;
+using Cdm.Common.Services;
 using Cdm.Web.Resources;
 using Cdm.Web.Services;
 using Cdm.Web.Services.ApiClients;
@@ -27,6 +28,9 @@ public partial class Profile
     private bool IsLoading = true;
     private bool IsSaving = false;
     private bool IsUploadingAvatar = false;
+
+    /// <summary>Limites de la photo de profil — partagées avec l'API via ImagePolicy.</summary>
+    private static readonly ImagePolicy AvatarPolicy = ImagePolicy.For("avatars");
     private string? AvatarError;
     private string ErrorMessage = string.Empty;
     private string SuccessMessage = string.Empty;
@@ -98,10 +102,10 @@ public partial class Profile
             return;
         }
 
-        // 2 Mo max côté serveur (avatar) ; on valide aussi ici pour un retour immédiat.
-        if (file.Size > 2 * 1024 * 1024)
+        // Mêmes limites que côté serveur (ImagePolicy), validées ici pour un retour immédiat.
+        if (file.Size > AvatarPolicy.MaxFileSizeBytes)
         {
-            AvatarError = "Image trop lourde (maximum 2 Mo).";
+            AvatarError = AvatarPolicy.TooHeavyMessage();
             return;
         }
 

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/WorldChapterNpcsPanel.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/WorldChapterNpcsPanel.razor
@@ -49,7 +49,7 @@
             </div>
             <div class="form-group" style="margin-bottom: var(--spacing-md);">
                 <label class="form-label">Portrait</label>
-                <AppImageUpload Category="misc" CurrentUrl="@NewNpc.ImageUrl"
+                <AppImageUpload Category="portraits" CurrentUrl="@NewNpc.ImageUrl"
                                 Label="Ajouter un portrait" OnUploaded="@((string url) => NewNpc.ImageUrl = url)" />
             </div>
             @if (IsDnD)
@@ -198,7 +198,7 @@
                                 </div>
                                 <div class="form-group" style="margin-bottom: var(--spacing-md);">
                                     <label class="form-label">Portrait</label>
-                                    <AppImageUpload Category="misc" CurrentUrl="@EditingNpcDraft.ImageUrl"
+                                    <AppImageUpload Category="portraits" CurrentUrl="@EditingNpcDraft.ImageUrl"
                                                     Label="Ajouter un portrait" OnUploaded="@((string url) => EditingNpcDraft.ImageUrl = url)" />
                                 </div>
                                 @if (IsDnD)

--- a/Cdm/Cdm.Web/Components/Shared/AppImageUpload.razor
+++ b/Cdm/Cdm.Web/Components/Shared/AppImageUpload.razor
@@ -1,6 +1,8 @@
 @* Upload d'image réutilisable : sélection d'un fichier, envoi via ImageApiClient,
-   aperçu + callback OnUploaded(url). Limite 5 Mo, images uniquement. *@
+   aperçu + callback OnUploaded(url). Les limites viennent d'ImagePolicy (partagée avec
+   l'API) et sont annoncées à l'utilisateur avant qu'il choisisse son fichier. *@
 @using Microsoft.AspNetCore.Components.Forms
+@using Cdm.Common.Services
 @inject Cdm.Web.Services.ApiClients.ImageApiClient ImageClient
 
 <div style="display: flex; align-items: center; gap: var(--spacing-md); flex-wrap: wrap;">
@@ -28,13 +30,17 @@
     }
 </div>
 
+<p style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin: var(--spacing-xs) 0 0;">
+    <i class="bi bi-info-circle"></i> @Policy.Describe()
+</p>
+
 @code {
     [Parameter] public string Category { get; set; } = "misc";
     [Parameter] public string? CurrentUrl { get; set; }
     [Parameter] public string Label { get; set; } = "Ajouter une image";
     [Parameter] public EventCallback<string> OnUploaded { get; set; }
 
-    private const long MaxBytes = 5 * 1024 * 1024;
+    private ImagePolicy Policy => ImagePolicy.For(Category);
 
     private string? PreviewUrl;
     private bool IsUploading;
@@ -57,9 +63,10 @@
             return;
         }
 
-        if (file.Size > MaxBytes)
+        if (file.Size > Policy.MaxFileSizeBytes)
         {
-            Error = "Image trop lourde (maximum 5 Mo).";
+            // Refus immédiat : inutile de faire transiter le fichier pour se faire jeter.
+            Error = Policy.TooHeavyMessage();
             return;
         }
 
@@ -67,7 +74,7 @@
         try
         {
             using var buffer = new MemoryStream();
-            await using (var stream = file.OpenReadStream(MaxBytes))
+            await using (var stream = file.OpenReadStream(Policy.MaxFileSizeBytes))
             {
                 await stream.CopyToAsync(buffer);
             }

--- a/Cdm/Cdm.Web/Program.cs
+++ b/Cdm/Cdm.Web/Program.cs
@@ -104,6 +104,30 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+// Les images envoyées par les utilisateurs sont servies par le stockage blob, donc depuis
+// une autre origine que le site. Sans l'ajouter à img-src, le navigateur les bloque : le
+// blob répond bien 200 mais l'utilisateur ne voit qu'une icône d'image cassée. En local le
+// problème n'apparaît pas (stockage disque servi par la même origine).
+var imageOrigin = builder.Configuration["ImageStorage:BlobServiceUri"];
+var imgSrc = "img-src 'self' data:";
+if (!string.IsNullOrWhiteSpace(imageOrigin) && Uri.TryCreate(imageOrigin, UriKind.Absolute, out var imageUri))
+{
+    imgSrc += $" {imageUri.GetLeftPart(UriPartial.Authority)}";
+}
+
+// Content-Security-Policy tuned for Blazor Server + FluentUI + external fonts/icons.
+// connect-src is restricted to same-origin (+ websockets) which limits token exfiltration
+// even if a script is injected — the main mitigation for the token stored in localStorage.
+// Follow-up: migrate the JWT to an HttpOnly cookie and drop 'unsafe-inline' from script-src via nonce/hash.
+var contentSecurityPolicy =
+    "default-src 'self'; " +
+    "script-src 'self' 'unsafe-inline'; " +
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; " +
+    "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; " +
+    imgSrc + "; " +
+    "connect-src 'self' ws: wss:; " +
+    "frame-ancestors 'none'; object-src 'none'; base-uri 'self'";
+
 // Security headers (OWASP Best Practices) — audit fix #4 (XSS mitigation) & #11
 app.Use(async (context, next) =>
 {
@@ -113,18 +137,7 @@ app.Use(async (context, next) =>
     context.Response.Headers["X-Permitted-Cross-Domain-Policies"] = "none";
     context.Response.Headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()";
 
-    // Content-Security-Policy tuned for Blazor Server + FluentUI + external fonts/icons.
-    // connect-src is restricted to same-origin (+ websockets) which limits token exfiltration
-    // even if a script is injected — the main mitigation for the token stored in localStorage.
-    // Follow-up: migrate the JWT to an HttpOnly cookie and drop 'unsafe-inline' from script-src via nonce/hash.
-    context.Response.Headers["Content-Security-Policy"] =
-        "default-src 'self'; " +
-        "script-src 'self' 'unsafe-inline'; " +
-        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; " +
-        "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; " +
-        "img-src 'self' data:; " +
-        "connect-src 'self' ws: wss:; " +
-        "frame-ancestors 'none'; object-src 'none'; base-uri 'self'";
+    context.Response.Headers["Content-Security-Policy"] = contentSecurityPolicy;
 
     await next();
 });

--- a/Cdm/Cdm.Web/appsettings.Production.json
+++ b/Cdm/Cdm.Web/appsettings.Production.json
@@ -7,5 +7,11 @@
   },
   "ApiSettings": {
     "BaseUrl": "https://app-chroniquedesmondes-api-fgd9a7dsghb8g8gh.francecentral-01.azurewebsites.net"
+  },
+  "ImageStorage": {
+    // Origine des images utilisateur, autorisée dans img-src de la CSP. Valeur publique
+    // (aucun secret) : elle vit ici comme l'URL de l'API, le site n'ayant pas d'identité
+    // managée pour lire App Configuration.
+    "BlobServiceUri": "https://stcdmchroniquemondes.blob.core.windows.net/"
   }
 }


### PR DESCRIPTION
Les images utilisateur ne s'affichaient pas en production (icone d'image cassee) alors que le blob repondait bien 200 image/jpeg : la CSP du site declarait `img-src 'self' data:`, donc le navigateur refusait toute image servie par le stockage blob, sur une autre origine. En local le probleme n'apparaissait pas, les images etant servies par la meme origine. L'entete est maintenant construit a partir d'ImageStorage:BlobServiceUri.

Limites annoncees et differenciees selon l'usage (ImagePolicy, partagee entre l'API qui les applique et le front qui les affiche) :
- portraits (photo de profil, personnage, PNJ) : 2 Mo et 2048x2048 px ;
- illustrations libres (cartes, lieux, campagnes, chapitres) : 5 Mo, pas de limite de dimensions. Les limites sont ecrites sous chaque champ d'envoi, un fichier trop lourd est refuse tout de suite sans transiter, et les dimensions sont lues dans l'en-tete PNG/JPEG/WebP cote serveur (aucune dependance graphique).

Les avatars de personnage et portraits de PNJ passent de la categorie fourre-tout "misc" a "portraits", qui porte ces limites.

12 tests ajoutes (222 verts au total).