### PR TITLE
feat(seo): favicon logo, metadonnees et robots.txt/sitemap

### DIFF
--- a/Cdm/Cdm.Web/Components/App.razor
+++ b/Cdm/Cdm.Web/Components/App.razor
@@ -4,9 +4,25 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Chronique des Mondes — Votre outil de gestion de campagnes de jeu de rôle" />
+    <meta name="description" content="Chronique des Mondes : l'outil pour créer et gérer vos campagnes de jeu de rôle — mondes, personnages, chapitres, PNJ, sessions et combats en ligne." />
     <base href="/" />
-    <title>Chronique des Mondes</title>
+    <title>Chronique des Mondes — Gérez vos campagnes de jeu de rôle</title>
+
+    <!-- SEO / réseaux sociaux (Open Graph + Twitter Card). L'image est le logo carré :
+         le grand blason illustré rend bien en carte de partage, contrairement au favicon. -->
+    <meta name="theme-color" content="#0f0f1e" />
+    <link rel="canonical" href="https://chroniques-des-mondes.fr/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Chronique des Mondes" />
+    <meta property="og:title" content="Chronique des Mondes — Gérez vos campagnes de jeu de rôle" />
+    <meta property="og:description" content="Créez et gérez vos campagnes de jeu de rôle : mondes, personnages, chapitres, PNJ, sessions et combats en ligne." />
+    <meta property="og:image" content="https://chroniques-des-mondes.fr/images/logo.png" />
+    <meta property="og:url" content="https://chroniques-des-mondes.fr/" />
+    <meta property="og:locale" content="fr_FR" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Chronique des Mondes" />
+    <meta name="twitter:description" content="Créez et gérez vos campagnes de jeu de rôle en ligne." />
+    <meta name="twitter:image" content="https://chroniques-des-mondes.fr/images/logo.png" />
 
     <!-- Bootstrap Icons -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
@@ -25,9 +41,12 @@
     <link rel="stylesheet" href="@Assets["Cdm.Web.styles.css"]" />
 
     <ImportMap />
-    <link rel="icon" type="image/svg+xml" href="/images/LogoCdm.svg" />
-    <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <link rel="icon" type="image/png" href="favicon.png" />
+    <!-- Favicon = le logo de l'application. On sert le logo carré (blason) plutôt que
+         LogoCdm.svg (877×500, format large qui se retrouve en « boîte aux lettres »
+         dans l'onglet). favicon.ico reste en repli pour les vieux navigateurs. -->
+    <link rel="icon" type="image/png" href="/images/logo.png" sizes="any" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/images/logo.png" />
     <HeadOutlet />
 </head>
 

--- a/Cdm/Cdm.Web/wwwroot/robots.txt
+++ b/Cdm/Cdm.Web/wwwroot/robots.txt
@@ -1,0 +1,25 @@
+# Chronique des Mondes — robots.txt
+# L'application est presque entierement derriere authentification : les pages privees
+# redirigent vers /login pour un visiteur non connecte, il n'y a donc rien a y indexer.
+# On laisse crawler les pages publiques et on exclut explicitement les URL a jeton
+# (jamais dans un index) et l'espace connecte (economie de budget de crawl).
+
+User-agent: *
+Allow: /
+
+# Pages a usage unique / porteuses de jeton — ne doivent jamais etre indexees
+Disallow: /confirm-email
+Disallow: /reset-password
+
+# Espace connecte (contenu prive, inaccessible sans compte)
+Disallow: /worlds
+Disallow: /characters
+Disallow: /campaigns
+Disallow: /sessions
+Disallow: /codex
+Disallow: /marketplace
+Disallow: /profile
+Disallow: /settings
+Disallow: /notifications
+
+Sitemap: https://chroniques-des-mondes.fr/sitemap.xml

--- a/Cdm/Cdm.Web/wwwroot/sitemap.xml
+++ b/Cdm/Cdm.Web/wwwroot/sitemap.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Chronique des Mondes — sitemap des pages publiques. L'espace connecte n'y figure
+     pas : son contenu est prive et redirige vers /login. URL canonique = domaine apex. -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://chroniques-des-mondes.fr/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://chroniques-des-mondes.fr/login</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://chroniques-des-mondes.fr/register</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://chroniques-des-mondes.fr/forgot-password</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Favicon : l'onglet affichait une icone generique. Le head referencait LogoCdm.svg (877x500, format large qui se retrouve letterboxe et illisible en carre) et favicon.png ; on sert desormais le logo carre /images/logo.png comme favicon et apple-touch-icon, favicon.ico restant en repli.

SEO : ajout des metadonnees Open Graph / Twitter Card (titre, description, image = logo, locale fr_FR), d'un canonical vers le domaine apex, du theme-color et d'un titre plus descriptif.

robots.txt + sitemap.xml : l'application etant presque entierement derriere authentification, seules les pages publiques (accueil, login, register, forgot-password) sont indexables. robots.txt les autorise, exclut les URL a jeton (confirm-email, reset-password) et l'espace connecte, et pointe vers le sitemap. Servis et verifies en local (200, bons content-types).