### PR TITLE
feat(seo): page d'accueil publique indexable + canonical par URL

### DIFF
--- a/Cdm/Cdm.Web/Components/App.razor
+++ b/Cdm/Cdm.Web/Components/App.razor
@@ -1,3 +1,5 @@
+@inject NavigationManager Nav
+
 <!DOCTYPE html>
 <html lang="fr" data-theme="dark">
 
@@ -11,7 +13,7 @@
     <!-- SEO / réseaux sociaux (Open Graph + Twitter Card). L'image est le logo carré :
          le grand blason illustré rend bien en carte de partage, contrairement au favicon. -->
     <meta name="theme-color" content="#0f0f1e" />
-    <link rel="canonical" href="https://chroniques-des-mondes.fr/" />
+    <link rel="canonical" href="@CanonicalUrl" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Chronique des Mondes" />
     <meta property="og:title" content="Chronique des Mondes — Gérez vos campagnes de jeu de rôle" />
@@ -19,7 +21,7 @@
     <meta property="og:image" content="https://chroniques-des-mondes.fr/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:url" content="https://chroniques-des-mondes.fr/" />
+    <meta property="og:url" content="@CanonicalUrl" />
     <meta property="og:locale" content="fr_FR" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Chronique des Mondes" />
@@ -67,3 +69,26 @@
 </body>
 
 </html>
+
+@code {
+    // Domaine canonique du site. Les pages sont servies indifféremment sur l'apex et
+    // sur `www.` : sans URL absolue figée sur un seul hôte, chaque page existerait en
+    // double aux yeux des moteurs.
+    private const string CanonicalOrigin = "https://chroniques-des-mondes.fr";
+
+    // App.razor est rendu en SSR statique (le `prerender: false` ne s'applique qu'à
+    // l'arbre du routeur) : `Nav.Uri` porte donc bien l'URL réellement demandée. Le
+    // canonical était codé en dur sur `/`, ce qui revenait à déclarer /login, /register
+    // et /forgot-password comme des doublons de l'accueil — en contradiction directe
+    // avec le sitemap qui demande leur indexation.
+    private string CanonicalUrl
+    {
+        get
+        {
+            // La query string ne participe pas à l'identité de la page, et elle peut
+            // porter un jeton (confirm-email, reset-password) : jamais dans un canonical.
+            var path = new Uri(Nav.Uri).AbsolutePath;
+            return path == "/" ? $"{CanonicalOrigin}/" : CanonicalOrigin + path.TrimEnd('/');
+        }
+    }
+}

--- a/Cdm/Cdm.Web/Components/Layout/MainLayout.razor
+++ b/Cdm/Cdm.Web/Components/Layout/MainLayout.razor
@@ -5,7 +5,7 @@
     <!-- SIDEBAR PRINCIPALE -->
     <aside class="app-sidebar @(IsCollapsed ? "collapsed" : "") @(IsMobileOpen ? "mobile-open" : "") @ContextThemeClass" id="main-sidebar">
         <div class="sidebar-header">
-            <a href="/" class="sidebar-brand d-flex align-items-center gap-sm text-decoration-none">
+            <a href="/dashboard" class="sidebar-brand d-flex align-items-center gap-sm text-decoration-none">
                 <img src="/images/LogoCdm.svg" alt="CDM" class="sidebar-logo" />
                 <span class="sidebar-brand-text">@L["AppName"]</span>
             </a>
@@ -14,8 +14,8 @@
         <nav class="sidebar-nav" aria-label="Navigation principale">
             <span class="nav-section-label">@L["Nav_Navigation"]</span>
 
-            <a href="/" class="nav-item @ActiveClass("/")" title="@L["Nav_Home"]"
-               aria-current="@(ActiveClass("/") == "active" ? "page" : null)">
+            <a href="/dashboard" class="nav-item @ActiveClass("/dashboard")" title="@L["Nav_Home"]"
+               aria-current="@(ActiveClass("/dashboard") == "active" ? "page" : null)">
                 <i class="bi bi-house nav-icon"></i>
                 <span class="nav-label">@L["Nav_Home"]</span>
             </a>

--- a/Cdm/Cdm.Web/Components/Layout/MainLayout.razor.cs
+++ b/Cdm/Cdm.Web/Components/Layout/MainLayout.razor.cs
@@ -311,9 +311,6 @@ public partial class MainLayout : IAsyncDisposable
             ? "/" + currentUri[baseUri.Length..].TrimStart('/')
             : "/";
 
-        if (href == "/")
-            return path == "/" ? "active" : string.Empty;
-
         return path.StartsWith(href, StringComparison.OrdinalIgnoreCase) ? "active" : string.Empty;
     }
 

--- a/Cdm/Cdm.Web/Components/Pages/Auth/ConfirmEmail.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Auth/ConfirmEmail.razor
@@ -25,7 +25,7 @@
             Votre adresse email est confirmée. Merci !
         </div>
         <div class="auth-footer-link">
-            <a href="/">Accéder à mon tableau de bord</a>
+            <a href="/dashboard">Accéder à mon tableau de bord</a>
         </div>
     }
     else

--- a/Cdm/Cdm.Web/Components/Pages/Auth/Login.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Auth/Login.razor.cs
@@ -27,7 +27,7 @@ public partial class Login
     {
         var state = await AuthProvider.GetAuthenticationStateAsync();
         if (state.User.Identity?.IsAuthenticated == true)
-            Nav.NavigateTo("/");
+            Nav.NavigateTo("/dashboard");
     }
 
     private async Task HandleLogin()
@@ -46,9 +46,11 @@ public partial class Login
                     response.UserId, response.Email, response.Nickname, response.Token,
                     response.RefreshToken, response.RefreshTokenExpiry, response.EmailConfirmed);
 
+                // `/` est désormais la page d'accueil publique : après connexion on
+                // envoie sur le tableau de bord, pas sur la page de présentation.
                 var target = !string.IsNullOrEmpty(ReturnUrl)
                     ? Uri.UnescapeDataString(ReturnUrl)
-                    : "/";
+                    : "/dashboard";
                 Nav.NavigateTo(target);
             }
             else

--- a/Cdm/Cdm.Web/Components/Pages/Auth/Register.razor.cs
+++ b/Cdm/Cdm.Web/Components/Pages/Auth/Register.razor.cs
@@ -51,7 +51,7 @@ public partial class Register
                         $"Bienvenue, {response.Nickname} ! Votre compte a bien été créé.",
                         "Inscription réussie");
 
-                    Nav.NavigateTo("/");
+                    Nav.NavigateTo("/dashboard");
                     return;
                 }
 

--- a/Cdm/Cdm.Web/Components/Pages/Home/Home.razor
+++ b/Cdm/Cdm.Web/Components/Pages/Home/Home.razor
@@ -1,4 +1,4 @@
-@page "/"
+@page "/dashboard"
 @attribute [Authorize]
 
 <PageTitle>Accueil — Chronique des Mondes</PageTitle>

--- a/Cdm/Cdm.Web/Components/Public/Landing.razor
+++ b/Cdm/Cdm.Web/Components/Public/Landing.razor
@@ -1,0 +1,214 @@
+@*
+    Landing.razor — page d'accueil publique de chroniques-des-mondes.fr
+
+    Volontairement HORS du routeur Blazor. `Routes.razor` impose
+    `InteractiveServerRenderMode(prerender: false)` à tout l'arbre : les pages de
+    l'application ne renvoient qu'un `<body>` vide et ne se remplissent qu'une fois
+    la connexion SignalR ouverte. Googlebot n'ouvre pas de WebSocket — le contenu lui
+    est donc invisible. Ce composant est rendu en SSR statique par un endpoint dédié
+    (`MapGet("/")` dans Program.cs), il porte donc son propre document HTML et n'a
+    besoin d'aucun JavaScript pour s'afficher.
+
+    Corollaire : pas de `@@rendermode`, pas d'injection de service scopé côté client,
+    pas de composant interactif ici. Tout ajout de ce genre casserait silencieusement
+    l'indexation en ramenant la page dans le monde interactif.
+*@
+@using Microsoft.AspNetCore.Components.Web
+
+<!DOCTYPE html>
+<html lang="fr" data-theme="dark">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chronique des Mondes — Gérez vos campagnes de jeu de rôle en ligne</title>
+    <meta name="description" content="Chronique des Mondes réunit vos mondes, personnages, campagnes, PNJ et combats dans un seul outil. Créez votre univers, menez vos sessions, gardez la mémoire de vos parties. Gratuit." />
+
+    <meta name="theme-color" content="#070a0d" />
+    <link rel="canonical" href="https://chroniques-des-mondes.fr/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Chronique des Mondes" />
+    <meta property="og:title" content="Chronique des Mondes — Gérez vos campagnes de jeu de rôle en ligne" />
+    <meta property="og:description" content="Vos mondes, personnages, campagnes, PNJ et combats dans un seul outil. Créez, menez, archivez vos parties de jeu de rôle." />
+    <meta property="og:image" content="https://chroniques-des-mondes.fr/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:url" content="https://chroniques-des-mondes.fr/" />
+    <meta property="og:locale" content="fr_FR" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Chronique des Mondes" />
+    <meta name="twitter:description" content="Créez et gérez vos campagnes de jeu de rôle en ligne." />
+    <meta name="twitter:image" content="https://chroniques-des-mondes.fr/og-image.png" />
+
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon-180.png" />
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@@400;600;700&family=Inter:wght@@300;400;500;600;700&display=swap" rel="stylesheet" />
+
+    <link rel="stylesheet" href="/css/variables.css" />
+    <link rel="stylesheet" href="/css/themes/themes.css" />
+    <link rel="stylesheet" href="/css/app.css" />
+    <link rel="stylesheet" href="/css/layouts/landing.css" />
+
+    @* Donnée structurée : décrit l'application aux moteurs sans dépendre du rendu. *@
+    <script type="application/ld+json">
+        {
+          "@@context": "https://schema.org",
+          "@@type": "WebApplication",
+          "name": "Chronique des Mondes",
+          "url": "https://chroniques-des-mondes.fr/",
+          "applicationCategory": "GameApplication",
+          "operatingSystem": "Web",
+          "inLanguage": "fr-FR",
+          "description": "Outil en ligne de gestion de campagnes de jeu de rôle : mondes, personnages, chapitres, PNJ, sessions et combats.",
+          "offers": { "@@type": "Offer", "price": "0", "priceCurrency": "EUR" }
+        }
+    </script>
+</head>
+
+<body class="landing">
+    <a href="#contenu" class="skip-to-content">Aller au contenu principal</a>
+
+    <header class="landing-topbar">
+        <a href="/" class="landing-brand">
+            <img src="/images/LogoCdm.svg" alt="" width="40" height="40" />
+            <span>Chronique des Mondes</span>
+        </a>
+        <nav class="landing-topbar-actions" aria-label="Accès au compte">
+            <a href="/login" class="btn btn-ghost">Se connecter</a>
+            <a href="/register" class="btn btn-primary">Créer un compte</a>
+        </nav>
+    </header>
+
+    <main id="contenu">
+
+        <section class="landing-hero">
+            <p class="landing-eyebrow">Forgez votre destinée</p>
+            <h1>Toute votre campagne de jeu de rôle, au même endroit</h1>
+            <p class="landing-lead">
+                Mondes, personnages, chapitres, PNJ, sessions et combats : Chronique des Mondes
+                remplace le classeur, les feuilles volantes et les six onglets ouverts pendant
+                une partie. Vous menez, l'outil se souvient.
+            </p>
+            <div class="landing-cta">
+                <a href="/register" class="btn btn-primary btn-lg">
+                    <i class="bi bi-stars" aria-hidden="true"></i>
+                    Créer mon univers — gratuit
+                </a>
+                <a href="/login" class="btn btn-secondary btn-lg">J'ai déjà un compte</a>
+            </div>
+            <p class="landing-hero-note">Aucune carte bancaire. Compatible D&amp;D 5e et systèmes génériques.</p>
+        </section>
+
+        <section class="landing-section" aria-labelledby="fonctionnalites">
+            <h2 id="fonctionnalites" class="section-eyebrow">
+                <i class="bi bi-grid-3x3-gap" aria-hidden="true"></i>
+                Ce que vous pouvez faire
+            </h2>
+
+            <ul class="landing-features">
+                <li class="cdm-card">
+                    <i class="bi bi-globe2" aria-hidden="true"></i>
+                    <h3>Construire un monde</h3>
+                    <p>
+                        Lieux, factions, lore, illustrations. Votre univers vit dans un codex
+                        consultable pendant la partie plutôt que dans un document oublié.
+                    </p>
+                </li>
+                <li class="cdm-card">
+                    <i class="bi bi-people" aria-hidden="true"></i>
+                    <h3>Gérer les personnages</h3>
+                    <p>
+                        Fiches complètes, caractéristiques, inventaire et progression. Support
+                        dédié pour D&amp;D 5e — classes, sous-classes, montée de niveau — et un
+                        mode générique pour les autres systèmes.
+                    </p>
+                </li>
+                <li class="cdm-card">
+                    <i class="bi bi-map" aria-hidden="true"></i>
+                    <h3>Mener des campagnes</h3>
+                    <p>
+                        Découpez l'aventure en chapitres, préparez vos PNJ et vos rencontres,
+                        invitez vos joueurs et suivez qui a participé à quoi.
+                    </p>
+                </li>
+                <li class="cdm-card">
+                    <i class="bi bi-shield-slash" aria-hidden="true"></i>
+                    <h3>Résoudre les combats</h3>
+                    <p>
+                        Ordre d'initiative, points de vie, attaques et jets de dés intégrés :
+                        le combat se déroule dans l'outil, sans calcul à côté.
+                    </p>
+                </li>
+                <li class="cdm-card">
+                    <i class="bi bi-clock-history" aria-hidden="true"></i>
+                    <h3>Garder la mémoire</h3>
+                    <p>
+                        Chaque session laisse une trace. Statistiques de jets, historique des
+                        événements, hauts faits débloqués : la chronique s'écrit toute seule.
+                    </p>
+                </li>
+                <li class="cdm-card">
+                    <i class="bi bi-shop" aria-hidden="true"></i>
+                    <h3>Échanger objets et butin</h3>
+                    <p>
+                        Inventaires, distribution de butin et place de marché entre joueurs,
+                        pour arrêter d'arbitrer les échanges à l'oral.
+                    </p>
+                </li>
+            </ul>
+        </section>
+
+        <section class="landing-section landing-steps" aria-labelledby="demarrer">
+            <h2 id="demarrer" class="section-eyebrow">
+                <i class="bi bi-signpost-split" aria-hidden="true"></i>
+                Démarrer en trois étapes
+            </h2>
+            <ol class="landing-steps-list">
+                <li>
+                    <span class="landing-step-num">1</span>
+                    <h3>Créez votre compte</h3>
+                    <p>Une adresse e-mail suffit. C'est gratuit et sans engagement.</p>
+                </li>
+                <li>
+                    <span class="landing-step-num">2</span>
+                    <h3>Posez votre monde</h3>
+                    <p>Un nom, un système de jeu, et vous pouvez déjà y placer vos premiers personnages.</p>
+                </li>
+                <li>
+                    <span class="landing-step-num">3</span>
+                    <h3>Invitez votre table</h3>
+                    <p>Vos joueurs rejoignent la campagne et la première session peut commencer.</p>
+                </li>
+            </ol>
+            <div class="landing-cta">
+                <a href="/register" class="btn btn-primary btn-lg">Commencer maintenant</a>
+            </div>
+        </section>
+    </main>
+
+    <footer class="landing-footer">
+        <p>Chronique des Mondes — outil de gestion de campagnes de jeu de rôle.</p>
+        <nav aria-label="Liens de pied de page">
+            <a href="/login">Connexion</a>
+            <a href="/register">Inscription</a>
+        </nav>
+    </footer>
+
+    @* Reprend le choix clair/sombre de l'utilisateur, comme App.razor, pour qu'un
+       visiteur qui revient ne bascule pas en sombre en passant par l'accueil. Ne
+       touche qu'un attribut : le contenu reste entierement dans le HTML servi. *@
+    <script>
+        (function () {
+            var theme = localStorage.getItem('cdm-theme') || 'dark';
+            document.documentElement.setAttribute('data-theme', theme);
+        })();
+    </script>
+</body>
+
+</html>

--- a/Cdm/Cdm.Web/Program.cs
+++ b/Cdm/Cdm.Web/Program.cs
@@ -1,5 +1,7 @@
 using Cdm.Web;
 using Cdm.Web.Components;
+using Cdm.Web.Components.Public;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Cdm.Web.Extensions;
 using Cdm.Web.Services;
 using Cdm.Web.Services.Storage;
@@ -190,6 +192,15 @@ app.MapGet("/set-culture", (string culture, string? redirectUri, HttpContext con
 
     return Results.LocalRedirect(isSafeRedirect ? redirectUri! : "/settings");
 });
+
+// Page d'accueil publique, rendue en SSR statique HORS du routeur Blazor.
+// Les pages de l'app sont en `prerender: false` (le token d'auth vit dans
+// localStorage, inaccessible au prérendu) : leur HTML est vide tant que SignalR
+// n'a pas répondu, et Googlebot n'ouvre pas de WebSocket. Cet endpoint sert donc
+// le seul contenu réellement indexable du site. Le tableau de bord, lui, est passé
+// sur /dashboard.
+app.MapGet("/", () => new RazorComponentResult<Landing>())
+    .AllowAnonymous();
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();

--- a/Cdm/Cdm.Web/wwwroot/css/layouts/landing.css
+++ b/Cdm/Cdm.Web/wwwroot/css/layouts/landing.css
@@ -1,0 +1,229 @@
+/*
+ * landing.css — Chronique des Mondes
+ * Page d'accueil publique (Components/Public/Landing.razor), rendue en SSR statique
+ * hors de l'application Blazor. Chargée uniquement par cette page : volontairement
+ * PAS importée depuis app.css, pour ne rien ajouter au poids de l'app connectée.
+ * Réutilise les tokens de variables.css et les primitives .btn / .cdm-card /
+ * .section-eyebrow de components.css.
+ */
+
+body.landing {
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  margin: 0;
+  line-height: 1.6;
+}
+
+body.landing a {
+  color: var(--color-primary-light);
+}
+
+/* ============================================
+   BARRE HAUTE
+   ============================================ */
+.landing-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+  padding: var(--spacing-md) var(--spacing-xl);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.landing-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: var(--font-size-h5);
+  color: var(--color-text-primary);
+  text-decoration: none;
+}
+
+.landing-brand img {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+}
+
+.landing-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+/* ============================================
+   HERO
+   ============================================ */
+.landing-hero {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: var(--spacing-2xl) var(--spacing-xl);
+  text-align: center;
+}
+
+.landing-eyebrow {
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+  font-weight: 600;
+  margin: 0 0 var(--spacing-md);
+}
+
+.landing-hero h1 {
+  font-family: var(--font-heading);
+  /* clamp() plutôt qu'une media query : le titre est la seule chose qui déborde
+     vraiment sur un petit écran. */
+  font-size: clamp(1.9rem, 5vw, var(--font-size-h1));
+  line-height: 1.15;
+  font-weight: 700;
+  margin: 0 0 var(--spacing-lg);
+  color: var(--color-text-primary);
+}
+
+.landing-lead {
+  font-size: 1.05rem;
+  color: var(--color-text-secondary);
+  max-width: 62ch;
+  margin: 0 auto var(--spacing-xl);
+}
+
+.landing-cta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--spacing-md);
+}
+
+.landing-hero-note {
+  margin-top: var(--spacing-lg);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+/* ============================================
+   SECTIONS
+   ============================================ */
+.landing-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: var(--spacing-2xl) var(--spacing-xl);
+}
+
+.landing-features {
+  list-style: none;
+  margin: var(--spacing-xl) 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--spacing-lg);
+}
+
+.landing-features > li {
+  padding: var(--spacing-lg);
+}
+
+.landing-features .bi {
+  font-size: 1.5rem;
+  color: var(--color-primary);
+}
+
+.landing-features h3 {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-h5);
+  font-weight: 600;
+  margin: var(--spacing-sm) 0;
+  color: var(--color-text-primary);
+}
+
+.landing-features p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+/* ============================================
+   ÉTAPES
+   ============================================ */
+.landing-steps {
+  border-top: 1px solid var(--color-border);
+}
+
+.landing-steps-list {
+  list-style: none;
+  margin: var(--spacing-xl) 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--spacing-xl);
+}
+
+.landing-step-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid var(--color-border-hover);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.landing-steps-list h3 {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-h5);
+  font-weight: 600;
+  margin: var(--spacing-md) 0 var(--spacing-sm);
+}
+
+.landing-steps-list p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+/* ============================================
+   PIED DE PAGE
+   ============================================ */
+.landing-footer {
+  border-top: 1px solid var(--color-border);
+  padding: var(--spacing-xl);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.landing-footer nav {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-lg);
+  margin-top: var(--spacing-sm);
+}
+
+@media (max-width: 640px) {
+  .landing-topbar {
+    padding: var(--spacing-md);
+  }
+
+  .landing-brand span {
+    /* Le nom complet pousse les boutons de compte hors de l'écran sur mobile ;
+       le logo suffit à identifier le site. */
+    display: none;
+  }
+
+  .landing-hero,
+  .landing-section {
+    padding-left: var(--spacing-md);
+    padding-right: var(--spacing-md);
+  }
+
+  .landing-cta .btn {
+    width: 100%;
+  }
+}

--- a/Cdm/Cdm.Web/wwwroot/robots.txt
+++ b/Cdm/Cdm.Web/wwwroot/robots.txt
@@ -1,8 +1,9 @@
 # Chronique des Mondes — robots.txt
-# L'application est presque entierement derriere authentification : les pages privees
-# redirigent vers /login pour un visiteur non connecte, il n'y a donc rien a y indexer.
-# On laisse crawler les pages publiques et on exclut explicitement les URL a jeton
-# (jamais dans un index) et l'espace connecte (economie de budget de crawl).
+# Seule `/` (la page de presentation) est publique et rendue en SSR statique. Tout le
+# reste est derriere authentification : les pages privees redirigent vers /login pour un
+# visiteur non connecte, il n'y a donc rien a y indexer. On laisse crawler les pages
+# publiques et on exclut explicitement les URL a jeton (jamais dans un index) et
+# l'espace connecte (economie de budget de crawl).
 
 User-agent: *
 Allow: /
@@ -12,6 +13,7 @@ Disallow: /confirm-email
 Disallow: /reset-password
 
 # Espace connecte (contenu prive, inaccessible sans compte)
+Disallow: /dashboard
 Disallow: /worlds
 Disallow: /characters
 Disallow: /campaigns

--- a/Cdm/Cdm.Web/wwwroot/sitemap.xml
+++ b/Cdm/Cdm.Web/wwwroot/sitemap.xml
@@ -1,25 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Chronique des Mondes — sitemap des pages publiques. L'espace connecte n'y figure
-     pas : son contenu est prive et redirige vers /login. URL canonique = domaine apex. -->
+<!-- Chronique des Mondes — sitemap des pages publiques. URL canonique = domaine apex.
+     Seule `/` (la page de presentation) porte du contenu reellement indexable : c'est
+     la seule page rendue en SSR statique. Les pages de l'app sont en `prerender: false`
+     et n'ont pas de HTML a indexer, il est donc inutile de les pousser ici. /login et
+     /register restent crawlables (robots.txt ne les bloque pas) sans etre promues. -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://chroniques-des-mondes.fr/</loc>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://chroniques-des-mondes.fr/login</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
     <loc>https://chroniques-des-mondes.fr/register</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://chroniques-des-mondes.fr/forgot-password</loc>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/Cdm/Cdm.Web/wwwroot/sitemap.xml
+++ b/Cdm/Cdm.Web/wwwroot/sitemap.xml
@@ -3,18 +3,13 @@
      Seule `/` (la page de presentation) porte du contenu reellement indexable : c'est
      la seule page rendue en SSR statique. Les pages de l'app sont en `prerender: false`
      et n'ont pas de HTML a indexer, il est donc inutile de les pousser ici. /login et
-     /register restent crawlables (robots.txt ne les bloque pas) sans etre promues. -->
+     /register restent crawlables (robots.txt ne les bloque pas) mais ne sont pas
+     promues ici : ce serait demander l'indexation de pages sans contenu. -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://chroniques-des-mondes.fr/</loc>
     <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://chroniques-des-mondes.fr/register</loc>
-    <lastmod>2026-08-01</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.5</priority>
   </url>
 </urlset>


### PR DESCRIPTION
Page d'accueil publique rendue en SSR statique, hors du routeur Blazor.

Les pages de l'app sont en `prerender: false` (le jeton d'auth vit dans localStorage, inaccessible au prérendu) : leur HTML est vide tant que SignalR n'a pas répondu, et Googlebot n'ouvre pas de WebSocket. Cet endpoint sert donc le seul contenu réellement indexable du site. Le tableau de bord passe sur `/dashboard`.

Inclut le canonical par URL et le retrait de `/register` du sitemap.

Vérifié : build de la solution OK, 222 tests verts (169 + 53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)