### PR TITLE
fix(infra): rend le domaine racine joignable en HTTPS

### DIFF
--- a/Cdm/Cdm.ApiService/appsettings.json
+++ b/Cdm/Cdm.ApiService/appsettings.json
@@ -14,7 +14,11 @@
     "FromAddress": "DoNotReply@67ee7f20-7b4b-4ba6-8d80-96458ff3392e.azurecomm.net"
   },
   "App": {
-    "WebBaseUrl": "https://www.chroniques-des-mondes.fr"
+    // URL canonique du front (celle déclarée dans <link rel="canonical"> et le sitemap).
+    // Les liens des e-mails (reset de mot de passe, invitations) partent d'ici : les faire
+    // pointer sur le même hôte que le canonical évite un domaine différent dans la boîte
+    // mail et sur le site.
+    "WebBaseUrl": "https://chroniques-des-mondes.fr"
   },
   "ConnectionStrings": {
     "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=ChroniqueDesMondesDb;Integrated Security=True;MultipleActiveResultSets=true",

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,6 +11,7 @@ au coup par coup ni du portail.
 |---------|------|
 | `main.bicep` | Description complète des ressources (paramétrée, rien en dur). |
 | `main.bicepparam` | Valeurs de l'environnement de production. |
+| `modules/hostname-ssl-binding.bicep` | Re-liaison d'un nom d'hôte en SNI SSL une fois son certificat émis. |
 
 ## Ressources décrites
 
@@ -24,6 +25,49 @@ au coup par coup ni du portail.
 - **Key Vault** `kv-chronique-mondes` (RBAC) + attributions de rôles :
   - dev humain → **Key Vault Secrets Officer**
   - identité managée de l'API → **Key Vault Secrets User**
+- **Domaines personnalisés** de la Web App : `chroniques-des-mondes.fr` et
+  `www.chroniques-des-mondes.fr`, chacun avec son **certificat managé App Service**
+  (gratuit, renouvellement automatique) lié en **SNI SSL**
+
+## Domaine public
+
+Le site est servi sur **`https://chroniques-des-mondes.fr`** (et `www.…`). Le domaine est
+enregistré chez **OVH**, dont les serveurs DNS (`ns110.ovh.net` / `dns110.ovh.net`) font
+autorité. La zone doit contenir :
+
+| Enregistrement | Type | Valeur | Rôle |
+|----------------|------|--------|------|
+| `@` | `A` | IP entrante de la Web App (`az webapp show … --query inboundIpAddress`) | Domaine racine → App Service |
+| `asuid` | `TXT` | `customDomainVerificationId` de la Web App | Preuve de propriété de la racine |
+| `www` | `CNAME` | `app-chronique-des-mondes-web.azurewebsites.net` | Sous-domaine www → App Service |
+| `asuid.www` | `TXT` | même `customDomainVerificationId` | Preuve de propriété du www |
+
+> ⚠️ L'IP entrante d'un App Service peut changer si l'app est supprimée/recréée ou déplacée
+> de plan. Après une telle opération, remettre l'enregistrement `A` à jour chez OVH, sinon
+> la racine tombe (le `www`, en CNAME, suit automatiquement).
+
+**Le point qui casse tout et ne se voit pas :** un nom d'hôte peut être lié à l'app *sans*
+certificat. Le DNS répond, mais `httpsOnly` redirige vers HTTPS et le navigateur refuse la
+connexion — le domaine paraît mort alors que l'app tourne. Vérification :
+
+```bash
+az webapp config hostname list -g rg-chronique-des-mondes-app \
+  --webapp-name app-chronique-des-mondes-web -o table   # sslState doit valoir SniEnabled partout
+```
+
+Réparation (le certificat managé existe déjà mais n'est pas lié) :
+
+```bash
+az webapp config ssl bind -g rg-chronique-des-mondes-app -n app-chronique-des-mondes-web \
+  --certificate-thumbprint <empreinte> --ssl-type SNI
+```
+
+S'il n'existe pas encore :
+
+```bash
+az webapp config ssl create -g rg-chronique-des-mondes-app \
+  --name app-chronique-des-mondes-web --hostname chroniques-des-mondes.fr
+```
 
 ## Ce qui est volontairement EXCLU du Bicep
 
@@ -37,9 +81,8 @@ au coup par coup ni du portail.
     --value "<chaîne de connexion ACS>"
   ```
 
-- **Les domaines personnalisés + certificats managés** (`chroniques-des-mondes.fr`, `www.…`) :
-  désactivés par défaut (`configureCustomDomains = false`) car ils exigent que le DNS pointe
-  déjà vers la Web App. À activer une fois l'enregistrement DNS et la vérification en place.
+- **La zone DNS elle-même** : elle vit chez OVH, hors d'Azure. Le Bicep décrit les liaisons
+  et les certificats côté App Service, jamais les enregistrements DNS.
 
 - **Les app settings des App Services** (`APPLICATIONINSIGHTS_CONNECTION_STRING`, `ConnectionStrings`,
   références Key Vault…) : gérés par le pipeline de déploiement, jamais par le Bicep, pour éviter
@@ -54,7 +97,8 @@ au coup par coup ni du portail.
 |-----------|--------------------------|-----------|
 | `assignKeyVaultRoles` | `false` — les rôles existent déjà | `true` |
 | `logAnalyticsWorkspaceResourceId` | workspace `DefaultWorkspace-…-PAR` existant | `''` → crée un workspace dédié |
-| `configureCustomDomains` | `false` | `true` une fois le DNS en place |
+| `configureCustomDomains` | `true` — la prod sert bien les deux domaines | `false` tant que le DNS ne pointe pas encore vers l'app |
+| `configureManagedCertificates` | `true` — certificats managés liés en SNI SSL | `false` pour lier les domaines sans HTTPS (transitoire uniquement) |
 
 ## Déploiement
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -97,6 +97,9 @@ param customDomainRoot string = 'chroniques-des-mondes.fr'
 @description('Sous-domaine www de la Web App.')
 param customDomainWww string = 'www.chroniques-des-mondes.fr'
 
+@description('Émettre les certificats managés App Service (gratuits) pour les domaines personnalisés et les lier en SNI SSL. Sans ça, taper le domaine dans le navigateur échoue en erreur de certificat.')
+param configureManagedCertificates bool = true
+
 // --- Journalisation / observabilité ------------------------------------------
 @description('Resource ID d\'un workspace Log Analytics existant à lier à Application Insights. Laisser vide pour en créer un dédié.')
 param logAnalyticsWorkspaceResourceId string = ''
@@ -342,14 +345,21 @@ resource webApp 'Microsoft.Web/sites@2024-11-01' = {
 }
 
 // --- Domaines personnalisés + certificats managés (optionnels) ---------------
-// Nécessitent que le DNS (A/CNAME + verification) pointe déjà vers la Web App.
+// Nécessitent que le DNS pointe déjà vers la Web App :
+//   - `www`  : CNAME vers <webAppName>.azurewebsites.net + TXT asuid.www
+//   - racine : A vers l'IP entrante de l'app             + TXT asuid
+// La séquence est en trois temps parce qu'ARM ne sait pas la faire en un seul :
+//   1. liaison du nom d'hôte SANS SSL (prérequis à l'émission du certificat) ;
+//   2. certificat managé App Service (gratuit, renouvelé automatiquement) ;
+//   3. re-liaison du même nom d'hôte en SniEnabled avec l'empreinte (module).
+// Sauter l'étape 3 laisse le domaine joignable en HTTP mais cassé en HTTPS —
+// et comme `httpsOnly` redirige tout vers HTTPS, le site devient inaccessible.
 resource webAppWwwBinding 'Microsoft.Web/sites/hostNameBindings@2024-11-01' = if (configureCustomDomains) {
   parent: webApp
   name: customDomainWww
   properties: {
     siteName: webAppName
     hostNameType: 'Verified'
-    sslState: 'SniEnabled'
   }
 }
 
@@ -359,6 +369,56 @@ resource webAppRootBinding 'Microsoft.Web/sites/hostNameBindings@2024-11-01' = i
   properties: {
     siteName: webAppName
     hostNameType: 'Verified'
+  }
+}
+
+resource wwwCertificate 'Microsoft.Web/certificates@2024-11-01' = if (configureCustomDomains && configureManagedCertificates) {
+  name: '${customDomainWww}-${webAppName}'
+  location: location
+  properties: {
+    canonicalName: customDomainWww
+    serverFarmId: appServicePlan.id
+    domainValidationMethod: 'cname-delegation'
+  }
+  dependsOn: [
+    webAppWwwBinding
+  ]
+}
+
+// La racine n'a pas de CNAME (uniquement un A) : la validation passe par le
+// jeton HTTP servi par l'app, pas par délégation CNAME.
+resource rootCertificate 'Microsoft.Web/certificates@2024-11-01' = if (configureCustomDomains && configureManagedCertificates) {
+  name: '${customDomainRoot}-${webAppName}'
+  location: location
+  properties: {
+    canonicalName: customDomainRoot
+    serverFarmId: appServicePlan.id
+    domainValidationMethod: 'http-token'
+  }
+  dependsOn: [
+    webAppRootBinding
+  ]
+}
+
+module wwwSslBinding 'modules/hostname-ssl-binding.bicep' = if (configureCustomDomains && configureManagedCertificates) {
+  name: 'ssl-binding-www'
+  params: {
+    webAppName: webAppName
+    hostName: customDomainWww
+    // Le module porte la même condition que le certificat : il n'est évalué que
+    // lorsque celui-ci existe.
+    #disable-next-line BCP318
+    certificateThumbprint: wwwCertificate.properties.thumbprint
+  }
+}
+
+module rootSslBinding 'modules/hostname-ssl-binding.bicep' = if (configureCustomDomains && configureManagedCertificates) {
+  name: 'ssl-binding-root'
+  params: {
+    webAppName: webAppName
+    hostName: customDomainRoot
+    #disable-next-line BCP318
+    certificateThumbprint: rootCertificate.properties.thumbprint
   }
 }
 
@@ -463,3 +523,4 @@ output appInsightsConnectionString string = appInsights.properties.ConnectionStr
 output storageBlobEndpoint string = storageAccount.properties.primaryEndpoints.blob
 output blobImagesContainer string = imagesContainerName
 output appConfigEndpoint string = appConfig.properties.endpoint
+output publicSiteUrl string = configureCustomDomains ? 'https://${customDomainRoot}' : 'https://${webApp.properties.defaultHostName}'

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -20,5 +20,9 @@ param logAnalyticsWorkspaceResourceId = '/subscriptions/065f4efd-7537-4678-9475-
 // Mettre à true pour un déploiement from-zero.
 param assignKeyVaultRoles = false
 
-// Domaines personnalisés : désactivés par défaut (à activer une fois le DNS en place)
-param configureCustomDomains = false
+// Domaines personnalisés : la prod sert bien `chroniques-des-mondes.fr` et `www.…`,
+// certificats managés App Service liés en SNI SSL. Mettre à false sur un environnement
+// neuf tant que le DNS ne pointe pas encore vers la Web App (l'émission du certificat
+// échouerait).
+param configureCustomDomains = true
+param configureManagedCertificates = true

--- a/infra/modules/hostname-ssl-binding.bicep
+++ b/infra/modules/hostname-ssl-binding.bicep
@@ -1,0 +1,33 @@
+// =============================================================================
+// Liaison SNI SSL d'un nom d'hôte personnalisé sur une Web App
+// -----------------------------------------------------------------------------
+// Module séparé à cause d'une dépendance circulaire côté ARM : un certificat
+// managé App Service ne peut être émis que si le nom d'hôte est DÉJÀ lié à
+// l'app (sans SSL), alors que la liaison SSL exige l'empreinte du certificat.
+// `main.bicep` crée donc la liaison nue, puis le certificat, puis appelle ce
+// module pour repasser sur la même liaison en SniEnabled.
+// =============================================================================
+
+@description('Nom de la Web App portant le nom d\'hôte.')
+param webAppName string
+
+@description('Nom d\'hôte personnalisé à lier (ex. www.exemple.fr).')
+param hostName string
+
+@description('Empreinte du certificat managé à lier en SNI SSL.')
+param certificateThumbprint string
+
+resource webApp 'Microsoft.Web/sites@2024-11-01' existing = {
+  name: webAppName
+}
+
+resource sslBinding 'Microsoft.Web/sites/hostNameBindings@2024-11-01' = {
+  parent: webApp
+  name: hostName
+  properties: {
+    siteName: webAppName
+    hostNameType: 'Verified'
+    sslState: 'SniEnabled'
+    thumbprint: certificateThumbprint
+  }
+}


### PR DESCRIPTION
Le nom d'hote `chroniques-des-mondes.fr` etait lie a la Web App mais sans certificat : le DNS repondait, `httpsOnly` redirigeait vers HTTPS et le navigateur refusait la connexion. Taper le domaine dans la barre d'adresse menait donc a une page d'erreur alors que l'app tournait (seul `www.` marchait).

Le certificat manage de la racine existait deja : il a ete lie en SNI SSL (`az webapp config ssl bind`). Le Bicep decrit desormais la sequence complete — liaison nue, certificat manage, re-liaison SniEnabled via un module, l'ordre impose par ARM — pour qu'un environnement recree de zero ne retombe pas dans le meme angle mort.

Cote code, `App:WebBaseUrl` passe sur la racine pour que les liens des e-mails pointent sur le meme hote que le `<link rel="canonical">` et le sitemap.