### PR TITLE
fix(web): rend l'application utilisable sur mobile

### DIFF
--- a/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignCreate.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignCreate.razor
@@ -58,7 +58,7 @@
                 }
             </div>
 
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-md);">
+            <div class="grid-2">
                 <div class="form-group">
                     <label class="form-label">@L["Campaigns_MaxPlayers"]</label>
                     <InputNumber @bind-Value="Model.MaxPlayers" class="form-control" min="1" max="20" />

--- a/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignDetail.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignDetail.razor
@@ -132,7 +132,7 @@ else
                                     }
 
                                     @* Base NPC fields *@
-                                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-sm);">
+                                    <div class="grid-2" style="gap: var(--spacing-sm);">
                                         <div class="form-group" style="margin-bottom: 0;">
                                             <label class="form-label">Prénom</label>
                                             <InputText @bind-Value="NewDndNpc.FirstName" class="form-control" placeholder="Prénom..." />
@@ -142,7 +142,7 @@ else
                                             <InputText @bind-Value="NewDndNpc.Name" class="form-control" placeholder="Nom..." />
                                         </div>
                                     </div>
-                                    <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: var(--spacing-sm); margin-top: var(--spacing-sm);">
+                                    <div class="grid-3" style="gap: var(--spacing-sm); margin-top: var(--spacing-sm);">
                                         <div class="form-group" style="margin-bottom: 0;">
                                             <label class="form-label">Âge</label>
                                             <InputNumber @bind-Value="NewDndNpc.Age" class="form-control" placeholder="Âge..." />
@@ -172,7 +172,7 @@ else
                                             <i class="bi bi-shield-fill-check" style="margin-right: 4px;"></i>Statistiques D&amp;D
                                         </strong>
                                     </div>
-                                    <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--spacing-xs);">
+                                    <div class="collapse-sm" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--spacing-xs);">
                                         <div class="form-group" style="margin-bottom: 0;">
                                             <label class="form-label" style="font-size: 0.7rem;">Niveau</label>
                                             <InputNumber @bind-Value="NewDndNpc.Level" class="form-control form-control-sm" placeholder="1" />
@@ -190,7 +190,7 @@ else
                                             <InputNumber @bind-Value="NewDndNpc.Speed" class="form-control form-control-sm" placeholder="30" />
                                         </div>
                                     </div>
-                                    <div style="display: grid; grid-template-columns: repeat(6, 1fr); gap: var(--spacing-xs); margin-top: var(--spacing-xs);">
+                                    <div class="grid-abilities" style="margin-top: var(--spacing-xs);">
                                         <div class="form-group" style="margin-bottom: 0; text-align: center;">
                                             <label class="form-label" style="font-size: 0.7rem;">FOR</label>
                                             <InputNumber @bind-Value="NewDndNpc.Strength" class="form-control form-control-sm" placeholder="10" />
@@ -228,7 +228,7 @@ else
                             else
                             {
                                 <EditForm Model="NewNpc" OnValidSubmit="CreateNpc" FormName="npc-create">
-                                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-sm);">
+                                    <div class="grid-2" style="gap: var(--spacing-sm);">
                                         <div class="form-group" style="margin-bottom: 0;">
                                             <label class="form-label">Prénom</label>
                                             <InputText @bind-Value="NewNpc.FirstName" class="form-control" placeholder="Prénom..." />
@@ -326,7 +326,7 @@ else
                                         </div>
                                         @if (dndNpc.Strength.HasValue)
                                         {
-                                            <div style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 4px; font-size: 0.7rem; text-align: center; margin-top: 4px;">
+                                            <div class="grid-abilities" style="gap: 4px; font-size: 0.7rem; text-align: center; margin-top: 4px;">
                                                 @{
                                                     int Mod(int? v) => v.HasValue ? (v.Value - 10) / 2 : 0;
                                                     string Sign(int m) => m >= 0 ? $"+{m}" : $"{m}";

--- a/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignLootPanel.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Campaigns/CampaignLootPanel.razor
@@ -19,7 +19,7 @@
     @if (ShowForm)
     {
         <div class="cdm-card" style="background: var(--color-surface-alt); margin-bottom: var(--spacing-md);">
-            <div style="display: grid; grid-template-columns: 2fr 1fr; gap: var(--spacing-sm);">
+            <div class="grid-2-1" style="gap: var(--spacing-sm);">
                 <div class="form-group" style="margin-bottom: 0;">
                     <label class="form-label">Nom</label>
                     <input class="form-control" @bind="Draft.Name" placeholder="Épée longue, Potion de soin..." />
@@ -29,7 +29,7 @@
                     <input class="form-control" @bind="Draft.ItemType" placeholder="Arme, Potion..." />
                 </div>
             </div>
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-sm); margin-top: var(--spacing-sm);">
+            <div class="grid-2" style="gap: var(--spacing-sm); margin-top: var(--spacing-sm);">
                 <div class="form-group" style="margin-bottom: 0;">
                     <label class="form-label">Quantité</label>
                     <input type="number" min="1" class="form-control" @bind="Draft.Quantity" />

--- a/Cdm/Cdm.Web/Components/Pages/Characters/WorldCharacterDndDetail.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Characters/WorldCharacterDndDetail.razor
@@ -277,7 +277,7 @@ else
         @* ══════════════════════════════════════════════════════════ *@
         @if (ActiveTab == "competences")
         {
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-md);">
+            <div class="grid-2">
 
                 @* Skills panel *@
                 <div class="cdm-card">

--- a/Cdm/Cdm.Web/Components/Pages/Marketplace/Marketplace.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Marketplace/Marketplace.razor
@@ -11,7 +11,7 @@
 <AppPageHeader Title="Marketplace" Subtitle="Découvrez et importez le contenu partagé par la communauté" Icon="bi-shop" />
 
 @* Onglets par type d'élément *@
-<div style="display: flex; gap: var(--spacing-xs); border-bottom: 1px solid var(--color-border); margin-bottom: var(--spacing-lg);">
+<div class="tab-strip" style="margin-bottom: var(--spacing-lg);">
     <button class="mkt-tab @(ActiveTab == Tab.Items ? "active" : "")" @onclick="() => SwitchTab(Tab.Items)"><i class="bi bi-journal-bookmark"></i> Items</button>
     <button class="mkt-tab @(ActiveTab == Tab.Worlds ? "active" : "")" @onclick="() => SwitchTab(Tab.Worlds)"><i class="bi bi-globe2"></i> Mondes</button>
     <button class="mkt-tab @(ActiveTab == Tab.Campaigns ? "active" : "")" @onclick="() => SwitchTab(Tab.Campaigns)"><i class="bi bi-map"></i> Campagnes</button>

--- a/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Sessions/SessionPlayer.razor
@@ -177,7 +177,7 @@ else if (Session != null)
                         {
                             <div style="margin-top: var(--spacing-md);">
                                 <p style="font-size: var(--font-size-xs); font-weight: 600; text-transform: uppercase; color: var(--color-text-muted); letter-spacing: 0.05em; margin-bottom: var(--spacing-sm);">Caractéristiques</p>
-                                <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--spacing-sm);">
+                                <div class="grid-3" style="gap: var(--spacing-sm);">
                                     @foreach (var pair in new[] { ("strength","FOR"),("dexterity","DEX"),("constitution","CON"),("intelligence","INT"),("wisdom","SAG"),("charisma","CHA") })
                                     {
                                         @if (GameSpecificFields.TryGetValue(pair.Item1, out var val))

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/DndCharacterWizard.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/DndCharacterWizard.razor
@@ -110,7 +110,7 @@ else
                     Personnalisez l'identité de votre personnage pour ce monde. Ces informations peuvent différer de votre personnage de base.
                 </p>
 
-                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-md);">
+                <div class="grid-2">
                     <div class="form-group">
                         <label class="form-label">Prénom *</label>
                         <input class="form-control" @bind="CharacterFirstName" placeholder="Ex: Elara" />
@@ -120,7 +120,7 @@ else
                         <input class="form-control" @bind="CharacterName" placeholder="Ex: Lumenveil" />
                     </div>
                 </div>
-                <div style="display: grid; grid-template-columns: 1fr 3fr; gap: var(--spacing-md); margin-top: var(--spacing-md);">
+                <div class="grid-1-3" style="margin-top: var(--spacing-md);">
                     <div class="form-group">
                         <label class="form-label">Âge</label>
                         <input type="number" class="form-control" @bind="CharacterAge" min="0" max="10000" placeholder="Ex: 127" />
@@ -149,7 +149,7 @@ else
                 </p>
 
                 @* Niveau + Classe + Race *@
-                <div style="display: grid; grid-template-columns: 1fr 2fr 2fr; gap: var(--spacing-md); margin-bottom: var(--spacing-md);">
+                <div class="collapse-sm" style="display: grid; grid-template-columns: 1fr 2fr 2fr; gap: var(--spacing-md); margin-bottom: var(--spacing-md);">
                     <div class="form-group">
                         <label class="form-label">Niveau (1-20)</label>
                         <input type="number" class="form-control" @bind="Stats.Level" @bind:after="OnStatsChanged" min="1" max="20" placeholder="1" />
@@ -294,7 +294,7 @@ else
                 }
 
                 @* Caractéristiques *@
-                <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--spacing-md); margin-bottom: var(--spacing-md);">
+                <div class="grid-3" style="margin-bottom: var(--spacing-md);">
                     <div class="form-group" style="text-align: center;">
                         <label class="form-label" style="font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.05em;">Force</label>
                         <input type="number" class="form-control" style="text-align: center; font-weight: 700;" min="1" max="30" placeholder="—"
@@ -358,7 +358,7 @@ else
                 </div>
 
                 @* PV et CA *@
-                <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: var(--spacing-md); margin-bottom: var(--spacing-md);">
+                <div class="grid-3" style="margin-bottom: var(--spacing-md);">
                     <div class="form-group">
                         <label class="form-label">Points de vie max</label>
                         <input type="number" class="form-control" @bind="Stats.MaxHitPoints" min="1" placeholder="@GetSuggestedHp()" />
@@ -455,7 +455,7 @@ else
                         </select>
                     </div>
 
-                    <div style="display: grid; grid-template-columns: 2fr 1fr; gap: var(--spacing-sm);">
+                    <div class="grid-2-1" style="gap: var(--spacing-sm);">
                         <div class="form-group">
                             <label class="form-label">Nom de l'objet *</label>
                             <input class="form-control" @bind="NewItem.Name" placeholder="Ex: Épée courte" />
@@ -465,7 +465,7 @@ else
                             <input type="number" class="form-control" @bind="NewItem.Quantity" min="1" />
                         </div>
                     </div>
-                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-sm);">
+                    <div class="grid-2" style="gap: var(--spacing-sm);">
                         <div class="form-group">
                             <label class="form-label">Catégorie</label>
                             <select class="form-select" @bind="NewItem.Category">
@@ -487,7 +487,7 @@ else
                     </div>
                     @if (NewItem.Category == "Arme")
                     {
-                        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-sm);">
+                        <div class="grid-2" style="gap: var(--spacing-sm);">
                             <div class="form-group">
                                 <label class="form-label">Dés de dégâts</label>
                                 <input class="form-control" @bind="NewItem.DamageDice" placeholder="Ex: 1d6, 2d4+2" />
@@ -602,7 +602,7 @@ else
                         </select>
                     </div>
 
-                    <div style="display: grid; grid-template-columns: 2fr 1fr 1fr; gap: var(--spacing-sm);">
+                    <div class="collapse-sm" style="display: grid; grid-template-columns: 2fr 1fr 1fr; gap: var(--spacing-sm);">
                         <div class="form-group">
                             <label class="form-label">Nom du sort *</label>
                             <input class="form-control" @bind="NewSpell.Name" placeholder="Ex: Boule de feu" />
@@ -627,7 +627,7 @@ else
                         </div>
                     </div>
 
-                    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--spacing-sm);">
+                    <div class="grid-2" style="gap: var(--spacing-sm);">
                         <div class="form-group">
                             <label class="form-label">Dés de dégâts</label>
                             <input class="form-control" @bind="NewSpell.DamageDice" placeholder="Ex: 8d6" />

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/WorldChapterNpcsPanel.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/WorldChapterNpcsPanel.razor
@@ -78,7 +78,7 @@
                         <input type="text" class="form-control" @bind="NewNpcDndStats.ChallengeRating" placeholder="1/4, 1/2, 1, 5..." style="max-width: 100px;" />
                     </div>
                 </div>
-                <div style="display: grid; grid-template-columns: repeat(6, 1fr); gap: var(--spacing-xs); margin-bottom: var(--spacing-sm);">
+                <div class="grid-abilities" style="margin-bottom: var(--spacing-sm);">
                     @foreach (var (Label, Getter, Setter) in new (string, Func<int>, Action<int>)[] {
                         ("FOR", () => NewNpcDndStats.Strength,     v => NewNpcDndStats.Strength = v),
                         ("DEX", () => NewNpcDndStats.Dexterity,    v => NewNpcDndStats.Dexterity = v),
@@ -227,7 +227,7 @@
                                             <input type="text" class="form-control" @bind="EditingNpcDndStats.ChallengeRating" placeholder="1/4, 1, 5..." style="max-width: 80px;" />
                                         </div>
                                     </div>
-                                    <div style="display: grid; grid-template-columns: repeat(6, 1fr); gap: var(--spacing-xs); margin-bottom: var(--spacing-sm);">
+                                    <div class="grid-abilities" style="margin-bottom: var(--spacing-sm);">
                                         @foreach (var (Label, Getter, Setter) in new (string, Func<int>, Action<int>)[] {
                                             ("FOR", () => EditingNpcDndStats.Strength,     v => EditingNpcDndStats.Strength = v),
                                             ("DEX", () => EditingNpcDndStats.Dexterity,    v => EditingNpcDndStats.Dexterity = v),
@@ -298,7 +298,7 @@
                                             <span>🛡 CA @dndStats.ArmorClass</span>
                                             <span>💨 @dndStats.Speed m</span>
                                         </div>
-                                        <div style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 4px; font-size: var(--font-size-xs); text-align: center;">
+                                        <div class="grid-abilities" style="gap: 4px; font-size: var(--font-size-xs); text-align: center;">
                                             @foreach (var (Label, Val) in new[] { ("FOR", dndStats.Strength), ("DEX", dndStats.Dexterity), ("CON", dndStats.Constitution), ("INT", dndStats.Intelligence), ("SAG", dndStats.Wisdom), ("CHA", dndStats.Charisma) })
                                             {
                                                 <div style="background: var(--color-bg-tertiary, var(--color-bg-secondary)); border-radius: 4px; padding: 4px 2px;">

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/WorldMyCharacter.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/WorldMyCharacter.razor
@@ -116,7 +116,7 @@ else
                             <label class="form-label">Background</label>
                             <input type="text" class="form-control" @bind="EditDndBackground" placeholder="Ex: Soldat" />
                         </div>
-                        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--spacing-sm); margin-top: var(--spacing-sm);">
+                        <div class="grid-3" style="gap: var(--spacing-sm); margin-top: var(--spacing-sm);">
                             <div class="form-group">
                                 <label class="form-label" style="font-size: 0.7rem;">FOR</label>
                                 <input type="number" class="form-control" @bind="EditDndStrength" min="1" max="30" />
@@ -202,7 +202,7 @@ else
                         </div>
                         @if (new[] {"strength","dexterity","constitution","intelligence","wisdom","charisma"}.Any(k => GameSpecificFields.ContainsKey(k)))
                         {
-                            <div style="display: grid; grid-template-columns: repeat(6, 1fr); gap: var(--spacing-xs); margin-top: var(--spacing-sm);">
+                            <div class="grid-abilities" style="margin-top: var(--spacing-sm);">
                                 @foreach (var pair in new[] { ("strength","FOR"), ("dexterity","DEX"), ("constitution","CON"), ("intelligence","INT"), ("wisdom","SAG"), ("charisma","CHA") })
                                 {
                                     @if (GameSpecificFields.TryGetValue(pair.Item1, out var val))

--- a/Cdm/Cdm.Web/Components/Pages/Worlds/WorldOverviewPanel.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Worlds/WorldOverviewPanel.razor
@@ -45,7 +45,7 @@
 {
     <div class="cdm-card" style="margin-bottom: var(--spacing-lg);">
         <AppSectionTitle Title="Description" Icon="bi-card-text" />
-        <p style="color: var(--color-text-secondary); line-height: 1.7; white-space: pre-wrap; margin: 0;">@World.Description</p>
+        <p class="prose-measure" style="color: var(--color-text-secondary); line-height: 1.7; white-space: pre-wrap; margin: 0;">@World.Description</p>
         @if (IsOwner)
         {
             <a href="/worlds/@WorldId?section=description" class="btn btn-ghost btn-sm" style="margin-top: var(--spacing-md);">

--- a/Cdm/Cdm.Web/wwwroot/css/components/components.css
+++ b/Cdm/Cdm.Web/wwwroot/css/components/components.css
@@ -14,6 +14,20 @@
   flex-wrap: wrap;
 }
 
+/* Barre d'onglets horizontale : sur petit ecran les onglets ne rentrent pas et
+   `white-space: nowrap` les faisait deborder sans moyen de les atteindre. Ils
+   defilent lateralement, comme la barre contextuelle mobile du shell. */
+.tab-strip {
+  display: flex;
+  gap: var(--spacing-xs);
+  border-bottom: 1px solid var(--color-border);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.tab-strip::-webkit-scrollbar { display: none; }
+
 .campaign-tab-btn {
   display: inline-flex;
   align-items: center;
@@ -1014,6 +1028,7 @@ textarea.form-control {
   .hide-mobile { display: none !important; }
   .cdm-card-grid { grid-template-columns: 1fr; }
 
+
   /* Cards grid : 1 seule colonne sur mobile étroit */
   .cards-grid {
     grid-template-columns: 1fr;
@@ -1386,6 +1401,33 @@ textarea.form-control {
   gap: var(--spacing-md);
 }
 
+/* ============================================
+   GRILLES RESPONSIVES (utilitaires)
+   ============================================
+   Remplacent les `style="display:grid; grid-template-columns: ..."` en dur qui
+   restaient a N colonnes quel que soit l'ecran : a 375 px, deux champs cote a cote
+   tombaient sous 130 px et les six caracteristiques D&D sous 50 px. */
+.grid-2,
+.grid-3,
+.grid-2-1,
+.grid-1-3,
+.grid-abilities {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.grid-2  { grid-template-columns: 1fr 1fr; }
+.grid-3  { grid-template-columns: repeat(3, 1fr); }
+.grid-2-1 { grid-template-columns: 2fr 1fr; }
+.grid-1-3 { grid-template-columns: 1fr 3fr; }
+
+/* Six caracteristiques (FOR/DEX/CON/INT/SAG/CHA) : jamais empilees, mais reparties
+   sur deux rangees de trois des que la largeur ne suit plus. */
+.grid-abilities {
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--spacing-xs);
+}
+
 .form-error {
   font-size: var(--font-size-xs);
   color: var(--color-error);
@@ -1418,6 +1460,29 @@ textarea.form-control {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--spacing-md);
+}
+
+/* Toutes les grilles a colonnes fixes s'effondrent sur petit ecran. */
+@media (max-width: 640px) {
+  .form-two-col,
+  .info-grid,
+  .grid-2,
+  .grid-3,
+  .grid-2-1,
+  .grid-1-3 {
+    grid-template-columns: 1fr;
+  }
+
+  .grid-abilities {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  /* Grilles aux proportions trop specifiques pour meriter leur propre classe : elles
+     gardent leur gabarit en ligne sur grand ecran et s'empilent ici. Le !important est
+     necessaire pour l'emporter sur l'attribut style. */
+  .collapse-sm {
+    grid-template-columns: 1fr !important;
+  }
 }
 
 .info-label {
@@ -4331,4 +4396,52 @@ textarea.form-control {
 .combat-participant-avatar-sm,
 .topbar-avatar {
   border-radius: var(--radius-md);
+}
+
+/* ============================================
+   AJUSTEMENTS RESPONSIVES — A GARDER EN FIN DE FICHIER
+   ============================================
+   Une media query n'ajoute aucune specificite : une regle placee avant la definition
+   du composant qu'elle vise est simplement ecrasee par celle-ci. C'est ce qui rendait
+   muet le `.info-grid { grid-template-columns: 1fr }` du bloc mobile situe plus haut,
+   alors que `.info-grid` est defini apres lui. Ces surcharges restent donc ici, en
+   dernier. */
+@media (max-width: 768px) {
+  /* Mises en page a colonne laterale fixe : elles reservaient de 280 a 360 px au
+     panneau lateral, ne laissant que quelques dizaines de pixels au contenu
+     principal sur un telephone (mesure : 34 px pour la colonne de droite du profil). */
+  .profile-layout,
+  .combat-player-body,
+  .initiative-preview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* Empilee, la vue MJ doit defiler : en trois colonnes chaque panneau gerait son
+     propre defilement, d'ou le overflow:hidden du parent qui, une fois empile,
+     rendrait le bas de l'ecran inatteignable. */
+  .session-gm-body {
+    overflow: auto;
+  }
+
+  .session-chapters-sidebar,
+  .session-participants-sidebar {
+    border-right: none;
+    border-bottom: 1px solid var(--color-border);
+  }
+}
+
+/* ============================================
+   CONFORT DE LECTURE SUR GRAND ECRAN
+   ============================================
+   Rien ne bornait la largeur du texte suivi : sur un ecran 1920, la description d'un
+   monde s'etalait sur 1791 px, soit ~250 caracteres par ligne (l'oeil en suit
+   confortablement 60 a 80). On borne les blocs de prose ; les grilles de cartes, elles,
+   gardent toute la largeur puisqu'elles s'en servent pour afficher plus de colonnes. */
+.chapter-preview,
+.prose-measure {
+  max-width: 78ch;
 }

--- a/Cdm/Cdm.Web/wwwroot/css/layouts/layout-shell.css
+++ b/Cdm/Cdm.Web/wwwroot/css/layouts/layout-shell.css
@@ -413,6 +413,11 @@
   flex: 1;
   min-height: 100vh;
   transition: margin-left var(--duration-normal) var(--ease-in-out);
+  /* Un enfant flex vaut min-width:auto par défaut : il refuse alors de rétrécir sous la
+     largeur intrinsèque de son contenu. Un titre long ou une rangée de boutons suffisait
+     à pousser toute la page au-delà du viewport (mesuré : 909 px de large sur un écran de
+     375 px). C'est LA cause des débordements horizontaux sur mobile. */
+  min-width: 0;
 }
 
 /* Marges dynamiques selon l'état des sidebars */
@@ -436,12 +441,16 @@
   top: 0;
   z-index: var(--z-topbar);
   flex-shrink: 0;
+  min-width: 0;
 }
 
 .topbar-left {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
+  /* Le fil d'Ariane cède la place aux actions plutôt que de les pousser hors écran. */
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* Topbar breadcrumb */
@@ -477,6 +486,8 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
+  /* Notifications, thème et avatar restent toujours atteignables. */
+  flex-shrink: 0;
 }
 
 .topbar-icon-btn {
@@ -608,6 +619,8 @@
   top: calc(100% + 8px);
   right: 0;
   width: 340px;
+  /* Ancre a droite : sur un petit telephone les 340 px depassaient par la gauche. */
+  max-width: calc(100vw - var(--spacing-md) * 2);
   max-height: 420px;
   background: var(--color-surface-primary);
   border: 1px solid var(--color-border);
@@ -760,6 +773,9 @@
   padding: var(--spacing-xl);
   overflow-y: auto;
   background: var(--color-bg-primary);
+  /* Même raison que .app-main-wrapper : le contenu se plie au viewport, il ne l'étire pas. */
+  min-width: 0;
+  max-width: 100%;
 }
 
 /* Combat pages need full-height layout without outer scroll */
@@ -767,6 +783,21 @@
 .app-main-wrapper:has(.combat-player-shell) {
   height: 100vh;
   overflow: hidden;
+}
+
+/* Sur mobile les panneaux de combat s'empilent : la page doit reprendre son
+   defilement normal, sinon tout ce qui depasse la hauteur d'ecran est perdu. */
+@media (max-width: 768px) {
+  .app-main-wrapper:has(.combat-gm-shell),
+  .app-main-wrapper:has(.combat-player-shell) {
+    height: auto;
+    overflow: visible;
+  }
+
+  .app-content:has(.combat-gm-shell),
+  .app-content:has(.combat-player-shell) {
+    overflow: visible;
+  }
 }
 
 .app-content:has(.combat-gm-shell),


### PR DESCRIPTION
Cause principale : .app-main-wrapper est un enfant flex, donc min-width:auto par defaut, et refusait de retrecir sous la largeur intrinseque de son contenu. Un titre long ou une rangee de boutons suffisait a etirer toute la page — mesure sur un ecran de 375 px : le contenu faisait 909 px de large, soit 534 px de defilement horizontal sur le detail d'un monde. Trois declarations (min-width:0 sur le wrapper et le contenu, topbar qui laisse le fil d'Ariane retrecir plutot que pousser les actions dehors) suppriment le debordement sur l'ensemble des ecrans.

Une media query n'ajoute aucune specificite : le bloc mobile place en haut de components.css etait ecrase par les composants definis plus bas. Son `.info-grid { grid-template-columns: 1fr }` n'avait donc jamais rien fait. Les surcharges responsives vivent desormais en fin de fichier, la ou elles l'emportent.

Grilles : 23 gabarits ecrits en dur dans les styles en ligne passent a des classes utilitaires (.grid-2, .grid-3, .grid-2-1, .grid-1-3, .grid-abilities) qui s'effondrent sous 640 px ; les six caracteristiques D&D passent de six colonnes de 50 px a deux rangees de trois. Les mises en page a colonne laterale fixe (profil, vue MJ, combat joueur) s'empilent sous 768 px — la vue MJ retrouve son defilement, sinon le bas de l'ecran devenait inatteignable. La barre d'onglets du marketplace defile lateralement au lieu de deborder.

Desktop : la description d'un monde s'etalait sur 1791 px en 1920, soit ~250 caracteres par ligne. Les blocs de texte suivi sont bornes a 78ch ; les grilles de cartes gardent toute la largeur.

Verifie au navigateur sur 18 ecrans en 320, 375, 768, 1280 et 1920 px : plus aucun debordement horizontal ni colonne ecrasee. 222 tests verts.